### PR TITLE
Fix Issue #1 - add online servers options

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -237,7 +237,7 @@ disabled since it requires a backend server to be running.  You can
 still play online with friends, but you need to manually share game URLs.
 
 If you want to run the game using your personal servers, you'll need to set go
-to _Options -> Online -> Online Servers_ and check the **Enabled** checkbox and
+to _Options -> Online -> Public Online Servers_ and check the **Enabled** checkbox and
 enter the server information in the two fields.
 
 If you start `poker` with **Enabled** checked, but your servers are not running, you may see a 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -232,25 +232,16 @@ To run the desktop poker game, either run `PokerMain` in IntelliJ or use the scr
 poker
 ```
 
-**NOTE**:  the `client.properties` file currently hard-codes the old DD Poker
-server host.  Since these don't exist anymore, the `settings.online.enable`
-flag is set to `false`, which disables online game functionality.
+By default, the game's "public game" and "online lobby" functionality is
+disabled since it requires a backend server to be running.  You can
+still play online with friends, but you need to manually share game URLs.
 
-```properties
-settings.online.enabled= false
-settings.online.server=  http://free.ddpoker.com:80/poker/servlet/
-settings.online.chat=	 free.ddpoker.com:11886
-```
+If you want to run the game using your personal servers, you'll need to set go
+to _Options -> Online -> Online Servers_ and check the **Enabled** checkbox and
+enter the server information in the two fields.
 
-If you want to run the game using your personal servers, you'll need to set the
-flag to `true` and update the `server` and `chat` entries.  During development,
-you can set these via personal `.properties` override files, described below.
-
-If you start `poker` with `enabled=true`, but your servers are not running, you may see a 
+If you start `poker` with **Enabled** checked, but your servers are not running, you may see a 
 several second delay on startup as a connection attempt is made and freezes the UI until it times out.
-
-[Issue #1](https://github.com/dougdonohoe/ddpoker/issues/1) discusses adding UI features
-to set the server.
 
 ## Code Notes
 

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessageListener.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessageListener.java
@@ -54,7 +54,7 @@ public interface DDMessageListener
     public static final int STATUS_UNKNOWN_ERROR = 4;
     public static final int STATUS_DNS_TIMEOUT = 5;
     public static final int STATUS_APPL_ERROR = 6;
-    public static final int STATUS_SHUTDOWN = 7;
+    public static final int STATUS_DISABLED = 7;
 
     public static final int STATUS_OK = 10;
     

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
@@ -142,7 +142,7 @@ public class DDMessenger
         try 
         {
             if (isDisabled(url.toString())) {
-                nStatus = DDMessageListener.STATUS_SHUTDOWN;
+                nStatus = DDMessageListener.STATUS_DISABLED;
             } else {
                 getURL(url, send, DDMessage.CONTENT_TYPE, ret, listener, null);
                 if (ret.getCategory() == DDMessage.CAT_ERROR)

--- a/code/common/src/main/java/com/donohoedigital/comms/Servlet.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/Servlet.java
@@ -1,0 +1,12 @@
+package com.donohoedigital.comms;
+
+public class Servlet {
+
+    /**
+     * Utility to build URI part of a URL to keep usages clear.
+     * Also see .properties entries "settings.online.server"
+     */
+    public static String ServletUri(String appName) {
+        return '/' + appName + "/servlet/";
+    }
+}

--- a/code/common/src/main/java/com/donohoedigital/config/ConfigUtils.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ConfigUtils.java
@@ -227,7 +227,7 @@ public class ConfigUtils
             if (!dir.mkdirs())
             {
                 //logger.error("Unable to create dir " + dir.getAbsolutePath());
-                throw new ApplicationError(ErrorCodes.ERROR_CREATE, "Unabled to create directory",
+                throw new ApplicationError(ErrorCodes.ERROR_CREATE, "Unable to create directory",
                                            dir.getAbsolutePath(), "Check permissions on parent directories");
             }
         }
@@ -256,7 +256,7 @@ public class ConfigUtils
         {
             if (!file.createNewFile())
             {
-                //logger.error("Unabled to create file: " + file.getAbsolutePath());
+                //logger.error("Unable to create file: " + file.getAbsolutePath());
                 throw new ApplicationError(ErrorCodes.ERROR_CREATE, "Unable to create file",
                                            file.getAbsolutePath(), "Check permissions");
             }

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/comms/EngineMessenger.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/comms/EngineMessenger.java
@@ -71,7 +71,7 @@ public class EngineMessenger extends DDMessenger
     /**
      * Create the messenger, get url
      */
-    private EngineMessenger()
+    protected EngineMessenger()
     {
         serverurl_ = PropertyConfig.getRequiredStringProperty("settings.online.server");
     }
@@ -145,16 +145,5 @@ public class EngineMessenger extends DDMessenger
     public DDMessage createNewMessage()
     {
         return new EngineMessage();
-    }
-
-    /**
-     * 2020: Disabled if attempting to reach old DD Poker server.
-     */
-    @Override
-    public boolean isDisabled(String url) {
-        if (!PropertyConfig.getBooleanProperty("settings.online.enabled", false, false)) {
-            return url.startsWith(serverurl_);
-        }
-        return false;
     }
 }

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/EngineConstants.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/EngineConstants.java
@@ -94,4 +94,8 @@ public class EngineConstants
     public static final String PREF_W = "w";
     public static final String PREF_H = "h";
     public static final String PREF_MAXIMIZED = "maximized";
+
+    // common options
+    public static final String OPTION_ONLINE_ENABLED = "onlineenabled";
+    public static final String OPTION_ONLINE_SERVER = "onlineserver";
 }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Demo.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Demo.java
@@ -114,7 +114,7 @@ public class Demo extends BasePhase
         {
             boolean bOkay = false;
 
-            Preferences prefs = engine_.getPrefsNode();
+            EnginePrefs prefs = engine_.getPrefsNode();
             if (!prefs.getBoolean(PREF_DEMO_LICENSE_DISPLAYED, false))
             {
                 engine_.setBDemo(false); // temp

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EnginePrefs.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EnginePrefs.java
@@ -38,12 +38,103 @@
 
 package com.donohoedigital.games.engine;
 
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.gui.DDOption;
+
+import java.util.prefs.Preferences;
+
 /**
  *
  * @author  Doug Donohoe
  */
 public class EnginePrefs {
-    
+
+    // Used to track "don't show again" for various info dialogs
     public static final String NODE_DIALOG_PHASE = "dialog-phase";
-    
+
+    private final Preferences prefs_;
+
+    /**
+     * Wrapper around Preferences, adding getters for options, with support for
+     * fetching default value from .properties file (option.[name].default).
+     */
+    public EnginePrefs(Preferences prefs) {
+        this.prefs_ = prefs;
+    }
+
+    public Preferences getPrefs() {
+        return prefs_;
+    }
+
+    public boolean getBooleanOption(String prefName) {
+        return prefs_.getBoolean(prefName,
+                PropertyConfig.getRequiredBooleanProperty(DDOption.GetDefaultKey(prefName)));
+    }
+
+    public String getStringOption(String prefName) {
+        return prefs_.get(prefName,
+                PropertyConfig.getRequiredStringProperty(DDOption.GetDefaultKey(prefName)));
+    }
+
+    public int getIntOption(String prefName) {
+        return prefs_.getInt(prefName,
+                PropertyConfig.getRequiredIntegerProperty(DDOption.GetDefaultKey(prefName)));
+    }
+
+    public double getDoubleOption(String prefName) {
+        return prefs_.getDouble(prefName,
+                PropertyConfig.getRequiredDoubleProperty(DDOption.GetDefaultKey(prefName)));
+    }
+
+    public String get(String key, String def) {
+        return prefs_.get(key, def);
+    }
+
+    public int getInt(String key, int def) {
+        return prefs_.getInt(key, def);
+    }
+
+    public long getLong(String key, long def) {
+        return prefs_.getLong(key, def);
+    }
+
+    public boolean getBoolean(String key, boolean def) {
+        return prefs_.getBoolean(key, def);
+    }
+
+    public float getFloat(String key, float def) {
+        return prefs_.getFloat(key, def);
+    }
+
+    public double getDouble(String key, double def) {
+       return prefs_.getDouble(key, def);
+    }
+
+    public void put(String key, String value) {
+        prefs_.put(key, value);
+    }
+
+    public void putInt(String key, int value) {
+        prefs_.putInt(key, value);
+    }
+
+    public void putLong(String key, long value) {
+        prefs_.putLong(key, value);
+    }
+
+    public void putBoolean(String key, boolean value) {
+        prefs_.putBoolean(key, value);
+    }
+
+    public void putFloat(String key, float value) {
+        prefs_.putFloat(key, value);
+    }
+
+    public void putDouble(String key, double value) {
+        prefs_.putDouble(key, value);
+    }
+
+    public void remove(String key) {
+        prefs_.remove(key);
+    }
 }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
@@ -91,7 +91,7 @@ public class EngineWindow extends BaseFrame
 
         // check size
         DisplayMode mode = getDisplayMode();
-        Preferences prefs = engine_.getPrefsNode();
+        EnginePrefs prefs = engine_.getPrefsNode();
 
         // size from prefs
         boolean bMaximized = prefs.getBoolean(EngineConstants.PREF_MAXIMIZED+"-"+getName(), false);
@@ -388,7 +388,7 @@ public class EngineWindow extends BaseFrame
             // store whether we are maximized
             boolean bMax = (e.getNewState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH;
 
-            Preferences prefs = engine_.getPrefsNode();
+            EnginePrefs prefs = engine_.getPrefsNode();
             prefs.putBoolean(EngineConstants.PREF_MAXIMIZED+"-"+getName(), bMax);
         }
 
@@ -403,7 +403,7 @@ public class EngineWindow extends BaseFrame
             // logger.debug("Window size changed: "+ size_+ " is Max: "+ isMaximized());
 
             // save
-            Preferences prefs = engine_.getPrefsNode();
+            EnginePrefs prefs = engine_.getPrefsNode();
             prefs.putInt(EngineConstants.PREF_W+"-"+getName(), size_.width);
             prefs.putInt(EngineConstants.PREF_H+"-"+getName(), size_.height);
         }
@@ -422,8 +422,8 @@ public class EngineWindow extends BaseFrame
 
             // save
             DisplayMode mode = getDisplayMode();
-            Preferences prefs = engine_.getPrefsNode();
-            // store if top corner is visible (more or less) and it isn't too far off screen at bottom/right
+            EnginePrefs prefs = engine_.getPrefsNode();
+            // store if top corner is visible (more or less) and it isn't too far off-screen at bottom/right
             if (location_.x >= -50 && location_.x < (mode.getWidth() - (DESIRED_MIN_WIDTH/2))) prefs.putInt(EngineConstants.PREF_X+"-"+getName(), location_.x);
             if (location_.y >= -50 && location_.y < (mode.getHeight() - (DESIRED_MIN_HEIGHT/2))) prefs.putInt(EngineConstants.PREF_Y+"-"+getName(), location_.y);
         }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/FileChooserDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/FileChooserDialog.java
@@ -92,7 +92,7 @@ public class FileChooserDialog extends DialogPhase implements PropertyChangeList
         GuiManager.setLabelAsMessage(name, params);
         base.add(name, BorderLayout.NORTH);
 
-        choose_ = new DDFileChooser(sName, STYLE, engine_.getPrefsNode());
+        choose_ = new DDFileChooser(sName, STYLE, engine_.getPrefsNode().getPrefs());
         choose_.addChoosableFileFilter(new ChooserFilter(EXT));
         //choose_.setAcceptAllFileFilterUsed(true);
         choose_.addPropertyChangeListener(this);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Game.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Game.java
@@ -1077,7 +1077,7 @@ public class Game extends TypedHashMap implements GameInfo, GamePlayerList, Game
         if (engine == null) return;
         
         // get prefs and check them
-        Preferences prefs = engine.getPrefsNode();
+        EnginePrefs prefs = engine.getPrefsNode();
         if (prefs.getBoolean(EngineConstants.PREF_AUTOSAVE, false) && getLastGameState() != null)
         {
             //logger.debug("Auto saving...");

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -87,7 +87,7 @@ public abstract class GameEngine extends BaseApp
     private String sHeadlessKey_;
     private String sLastReal_ = null;
     private String sLastGen_ = null;
-    private Preferences prefNode_;
+    private EnginePrefs prefNode_;
     private String sPrefNode_;
     private String sKeyNode_;
     private boolean bSkipSplashChoice_ = false;
@@ -391,9 +391,9 @@ public abstract class GameEngine extends BaseApp
     /**
      * Get Node used for prefs
      */
-    public Preferences getPrefsNode()
+    public EnginePrefs getPrefsNode()
     {
-        if (prefNode_ == null) prefNode_ = DDOption.getOptionPrefs(sPrefNode_);
+        if (prefNode_ == null) prefNode_ = new EnginePrefs(DDOption.getOptionPrefs(sPrefNode_));
         return prefNode_;
     }
 
@@ -748,21 +748,15 @@ public abstract class GameEngine extends BaseApp
      */
     private void setAudioPrefs()
     {
-        Preferences prefs = getPrefsNode();
+        EnginePrefs prefs = getPrefsNode();
 
-        AudioConfig.setFXGain(prefs.getInt(EngineConstants.PREF_FX_VOL,
-                                           PropertyConfig.getRequiredIntegerProperty(DDOption.GetDefaultKey(EngineConstants.PREF_FX_VOL))));
-        AudioConfig.setMusicGain(prefs.getInt(EngineConstants.PREF_MUSIC_VOL,
-                                              PropertyConfig.getRequiredIntegerProperty(DDOption.GetDefaultKey(EngineConstants.PREF_MUSIC_VOL))));
-        AudioConfig.setBGMusicGain(prefs.getInt(EngineConstants.PREF_BGMUSIC_VOL,
-                                                PropertyConfig.getRequiredIntegerProperty(DDOption.GetDefaultKey(EngineConstants.PREF_BGMUSIC_VOL))));
+        AudioConfig.setFXGain(prefs.getIntOption(EngineConstants.PREF_FX_VOL));
+        AudioConfig.setMusicGain(prefs.getIntOption(EngineConstants.PREF_MUSIC_VOL));
+        AudioConfig.setBGMusicGain(prefs.getIntOption(EngineConstants.PREF_BGMUSIC_VOL));
 
-        AudioConfig.setMuteFX(!prefs.getBoolean(EngineConstants.PREF_FX,
-                                                PropertyConfig.getRequiredBooleanProperty(DDOption.GetDefaultKey(EngineConstants.PREF_FX))));
-        AudioConfig.setMuteMusic(!prefs.getBoolean(EngineConstants.PREF_MUSIC,
-                                                   PropertyConfig.getRequiredBooleanProperty(DDOption.GetDefaultKey(EngineConstants.PREF_MUSIC))));
-        AudioConfig.setMuteBGMusic(!prefs.getBoolean(EngineConstants.PREF_BGMUSIC,
-                                                     PropertyConfig.getRequiredBooleanProperty(DDOption.GetDefaultKey(EngineConstants.PREF_BGMUSIC))));
+        AudioConfig.setMuteFX(!prefs.getBooleanOption(EngineConstants.PREF_FX));
+        AudioConfig.setMuteMusic(!prefs.getBooleanOption(EngineConstants.PREF_MUSIC));
+        AudioConfig.setMuteBGMusic(!prefs.getBooleanOption(EngineConstants.PREF_BGMUSIC));
     }
 
     // sizes

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -116,6 +116,10 @@ public abstract class GameEngine extends BaseApp
         sMainModule_ = sMainModule;
     }
 
+    public String name() {
+        return super.sAppName;
+    }
+
     /**
      * primary initialization
      */

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameMessenger.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameMessenger.java
@@ -1,0 +1,50 @@
+package com.donohoedigital.games.engine;
+
+import com.donohoedigital.comms.DDMessageListener;
+import com.donohoedigital.comms.Servlet;
+import com.donohoedigital.games.comms.EngineMessage;
+import com.donohoedigital.games.comms.EngineMessenger;
+import com.donohoedigital.games.config.EngineConstants;
+
+/**
+ * GameMessenger wraps EngineMessenger, getting server URL from options (instead of .properties)
+ */
+public class GameMessenger extends EngineMessenger {
+
+    /**
+     * Default instance to use for messaging
+     */
+    private static final GameMessenger GAME_MESSENGER;
+
+    // Create sole engine messenger
+    static {
+        GAME_MESSENGER = new GameMessenger();
+    }
+
+    public GameMessenger() {
+        super();
+    }
+
+    private static String getServerURL(String url) {
+        if (url != null) return url;
+        GameEngine engine = GameEngine.getGameEngine();
+        EnginePrefs prefs = engine.getPrefsNode();
+        String serverAndPort = prefs.getStringOption(EngineConstants.OPTION_ONLINE_SERVER);
+        // Result is something like http://free.ddpoker.com:80/poker/servlet/
+        return "http://" + serverAndPort + Servlet.ServletUri(engine.name());
+    }
+
+    @Override
+    public boolean isDisabled(String url) {
+        EnginePrefs prefs = GameEngine.getGameEngine().getPrefsNode();
+        return !prefs.getBooleanOption(EngineConstants.OPTION_ONLINE_ENABLED);
+    }
+
+    public static EngineMessage SendEngineMessage(String url, EngineMessage send, DDMessageListener listener) {
+        return GAME_MESSENGER.sendEngineMessage(getServerURL(url), send, listener);
+    }
+
+    public static void SendEngineMessageAsync(String url, EngineMessage send, DDMessageListener listener) {
+        GAME_MESSENGER.sendEngineMessageAsync(getServerURL(url), send, listener);
+    }
+}

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
@@ -600,7 +600,7 @@ public class Gameboard extends ImageComponent implements Scrollable,
     public void getFillSetting()
     {
         if (engine_ == null) return;
-        Preferences prefs = engine_.getPrefsNode();
+        EnginePrefs prefs = engine_.getPrefsNode();
         boolean bFillOld = bFill_;
         bFill_ = prefs.getBoolean(EngineConstants.PREF_FILL, true);
         if (bFillOld != bFill_)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
@@ -82,7 +82,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
     private boolean bFileMode_ = true;
     private DDPanel buttons_;
     private DDPanel top_;
-    private Preferences prefs_;
+    private EnginePrefs prefs_;
     private String sPrefName_;
     private boolean bUIMode_ = true;
 
@@ -114,7 +114,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
      */
     public static String getStoredProfile(String sMsgName)
     {
-        Preferences prefs = GameEngine.getGameEngine().getPrefsNode();
+        EnginePrefs prefs = GameEngine.getGameEngine().getPrefsNode();
         return prefs.get(getPrefsName(sMsgName), null);        
     }
     
@@ -123,7 +123,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
      */
     public static void setStoredProfile(BaseProfile profile, String sMsgName)
     {
-        Preferences prefs = GameEngine.getGameEngine().getPrefsNode();
+        EnginePrefs prefs = GameEngine.getGameEngine().getPrefsNode();
         rememberProfile(profile, prefs, getPrefsName(sMsgName));
         
     }
@@ -139,8 +139,8 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
     /**
      * remember profile
      */
-    private static void rememberProfile(BaseProfile profile, 
-                        Preferences prefs, String sPrefName)
+    private static void rememberProfile(BaseProfile profile,
+                                        EnginePrefs prefs, String sPrefName)
     {
         if (profile != null)
             prefs.put(sPrefName, profile.getFileName());

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
@@ -203,7 +203,7 @@ public class ScrollGameboard extends JViewport implements
      */
     private void toggleColor()
     {
-        Preferences prefs = engine_.getPrefsNode();
+        EnginePrefs prefs = engine_.getPrefsNode();
         boolean bFill = prefs.getBoolean(EngineConstants.PREF_FILL, true);
         prefs.putBoolean(EngineConstants.PREF_FILL, !bFill);
         board_.getFillSetting();
@@ -392,7 +392,7 @@ public class ScrollGameboard extends JViewport implements
     public void getClickToScroll()
     {
         if (engine_ == null) return;
-        Preferences prefs = engine_.getPrefsNode();
+        EnginePrefs prefs = engine_.getPrefsNode();
         CLICKTOSCROLL = prefs.getBoolean(EngineConstants.PREF_SCROLL, true);
     }
     

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
@@ -44,7 +44,6 @@ import com.donohoedigital.comms.DDMessageListener;
 import com.donohoedigital.config.ImageConfig;
 import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.comms.EngineMessage;
-import com.donohoedigital.games.comms.EngineMessenger;
 import com.donohoedigital.games.config.GamePhase;
 import com.donohoedigital.gui.*;
 import org.apache.log4j.Logger;
@@ -142,7 +141,7 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
                 PropertyConfig.getMessage("msg.msgerror." + DDMessageListener.STATUS_UNKNOWN_ERROR + MOD),
                 PropertyConfig.getMessage("msg.msgerror." + DDMessageListener.STATUS_DNS_TIMEOUT + MOD),
                 PropertyConfig.getMessage("msg.msgerror." + DDMessageListener.STATUS_APPL_ERROR),
-                PropertyConfig.getMessage("msg.msgerror." + DDMessageListener.STATUS_SHUTDOWN)
+                PropertyConfig.getMessage("msg.msgerror." + DDMessageListener.STATUS_DISABLED)
         };
 
         // get sleep amount
@@ -222,11 +221,11 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
     {
         if (doSynchronousSend())
         {
-            messageReceived(EngineMessenger.SendEngineMessage(sURL, msg, null));
+            messageReceived(GameMessenger.SendEngineMessage(sURL, msg, null));
         }
         else
         {
-            EngineMessenger.SendEngineMessageAsync(sURL, msg, this);
+            GameMessenger.SendEngineMessageAsync(sURL, msg, this);
         }
     }
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
@@ -174,12 +174,29 @@ public class GuiUtils
     }
 
     /**
+     * Set preferred height of a component, keeping preferred width
+     */
+    public static void setPreferredHeight(JComponent c, int height)
+    {
+        c.setPreferredSize(new Dimension((int) c.getPreferredSize().getWidth(), height));
+    }
+
+    /**
+     * Set preferred width of a component, keeping preferred height
+     */
+    public static void setPreferredWidth(JComponent c, int width)
+    {
+        c.setPreferredSize(new Dimension(width, (int) c.getPreferredSize().getHeight()));
+    }
+
+    /**
      * Print container and all the children of the container
      */
     public static void printChildren(Container container, int nIndent)
     {
-        if (nIndent == 0)
-        logger.debug("===============================================================================================");
+        if (nIndent == 0) {
+            logger.debug("===============================================================================================");
+        }
         logger.debug(indent(nIndent) + "Container: " + container);
         Component[] children = container.getComponents();
         for (Component aChildren : children)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/CardPiece.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/CardPiece.java
@@ -372,7 +372,7 @@ public class CardPiece extends PokerGamePiece
      */
     protected String getDeckPref()
     {
-        Preferences prefs = GameEngine.getGameEngine().getPrefsNode();
+        EnginePrefs prefs = GameEngine.getGameEngine().getPrefsNode();
         String sName = prefs.get(sPrefName_, null);
         if (sName == null)
         {
@@ -931,7 +931,7 @@ public class CardPiece extends PokerGamePiece
     {
         if (card.isFaceCard())
         {
-            Preferences prefsNode = GameEngine.getGameEngine().getPrefsNode();
+            EnginePrefs prefsNode = GameEngine.getGameEngine().getPrefsNode();
             boolean fourColorDeck = prefsNode.getBoolean(PokerConstants.OPTION_FOUR_COLOR_DECK, false);
             boolean stylized = prefsNode.getBoolean(PokerConstants.OPTION_STYLIZED_FACE_CARDS, true);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
@@ -153,7 +153,7 @@ public class DeckDialog extends DialogPhase implements PropertyChangeListener
                 bResult = Boolean.TRUE;
                 
             } catch (Exception e) {
-                logger.error("Unabled to copy " + selected_.getAbsolutePath() + " to " +
+                logger.error("Unable to copy " + selected_.getAbsolutePath() + " to " +
                                     dir.getAbsolutePath());
                 logger.error(Utils.formatExceptionText(e));
                 EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.deck.copyfailed",selected_.getName(),

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
@@ -95,7 +95,7 @@ public class DeckDialog extends DialogPhase implements PropertyChangeListener
             format.add(displayBorder_);
             format.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 0));
         
-            choose_ = new DDFileChooser("deckimage", STYLE, engine_.getPrefsNode());
+            choose_ = new DDFileChooser("deckimage", STYLE, engine_.getPrefsNode().getPrefs());
             choose_.addChoosableFileFilter(new DeckProfile.DeckFilter());
             choose_.setAccessory(format);
             choose_.addPropertyChangeListener(this);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -578,7 +578,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             base.add(serverBorder, BorderLayout.SOUTH);
 
             // online enabled checkbox
-            onlineEnabled_ = new OptionBoolean(NODE, PokerConstants.OPTION_ONLINE_ENABLED, OSTYLE, map_, true);
+            onlineEnabled_ = new OptionBoolean(NODE, EngineConstants.OPTION_ONLINE_ENABLED, OSTYLE, map_, true);
             serverBorder.add(GuiUtils.NORTH(onlineEnabled_), BorderLayout.WEST);
             onlineEnabled_.addChangeListener(new ChangeListener()
             {
@@ -592,7 +592,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             DDPanel serversTable = new DDPanel();
             serversTable.setLayout(new VerticalFlowLayout(VerticalFlowLayout.LEFT, 10, 2));
 
-            onlineServer_ = new OptionText(NODE, PokerConstants.OPTION_ONLINE_SERVER, OSTYLE, map_,
+            onlineServer_ = new OptionText(NODE, EngineConstants.OPTION_ONLINE_SERVER, OSTYLE, map_,
                     ONLINE_SERVER_LIMIT, ONLINE_SERVER_REGEXP, 400, true);
             chatServer_ = new OptionText(NODE, PokerConstants.OPTION_ONLINE_CHAT, OSTYLE, map_,
                     ONLINE_SERVER_LIMIT, ONLINE_SERVER_REGEXP, 400, true);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -717,7 +717,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
         }
         catch (BackingStoreException bse)
         {
-            logger.warn("Unabled to clear prefs for node: " + EnginePrefs.NODE_DIALOG_PHASE);
+            logger.warn("Unable to clear prefs for node: " + EnginePrefs.NODE_DIALOG_PHASE);
         }
         EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.resetdialog"));
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -66,15 +66,18 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
     public static final Integer ICHEIGHT = 30;
 
 
-    private TypedHashMap map_ = new TypedHashMap();
-    private GameEngine engine_;
-    private GameContext context_;
-    private String OSTYLE;
-    private String BSTYLE;
+    private final TypedHashMap map_ = new TypedHashMap();
+    private final GameEngine engine_;
+    private final GameContext context_;
+    private final String OSTYLE;
+    private final String BSTYLE;
     private DDTabbedPane tabs_;
-    private GuiUtils.CheckListener checkListeners_;
+    private final GuiUtils.CheckListener checkListeners_;
+    private OptionText onlineServer_;
+    private OptionText chatServer_;
+    private OptionBoolean onlineEnabled_;
 
-    private String NODE;
+    private final String NODE;
     private int GRIDADJUST2;
     private int GRIDADJUST1;
     private int GRIDADJUST3;
@@ -154,7 +157,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             tabs_.addTab("msg.options.handgroups", ic, error, new HandGroups());
         }
 
-        // select pertinent tab for circumstance, which happens to be tab at position 1
+        // select pertinent tab if in a game, which happens to be the tab at position 1
         if (bDialog && game != null && tabs_.getTabCount() > 1)
         {
             DDTabPanel tp = (DDTabPanel) tabs_.getComponent(1);
@@ -176,7 +179,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
      */
     private abstract class OptionTab extends DDTabPanel
     {
-        private List<DDOption> localOptions = new ArrayList<DDOption>();
+        private final List<DDOption> localOptions = new ArrayList<DDOption>();
 
         OptionTab()
         {
@@ -463,6 +466,9 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
      */
     private class OnlineOptions extends OptionTab
     {
+        public static final int ONLINE_SERVER_LIMIT = 50;
+        public static final String ONLINE_SERVER_REGEXP = // server.domain.com:port or ip:port
+           "^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b):\\d{1,5}$";
 
         @Override
         protected void createUILocal()
@@ -541,7 +547,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             buttonbase.add(mutedplayers);
             misc.add(GuiUtils.CENTER(buttonbase), BorderLayout.SOUTH);
 
-            // display
+            // chat display
             DDLabelBorder dispbase = new DDLabelBorder("chatdisplay", OSTYLE);
             dispbase.setLayout(new GridLayout(0, 1, 0, GRIDADJUST1));
             ButtonGroup chatgroup2 = new ButtonGroup();
@@ -549,7 +555,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             OptionMenu.add(new OptionRadio(NODE, PokerConstants.OPTION_CHAT_DISPLAY, OSTYLE, map_, "display.tab", chatgroup2, PokerConstants.DISPLAY_TAB), dispbase);
             OptionMenu.add(new OptionRadio(NODE, PokerConstants.OPTION_CHAT_DISPLAY, OSTYLE, map_, "display.one", chatgroup2, PokerConstants.DISPLAY_ONE), dispbase);
 
-
+            // chat options
             DDLabelBorder detailbase = new DDLabelBorder("chatdetails", OSTYLE);
             detailbase.setLayout(new GridLayout(0, 1, 0, GRIDADJUST1));
             OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_CHAT_PLAYERS, OSTYLE, map_, true), detailbase);
@@ -562,6 +568,53 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             rightbase.add(dispbase);
             rightbase.add(detailbase);
             base.add(GuiUtils.NORTH(rightbase), BorderLayout.EAST);
+
+            //
+            // online server section
+            //
+
+            DDLabelBorder serverBorder = new DDLabelBorder("onlineserver", OSTYLE);
+            serverBorder.setLayout(new BorderLayout());
+            base.add(serverBorder, BorderLayout.SOUTH);
+
+            // online enabled checkbox
+            onlineEnabled_ = new OptionBoolean(NODE, PokerConstants.OPTION_ONLINE_ENABLED, OSTYLE, map_, true);
+            serverBorder.add(GuiUtils.NORTH(onlineEnabled_), BorderLayout.WEST);
+            onlineEnabled_.addChangeListener(new ChangeListener()
+            {
+                public void stateChanged(ChangeEvent e)
+                {
+                    doOnlineEnabled();
+                }
+            });
+
+            // servers list (online, chat)
+            DDPanel serversTable = new DDPanel();
+            serversTable.setLayout(new VerticalFlowLayout(VerticalFlowLayout.LEFT, 10, 2));
+
+            onlineServer_ = new OptionText(NODE, PokerConstants.OPTION_ONLINE_SERVER, OSTYLE, map_,
+                    ONLINE_SERVER_LIMIT, ONLINE_SERVER_REGEXP, 400, true);
+            chatServer_ = new OptionText(NODE, PokerConstants.OPTION_ONLINE_CHAT, OSTYLE, map_,
+                    ONLINE_SERVER_LIMIT, ONLINE_SERVER_REGEXP, 400, true);
+            int maxLabelWidth = Math.max(onlineServer_.getLabelComponent().getPreferredSize().width,
+                    chatServer_.getLabelComponent().getPreferredSize().width);
+
+            // adjust labels so same size (doing this since not using a GridBag layout)
+            GuiUtils.setPreferredWidth(onlineServer_.getLabelComponent(), maxLabelWidth);
+            GuiUtils.setPreferredWidth(chatServer_.getLabelComponent(), maxLabelWidth);
+
+            serversTable.add(onlineServer_);
+            serversTable.add(chatServer_);
+            serverBorder.add(serversTable, BorderLayout.CENTER);
+
+            // update text fields based on pref
+            doOnlineEnabled();
+        }
+
+        private void doOnlineEnabled() {
+            boolean enabled = onlineEnabled_.getCheckBox().isSelected();
+            onlineServer_.setEnabled(enabled);
+            chatServer_.setEnabled(enabled);
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -39,11 +39,15 @@
 package com.donohoedigital.games.poker;
 
 import com.donohoedigital.base.*;
+import com.donohoedigital.comms.DDMessageListener;
+import com.donohoedigital.comms.DMTypedHashMap;
 import com.donohoedigital.config.*;
+import com.donohoedigital.games.comms.EngineMessage;
 import com.donohoedigital.games.config.*;
 import com.donohoedigital.games.engine.*;
 import com.donohoedigital.games.poker.ai.gui.*;
 import com.donohoedigital.games.poker.engine.*;
+import com.donohoedigital.games.poker.online.GetPublicIP;
 import com.donohoedigital.gui.*;
 import org.apache.log4j.*;
 
@@ -76,6 +80,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
     private OptionText onlineServer_;
     private OptionText chatServer_;
     private OptionBoolean onlineEnabled_;
+    private GlassButton test_;
 
     private final String NODE;
     private int GRIDADJUST2;
@@ -357,7 +362,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             rightbase.add(spacer);
 
             ///
-            /// SCREEEN SHOT
+            /// SCREENSHOT
             ///
 
             OptionInteger oi;
@@ -607,6 +612,17 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             serversTable.add(chatServer_);
             serverBorder.add(serversTable, BorderLayout.CENTER);
 
+            // test button
+            test_ = new GlassButton("testonline", "Glass");
+            serverBorder.add(GuiUtils.CENTER(test_), BorderLayout.EAST);
+            test_.addActionListener(new ActionListener()
+            {
+                public void actionPerformed(ActionEvent e)
+                {
+                    testConnection();
+                }
+            });
+
             // update text fields based on pref
             doOnlineEnabled();
         }
@@ -615,6 +631,17 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             boolean enabled = onlineEnabled_.getCheckBox().isSelected();
             onlineServer_.setEnabled(enabled);
             chatServer_.setEnabled(enabled);
+            test_.setEnabled(enabled);
+        }
+    }
+
+    private void testConnection() {
+        DMTypedHashMap params = new DMTypedHashMap();
+        params.setBoolean(GetPublicIP.PARAM_TEST_SERVER, true);
+        SendMessageDialog dialog = (SendMessageDialog) context_.processPhaseNow("GetPublicIP", params);
+        if (dialog.getStatus() == DDMessageListener.STATUS_OK)
+        {
+            dialog.getReturnMessage().getString(EngineMessage.PARAM_IP);
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
@@ -275,8 +275,8 @@ public class PokerStartMenu extends StartMenu
             firstTimeMusic = false;
         }
 
-        // 2020: no server to check messages
-        boolean enabled = PropertyConfig.getBooleanProperty("settings.online.enabled", false, false);
+        // Only do server code if enabled
+        boolean enabled = engine_.getPrefsNode().getBooleanOption(PokerConstants.OPTION_ONLINE_ENABLED);
 
         // Preform message check the first time the start menu is displayed.
         if (enabled && messageCheck && profile_ != null && engine_.getPrefsNode().getBoolean(PokerConstants.OPTION_AUTO_CHECK_UPDATE, true))

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
@@ -42,6 +42,7 @@ import com.donohoedigital.base.Utils;
 import com.donohoedigital.config.Prefs;
 import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.comms.EngineMessage;
+import com.donohoedigital.games.config.EngineConstants;
 import com.donohoedigital.games.config.GameButton;
 import com.donohoedigital.games.engine.*;
 import com.donohoedigital.games.poker.engine.PokerConstants;
@@ -276,7 +277,7 @@ public class PokerStartMenu extends StartMenu
         }
 
         // Only do server code if enabled
-        boolean enabled = engine_.getPrefsNode().getBooleanOption(PokerConstants.OPTION_ONLINE_ENABLED);
+        boolean enabled = engine_.getPrefsNode().getBooleanOption(EngineConstants.OPTION_ONLINE_ENABLED);
 
         // Preform message check the first time the start menu is displayed.
         if (enabled && messageCheck && profile_ != null && engine_.getPrefsNode().getBoolean(PokerConstants.OPTION_AUTO_CHECK_UPDATE, true))

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
@@ -32,6 +32,7 @@
  */
 package com.donohoedigital.games.poker;
 
+import com.donohoedigital.games.engine.GameEngine;
 import com.donohoedigital.udp.*;
 import com.donohoedigital.games.poker.online.*;
 import com.donohoedigital.games.poker.model.*;
@@ -70,7 +71,10 @@ public class PokerUDPServer extends UDPServer implements PokerConnectionServer, 
     {
         if (chatServer_ == null)
         {
-            String sChatServer = PropertyConfig.getRequiredStringProperty("settings.online.chat");
+            String sChatServer = GameEngine.getGameEngine().getPrefsNode().getStringOption(PokerConstants.OPTION_ONLINE_CHAT);
+            if (sChatServer == null || sChatServer.isEmpty()) {
+                return null;
+            }
             P2PURL url = new P2PURL("chat://"+sChatServer+'/'); // easy parsing
             chatServer_ = new InetSocketAddress(url.getHost(), url.getPort());
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
@@ -32,6 +32,7 @@
  */
 package com.donohoedigital.games.poker;
 
+import com.donohoedigital.games.config.EngineConstants;
 import com.donohoedigital.games.engine.GameEngine;
 import com.donohoedigital.udp.*;
 import com.donohoedigital.games.poker.online.*;
@@ -177,16 +178,32 @@ public class PokerUDPServer extends UDPServer implements PokerConnectionServer, 
 
         if (chatLink_ == null || chatLink_.isDone())
         {
+            ChatHandler handler = main_.getChatLobbyHandler();
+
+            // if not enabled, just show same message we show in the SendMessageDialog
+            if (!GameEngine.getGameEngine().getPrefsNode().getBooleanOption(EngineConstants.OPTION_ONLINE_ENABLED)) {
+                // msg.msgerror.7
+                if (handler != null)
+                {
+                    OnlineMessage chat = new OnlineMessage(OnlineMessage.CAT_CHAT_ADMIN);
+                    chat.setChat(PropertyConfig.getMessage("msg.msgerror.7"));
+                    handler.chatReceived(chat);
+                }
+                return false;
+            }
+
             // make sure addr is resolved
             InetSocketAddress addr = _getChatServer();
-            ChatHandler handler = main_.getChatLobbyHandler();
-            if (addr.isUnresolved())
+            if (addr == null || addr.isUnresolved())
             {
                 if (handler != null)
                 {
                     OnlineMessage chat = new OnlineMessage(OnlineMessage.CAT_CHAT_ADMIN);
-                    chat.setChat(PropertyConfig.getMessage("msg.chat.lobby.unresolved",
-                                                           addr.getHostName()));
+                    if (addr == null) {
+                        chat.setChat(PropertyConfig.getMessage("msg.chat.lobby.notset"));
+                    } else {
+                        chat.setChat(PropertyConfig.getMessage("msg.chat.lobby.unresolved", addr.getHostString()));
+                    }
                     handler.chatReceived(chat);
                 }
                 return false;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/GetPublicIP.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/GetPublicIP.java
@@ -38,6 +38,8 @@
 
 package com.donohoedigital.games.poker.online;
 
+import com.donohoedigital.comms.DDMessageListener;
+import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.comms.*;
 import com.donohoedigital.games.engine.*;
 
@@ -47,32 +49,54 @@ import com.donohoedigital.games.engine.*;
  */
 public class GetPublicIP extends SendMessageDialog
 {
-    //static Logger logger = Logger.getLogger(GetPublicIP.class);
-    
-    /** 
+    public static final String PARAM_TEST_SERVER = "testServer";
+
+    /**
+     * Indicates using this test to verify server connectivity for GamePrefsPanel
+     */
+    private boolean testServer_;
+
+    /**
      * message to send to server
      */
     protected EngineMessage getMessage()
     {
-        EngineMessage msg = new EngineMessage(EngineMessage.GAME_NOTDEFINED,
-                                            EngineMessage.PLAYER_NOTDEFINED, 
+        testServer_ = gamephase_.getBoolean(PARAM_TEST_SERVER, false);
+        return new EngineMessage(EngineMessage.GAME_NOTDEFINED,
+                                            EngineMessage.PLAYER_NOTDEFINED,
                                             EngineMessage.CAT_PUBLIC_IP);
-        return msg;
     }
-    
+
     /**
      * Message to display to user
      */
     protected String getMessageKey()
     {
-        return "msg.getPublicIP";
+        return "msg.testConnection";
     }
-    
+
+    /**
+     * Override to change done step message
+     */
+    @Override
+    public void updateStep(int nStep)
+    {
+        if (nStep == DDMessageListener.STEP_DONE && testServer_)
+        {
+            setStatusText(PropertyConfig.getMessage("msg.p2p.testserver.done"));
+        }
+        else super.updateStep(nStep);
+    }
+
     /**
      * Don't do server redirect query
      */
     protected boolean doServerQuery()
     {
         return false;
+    }
+
+    protected boolean isAutoClose() {
+        return !testServer_;
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
@@ -276,7 +276,7 @@ public class OnlineServer
      */
     private void sendEngineMessage(EngineMessage reqMsg)
     {
-        EngineMessage resMsg = EngineMessenger.SendEngineMessage(null, reqMsg, null);
+        EngineMessage resMsg = GameMessenger.SendEngineMessage(null, reqMsg, null);
 
         if (resMsg.getStatus() == DDMessageListener.STATUS_APPL_ERROR)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/TestPublicConnect.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/TestPublicConnect.java
@@ -195,7 +195,7 @@ public class TestPublicConnect extends SendMessageDialog implements OnlineMessag
     }
 
     /**
-     * Over-ride to change done step message
+     * Override to change done step message
      */
     @Override
     public void updateStep(int nStep)
@@ -208,7 +208,7 @@ public class TestPublicConnect extends SendMessageDialog implements OnlineMessag
     }
 
     /**
-     * Over-ride to set icon upon failure
+     * Override to set icon upon failure
      */
     @Override
     protected void displayError(int nStatus)

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1691,13 +1691,16 @@ msg.chat.break=				Level {0} is starting:  {1} minute break
 
 msg.chat.lobby.connect=		Connecting to the DD Poker Chat Server...
 
-msg.chat.lobby.unresolved	Unable to create UDP connection to DD Poker Chat Server because the \
+msg.chat.lobby.unresolved=	Unable to create UDP connection to DD Poker Chat Server because the \
 							IP address lookup for <font color=blue>{0}</font> failed (DNS failure).   The most likely cause is that \
 							your internet connection is down.
 
-msg.chat.lobby.notbound		Unable to create UDP connection to DD Poker Chat Server.
-msg.chat.lobby.lost			Connection to the DD Poker Chat Server was lost.
-msg.chat.lobby.timeout		Timed out connecting to the DD Poker Chat Server.
+msg.chat.lobby.notset=	    Unable to create UDP connection to DD Poker Chat Server because the \
+							server address is not defined (usually set in Options -> Online).
+
+msg.chat.lobby.notbound=	Unable to create UDP connection to DD Poker Chat Server.
+msg.chat.lobby.lost=		Connection to the DD Poker Chat Server was lost.
+msg.chat.lobby.timeout=		Timed out connecting to the DD Poker Chat Server.
 
 msg.chat.lobby.unavail=		{0}  This can happen if:<BR><BR>\
 									<TABLE CELLSPACING=0 CELLPADDING=0>\

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -35,8 +35,6 @@
 #
 # Various settings
 #
-settings.online.server= http://free.ddpoker.com:80/poker/servlet/
-settings.online.chat=	free.ddpoker.com:11886
 settings.http.readtimeout.millis=       45000
 settings.http.connecttimeout.millis=    15000
 settings.http.dnstimeout.millis=        30000
@@ -230,9 +228,12 @@ msg.msgerror.5=						Unable to determine the location of the DD Poker Server in 
 # This message should never be shown (application should show message) (not used in mod versions)
 msg.msgerror.6=						Unable to perform this action - please verify all data is correct.
 
-msg.msgerror.7=						The DD Poker Server was shut down in July 2017. While this means \
-         							you cannot host public games, the private game functionality still \
-   									works.
+# If online functionality is disabled
+msg.msgerror.7=						Public online game functionality is disabled. While this means \
+         							you cannot host or find public games, the private game functionality still \
+   									works.<BR><BR>\
+                                    If you know of a DD Poker server, you can specify it via \
+                                    Options -> Online -> Public Online Servers.
 
 # P2P the "p2p" versions are used online games
 msg.msgerror.disconnect.p2p.lobby=	<HTML>You were disconnected from the host of this online game.<BR><BR>\
@@ -2628,17 +2629,17 @@ option.screenshotmaxh.help=         When taking a screenshot, the image is scale
 
 option.onlineenabled.label=	  Enabled
 option.onlineenabled.default= false
-option.onlineenabled.help=    If this option is on, it enables Online functionality.  You must specify the \
-                              ip/dns address and port of the DD Poker servers.
+option.onlineenabled.help=    If this option is on, it enables Public Online functionality.  You must specify the \
+                              ip/dns address and port of known DD Poker servers.
 
 option.onlineserver.label=   Online Server
 option.onlineserver.default= example.ddpoker.com:80
-option.onlineserver.help=    Specify the server dns/ip and port of the DD Poker backend server (e.g., 127.0.0.1:8877 or \
+option.onlineserver.help=    Specify the server dns/ip and port of a DD Poker backend server (e.g., 127.0.0.1:8877 or \
                              my.server.com:80)
 
 option.onlinechat.label=     Online Chat
 option.onlinechat.default=   example.ddpoker.com:11886
-option.onlinechat.help=      Specify the server dns/ip and port of the DD Poker chat server (e.g., 127.0.0.1:11886 or \
+option.onlinechat.help=      Specify the server dns/ip and port of a DD Poker chat server (e.g., 127.0.0.1:11886 or \
                              my.server.com:11886)
 
 #
@@ -3045,7 +3046,7 @@ labelborder.cheat.label=		"Cheat" Options
 labelborder.audio.label=		Sound
 labelborder.boot.label=			Boot Rules
 labelborder.onlineother.label=	Miscellaneous
-labelborder.onlineserver.label=	Online Servers
+labelborder.onlineserver.label=	Public Online Servers
 labelborder.chatoptions.label=	Chat Messages
 labelborder.chatdisplay.label=	Chat Display
 labelborder.chatdetails.label=	Chat Options

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -234,7 +234,7 @@ msg.msgerror.5=						Unable to determine the location of the DD Poker Server in 
 									is available and that DNS is properly configured.
 
 # This message should never be shown (application should show message) (not used in mod versions)
-msg.msgerror.6=						Unabled to perform this action - please verify all data is correct.
+msg.msgerror.6=						Unable to perform this action - please verify all data is correct.
 
 msg.msgerror.7=						The DD Poker Server was shut down in July 2017. While this means \
          							you cannot host public games, the private game functionality still \
@@ -2187,7 +2187,7 @@ msg.odds.hs.over=		Hand completed
 msg.odds.pot=			<HTML><font color=yellow>{1} to 1 ({0}%)</font>
 msg.odds.pot.none=		No bet to call
 
-msg.deck.copyfailed=		<HTML>Unabled to copy file<BR>\
+msg.deck.copyfailed=		<HTML>Unable to copy file<BR>\
 							<CENTER><font color="yellow">{0}</font><BR>to<BR><font color="yellow">{1}</font><CENTER><BR>\
 							Perhaps there is a permissions problem.<BR>\
 							<HTML>

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -33,12 +33,6 @@
 #
 
 #
-# 2020 build - since server is turned off, use to
-#              disable certain features (false)
-# 2024 redux - TODO(#2): make editable in GUI
-settings.online.enabled=false
-
-#
 # Various settings
 #
 settings.online.server= http://free.ddpoker.com:80/poker/servlet/

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -75,12 +75,12 @@ settings.poker.connect.timeout.millis=  10000
 
 # file extensions/mime types - must match installer/poker.reg entries
 settings.save.ext=		ddpokersave
-settings.save.gamestate.class=com.donohoedigital.games.poker.PokerGameState 
+settings.save.gamestate.class=com.donohoedigital.games.poker.PokerGameState
 
 #
 # Values needed by computer logic to process based on list value.
 # Must match a value defined in data-elements for the given listname
-# list.[listname].[identifier] = listvalue.  The idea is that that
+# list.[listname].[identifier] = listvalue.  The idea is that
 # the identifier implies the list value
 #
 
@@ -452,7 +452,7 @@ msg.windowtitle.quitGame= 			Quit Tournament Confirmation
 msg.windowtitle.loadGame= 			Load Tournament
 msg.windowtitle.exportTable= 		Export Table
 msg.windowtitle.exportChat= 		Export Chat
-msg.windowtitle.screenShot=         Save Screen Shot
+msg.windowtitle.screenShot=         Save Screenshot
 msg.windowtitle.deckAdd=   			Add Deck Image
 msg.windowtitle.mutedPlayer=		Muted Player List
 msg.windowtitle.bannedPlayer=		Banned Player List
@@ -1361,7 +1361,7 @@ label.exporthistory.label=			<HTML><CENTER><font size=+1>\
 									</CENTER></HTML>
 
 label.savescreenshot.label=			<HTML><CENTER><font size=+1>\
-									Please choose a name and location to save the screen shot.</font><BR>\
+									Please choose a name and location to save the screenshot.</font><BR>\
                                     The image is scaled to {0}w x {1}h pixels (as set in options).\
 									</CENTER></HTML>
 
@@ -2404,13 +2404,13 @@ option.clockcolorup.help=			With this option on, the Poker Clock will automatica
 option.onlineaudio.label=			Play Sound When Your Turn To Act
 option.onlineaudio.default=			true
 option.onlineaudio.help=			If this option is on, a bell will chime when it is your turn to act in an online game.  This \
-									is helpful if you are multi-tasking and DD Poker is obscured or minimized.
+									is helpful if you are multitasking and DD Poker is obscured or minimized.
 
 option.onlinefront.label=			Move Window To Front When Your Turn To Act
 option.onlinefront.default=			true
 option.onlinefront.help=			If this option is on, the DD Poker window will be moved to the front \
 									of other windows on your screen when it is your turn to act.  This \
-									is helpful if you are multi-tasking and DD Poker is obscured or minimized.
+									is helpful if you are multitasking and DD Poker is obscured or minimized.
 
 option.onlinepause.label=			Pause Tournament At Start (host)
 option.onlinepause.default=			false
@@ -2622,12 +2622,30 @@ option.onlinestart.help=   		Number of seconds to countdown after the host press
 
 option.screenshotmaxw.label=        Max Width (pixels)
 option.screenshotmaxw.default=      1024
-option.screenshotmaxw.help=         When taking a screen shot, the image is scaled down so as not exceed this width.
+option.screenshotmaxw.help=         When taking a screenshot, the image is scaled down so as not exceed this width.
 
 option.screenshotmaxh.label=        Max Height (pixels)
 option.screenshotmaxh.default=      768
-option.screenshotmaxh.help=         When taking a screen shot, the image is scaled down so as not to exceed this height.
+option.screenshotmaxh.help=         When taking a screenshot, the image is scaled down so as not to exceed this height.
 
+#
+# Online server fields
+#
+
+option.onlineenabled.label=	  Enabled
+option.onlineenabled.default= false
+option.onlineenabled.help=    If this option is on, it enables Online functionality.  You must specify the \
+                              ip/dns address and port of the DD Poker servers.
+
+option.onlineserver.label=   Online Server
+option.onlineserver.default= example.ddpoker.com:80
+option.onlineserver.help=    Specify the server dns/ip and port of the DD Poker backend server (e.g., 127.0.0.1:8877 or \
+                             my.server.com:80)
+
+option.onlinechat.label=     Online Chat
+option.onlinechat.default=   example.ddpoker.com:11886
+option.onlinechat.help=      Specify the server dns/ip and port of the DD Poker chat server (e.g., 127.0.0.1:11886 or \
+                             my.server.com:11886)
 
 #
 # Table list
@@ -3027,12 +3045,13 @@ msg.bigiter=<HTML>\
 labelborder.practice.label=		Practice
 labelborder.general.label=		General
 labelborder.delayopt.label=		Time Delay
-labelborder.screenshot.label=   Screen Shot
+labelborder.screenshot.label=   Screenshot
 labelborder.clock.label=		Poker Clock
 labelborder.cheat.label=		"Cheat" Options
 labelborder.audio.label=		Sound
 labelborder.boot.label=			Boot Rules
 labelborder.onlineother.label=	Miscellaneous
+labelborder.onlineserver.label=	Online Servers
 labelborder.chatoptions.label=	Chat Messages
 labelborder.chatdisplay.label=	Chat Display
 labelborder.chatdetails.label=	Chat Options

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -42,7 +42,7 @@ settings.http.dnstimeout.millis=        30000
 #
 # p2p online
 #
-settings.server.port=                   11885
+settings.p2p.server.port=               11885
 settings.server.threads=                3
 settings.server.readtimeout.millis=     10000
 settings.server.readwait.millis=        100

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -182,6 +182,7 @@ msg.playstrength.10=	Raise / Reraise
 
 msg.p2p.test.done=					The server successfully contacted your game, which means your \
 									online game is ready to go!
+msg.p2p.testserver.done=			Success connecting to the Online Server!
 msg.p2p.test.msgrcvd=				Test message from DD Poker server received...
 
 
@@ -686,6 +687,7 @@ msg.userRegistration=				<HTML>Contacting DD Poker Server<BR>to submit registrat
 msg.errorOnline=					<HTML>Error contacting DD Poker Server</HTML>
 
 msg.getPublicIP=					<HTML>Contacting DD Poker Server to determine your public IP address...</HTML>
+msg.testConnection=					<HTML>Contacting DD Poker Server to test your connection...</HTML>
 msg.testPublicConnect=				<HTML>Contacting DD Poker Server to test your public connect URL...</HTML>
 msg.activateWanProfile=				<HTML>Contacting DD Poker Server to activate your online profile...</HTML>
 msg.addWanProfile=					<HTML>Contacting DD Poker Server to create your online profile...</HTML>
@@ -2644,6 +2646,11 @@ option.onlinechat.label=     Online Chat
 option.onlinechat.default=   example.ddpoker.com:11886
 option.onlinechat.help=      Specify the server dns/ip and port of a DD Poker chat server (e.g., 127.0.0.1:11886 or \
                              my.server.com:11886)
+
+
+button.testonline.label=  	Test
+button.testonline.help=   	Test connection to the Online Server address.
+
 
 #
 # Table list

--- a/code/poker/src/main/resources/config/poker/styles.xml
+++ b/code/poker/src/main/resources/config/poker/styles.xml
@@ -373,6 +373,10 @@
 	<color name="Options.scrollbar.fg" r="64" g="64" b="64"/>
 	<color name="Options.scrollbar.focus" r="0" g="0" b="255" a="50"/>
 	<color name="Options.scrollpane.bg" r="204" g="204" b="204"/>
+	<color name="Options.textfield.fg" copy="primarywidget.fg"/>
+	<color name="Options.textfield.bg" copy="primarywidget.bg"/>
+	<color name="Options.textfield.error.bg" copy="primarywidget.error"/>
+	<font name="Options.textfield" fontname="Lucida Sans Regular" pointsize="15"/>
 
 	<color name="OptionsDialog.slider.fg" r="0" g="0" b="0" />
 	<color name="OptionsDialog.slider.bg" r="204" g="204" b="204"/>

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -153,6 +153,9 @@ public class PokerConstants
     public static final String OPTION_ONLINE_PAUSE_ALL_DISCONNECTED = "onlinepauseall";
     public static final String OPTION_ONLINE_UDP = "onlineudp";
     public static final String OPTION_ONLINE_COUNTDOWN = "countdown";
+    public static final String OPTION_ONLINE_ENABLED = "onlineenabled";
+    public static final String OPTION_ONLINE_SERVER = "onlineserver";
+    public static final String OPTION_ONLINE_CHAT = "onlinechat";
     public static final String OPTION_SCREENSHOT_MAX_WIDTH = "screenshotmaxw";
     public static final String OPTION_SCREENSHOT_MAX_HEIGHT = "screenshotmaxh";
 

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -153,8 +153,6 @@ public class PokerConstants
     public static final String OPTION_ONLINE_PAUSE_ALL_DISCONNECTED = "onlinepauseall";
     public static final String OPTION_ONLINE_UDP = "onlineudp";
     public static final String OPTION_ONLINE_COUNTDOWN = "countdown";
-    public static final String OPTION_ONLINE_ENABLED = "onlineenabled";
-    public static final String OPTION_ONLINE_SERVER = "onlineserver";
     public static final String OPTION_ONLINE_CHAT = "onlinechat";
     public static final String OPTION_SCREENSHOT_MAX_WIDTH = "screenshotmaxw";
     public static final String OPTION_SCREENSHOT_MAX_HEIGHT = "screenshotmaxh";

--- a/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
+++ b/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
@@ -33,7 +33,6 @@
 # client - testing
 settings.online.server=    http://192.168.64.1:8877/poker/servlet/
 settings.online.chat=      192.168.64.1:11886
-settings.online.enabled=   true
 
 # server (turn off port 80)
 settings.server.port=					8877

--- a/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
+++ b/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
@@ -30,10 +30,6 @@
 # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 # Overrides for Doug's development environments
 
-# client - testing
-settings.online.server=    http://192.168.64.1:8877/poker/servlet/
-settings.online.chat=      192.168.64.1:11886
-
 # server (turn off port 80)
 settings.server.port=					8877
 

--- a/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
+++ b/code/pokernetwork/src/main/resources/config/poker/override/donohoe.properties
@@ -35,11 +35,11 @@ settings.server.port=					8877
 
 # debug
 settings.debug.enabled=                true
-#settings.debug.repaint=                 true
-#settings.debug.dougcontrolsai=		   true
+#settings.debug.repaint=                true
+#settings.debug.dougcontrolsai=		    true
 #settings.debug.pots=                   true
-settings.debug.skip.dup.key.check=      true
-settings.debug.override.key=            true
+settings.debug.skip.dup.key.check=     true
+settings.debug.override.key=           true
 settings.debug.profile.email.override= false
 settings.debug.profile.email.override.to=
 

--- a/code/pokerserver/src/main/resources/config/poker/cmdline.properties
+++ b/code/pokerserver/src/main/resources/config/poker/cmdline.properties
@@ -59,4 +59,4 @@ msg.msgerror.2=						The DD Poker Server encountered an unexpected error while p
 msg.msgerror.3=						Unable to locate the DD Poker Server.
 msg.msgerror.4=						Failed to send the message for some obscure reason.
 msg.msgerror.5=						Unable to determine the location of the DD Poker Server in a reasonable time.
-msg.msgerror.6=						Unabled to perform this action - please verify all data is correct.
+msg.msgerror.6=						Unable to perform this action - please verify all data is correct.

--- a/code/pokerserver/src/main/resources/config/poker/server.properties
+++ b/code/pokerserver/src/main/resources/config/poker/server.properties
@@ -356,9 +356,8 @@ msg.Xth=					{0}th
 ###
 ### Chat
 ###
-msg.chat.welcome=			<font color=blue><B>Hello {0}</b></font>.  Welcome to the DD Poker Online Chat Lobby.  Please remember that your \
-							use of the online features of DD Poker is subject to our terms and conditions found \
-							at <B>http://www.ddpoker.com/terms</B>.  Thanks for your support of DD Poker!
+msg.chat.welcome=			<font color=blue><B>Hello {0}</b></font>.  Welcome to the DD Poker Online Chat Lobby.  \
+                            Thanks for your support of DD Poker!
 
 msg.chat.hello=				{0} joined the lobby.
 msg.chat.goodbye=			{0} left the lobby.

--- a/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerServer.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerServer.java
@@ -48,7 +48,7 @@ import java.nio.channels.*;
  */
 public class Peer2PeerServer extends GameServer
 {
-    private Peer2PeerControllerInterface controller_;
+    private final Peer2PeerControllerInterface controller_;
 
     /**
      * Constructor
@@ -56,6 +56,7 @@ public class Peer2PeerServer extends GameServer
     public Peer2PeerServer(Peer2PeerControllerInterface controller)
     {
         setAppName("Peer2PeerServer");
+        setPortKey("settings.p2p.server.port");
         setConfigLoadRequired(false);
         setServlet(new Peer2PeerServlet());
         setLogStatus(false);

--- a/code/server/src/main/java/com/donohoedigital/server/GameServer.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServer.java
@@ -388,7 +388,7 @@ public abstract class GameServer extends Thread
         // store first port as preferred
         if (!channels_.isEmpty())
         {
-            logger.info("Preferred TCP address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
+            logger.info("Preferred TCP (online server) address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
         }
 
         // create pool

--- a/code/server/src/main/java/com/donohoedigital/server/GameServer.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServer.java
@@ -57,6 +57,7 @@ public abstract class GameServer extends Thread
     private long nNum_ = 0;
 
     // config stuff
+    private String sPortKey_ = "settings.server.port";
     private boolean exceptionOnNoPortsBound = true;
     private boolean bindLoopback = false;
     private boolean configLoadRequired = true;
@@ -100,6 +101,13 @@ public abstract class GameServer extends Thread
     {
         setName(appName); // set thread name too
         this.appName = appName;
+    }
+
+    /**
+     * allow override of the properties key used to lookup our port
+     */
+    public final void setPortKey(String portKey) {
+        sPortKey_ = portKey;
     }
 
     /**
@@ -251,7 +259,7 @@ public abstract class GameServer extends Thread
         LOG_UNAVAIL = PropertyConfig.getRequiredIntegerProperty("settings.server.noworker.log.millis");
         LOG_STATUS = PropertyConfig.getRequiredIntegerProperty("settings.server.status.log.seconds") * 1000;
         int nThreads = PropertyConfig.getRequiredIntegerProperty("settings.server.threads");
-        sPort_ = PropertyConfig.getRequiredStringProperty("settings.server.port");
+        sPort_ = PropertyConfig.getRequiredStringProperty(sPortKey_);
         String ip = PropertyConfig.getStringProperty("settings.server.ip", null, false);
         bBindFailover_ = PropertyConfig.getBooleanProperty("settings.server.failover", false, false);
         nFailoverAttempts_ = PropertyConfig.getIntegerProperty("settings.server.failover.attempts", 2);

--- a/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
+++ b/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
@@ -35,6 +35,7 @@ package com.donohoedigital.server;
 
 import com.donohoedigital.base.*;
 import com.donohoedigital.comms.*;
+import com.donohoedigital.comms.Servlet;
 import com.donohoedigital.config.*;
 import org.apache.log4j.*;
 
@@ -79,8 +80,7 @@ public class SocketThread extends Thread
     {
         pool_ = pool;
         servlet_ = servlet;
-        // matches tomcat and client.properties entry "settings.online.server"
-        DD_URI_STARTS_WITH = '/' + pool.getServer().getAppName() + "/servlet/";
+        DD_URI_STARTS_WITH = Servlet.ServletUri(pool.getServer().getAppName());
         DD_URI_STARTS_WITH = DD_URI_STARTS_WITH.toLowerCase();
     }
     

--- a/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
+++ b/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
@@ -79,7 +79,7 @@ public class SocketThread extends Thread
     {
         pool_ = pool;
         servlet_ = servlet;
-        // matches Jboss and client.properties entry "settings.online.server"
+        // matches tomcat and client.properties entry "settings.online.server"
         DD_URI_STARTS_WITH = '/' + pool.getServer().getAppName() + "/servlet/";
         DD_URI_STARTS_WITH = DD_URI_STARTS_WITH.toLowerCase();
     }

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPServer.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPServer.java
@@ -303,7 +303,7 @@ public class UDPServer extends Thread
         // store first port as preferred
         if (!channels_.isEmpty())
         {
-            logger.info("Preferred UDP address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
+            logger.info("Preferred UDP (chat) address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
         }
 
         // create dispatch queue


### PR DESCRIPTION
Allow user to enable public online games and specify the server ip or DNS name.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/e5049047-69ff-4941-a49b-fc758a986b22">

This means no longer having to change a `.properties` file and allows private server operators to easily communicate what server to their players.

Players can verify connectivity using the `Test` button.

Had to fix a bunch of option internals to make this possible, hence the large commit.  Also fixed some typos and other warnings.