### PR TITLE
Spring 5.3.39 / Hibernate 5.6.16 / slf4j 2.0.16 upgrade

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -173,8 +173,8 @@ of DD Poker was written from 2004-2007, with sporadic updates after that.  The o
 JDK was 1.5.
 
 While some things were upgraded to get the code to work with Java 1.8, our maven dependencies
-still largely date from this time frame too.  We are currently on ancient versions of
-Swing, Wicket, log4j, junit, etc.
+still largely date from this time frame too.  We are currently on older/ancient versions of
+Swing, Wicket, log4j, junit, etc. (although we are upgrading some as the mood strikes).
 
 That said, amazingly, it all still seems to work.  If anybody wants to start upgrading dependencies,
 we are happy to take PRs.

--- a/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
+++ b/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
@@ -43,6 +43,7 @@ import java.util.concurrent.*;
  * Time: 3:15:11 PM
  * To change this template use File | Settings | File Templates.
  */
+@SuppressWarnings("ResultOfMethodCallIgnored")
 public abstract class ManagedQueue<T>
 {
     private static final Logger logger = Logger.getLogger(ManagedQueue.class);
@@ -165,7 +166,7 @@ public abstract class ManagedQueue<T>
         {
             // wait for thread to end.  If finishing queue,
             // wait indefinitely (e.g., until quitItem is processed).
-            // Otherwise only wait a little bit.
+            // Otherwise, only wait a little bit.
             processor.join(finishQueue ? 0 : WAIT_FOR_THREAD_FINISH);
         }
         catch (InterruptedException e)
@@ -280,7 +281,7 @@ public abstract class ManagedQueue<T>
     }
 
     /**
-     * Is done?
+     * Are we done?
      */
     public boolean isDone()
     {

--- a/code/common/src/main/resources/log4j.properties
+++ b/code/common/src/main/resources/log4j.properties
@@ -44,6 +44,7 @@ log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MMM/dd kk:mm:ss.SSS} [*]
 # Specific customizations
 log4j.logger.com.donohoedigital=DEBUG
 log4j.logger.com.donohoedigital.config.MatchingResources=INFO
+log4j.logger.com.donohoedigital.base.ManagedQueue=INFO
 
 # Hibernate (type must be TRACE to display, debug or other to suppress)
 log4j.logger.org.hibernate=WARN

--- a/code/gameserver/pom.xml
+++ b/code/gameserver/pom.xml
@@ -117,23 +117,18 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.5.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.5.8</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>4.3.11.Final</version>
+      <version>${hibernate.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <version>4.3.11.Final</version>
+      <version>${hibernate.version}</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>

--- a/code/gameserver/pom.xml
+++ b/code/gameserver/pom.xml
@@ -117,7 +117,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/BannedKey.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/BannedKey.java
@@ -50,10 +50,10 @@ import java.util.*;
 @Table(name = "banned_key")
 public class BannedKey implements BaseModel<Long>, Comparable<BannedKey>
 {
-    public static final Date DEFAULT_UNTIL = new GregorianCalendar(2032, 11, 31).getTime();  // 12/31/2032
+    public static final Date DEFAULT_UNTIL = new GregorianCalendar(2099, Calendar.DECEMBER, 31).getTime();  // 12/31/2099
 
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ban_id", nullable = false)
     private Long id;
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/Registration.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/Registration.java
@@ -58,7 +58,7 @@ public class Registration implements BaseModel<Long>
     }
 
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "reg_id", nullable = false)
     private Long id;
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/UpgradedKey.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/UpgradedKey.java
@@ -50,7 +50,7 @@ import java.util.*;
 public class UpgradedKey implements BaseModel<Long>
 {
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "upg_id", nullable = false)
     private Long id;
 

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyServiceTest.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Calendar;
@@ -56,7 +55,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(transactionManager = "transactionManager", defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class BannedKeyServiceTest
 {

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyTest.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
@@ -60,7 +59,6 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class BannedKeyTest {
     private final Logger logger = Logger.getLogger(BannedKeyTest.class);

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.assertNotNull;
@@ -56,7 +55,6 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class RegistrationServiceTest
 {

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationTest.java
@@ -44,7 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -61,7 +60,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class RegistrationTest
 {

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
@@ -42,7 +42,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.util.Log4jConfigurer;
 
 import java.io.FileNotFoundException;
 
@@ -51,23 +50,21 @@ import java.io.FileNotFoundException;
  * User: donohoe
  * Date: Feb 17, 2008
  * Time: 9:08:21 PM
- *
  * Simple Spring test - configure logging, load app context, get a bean
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class SpringCreatedServiceTest extends TestCase
 {
-    private Logger logger = Logger.getLogger(SpringCreatedServiceTest.class);
+    private final Logger logger = Logger.getLogger(SpringCreatedServiceTest.class);
 
     /**
      * Load app config
      */
     @Test
-    public void testSpring() throws FileNotFoundException
+    public void testSpring()
     {
         // TODO: auto-wire service instead?
-        Log4jConfigurer.initLogging("classpath:log4j.properties");
         String[] contextPaths = new String[] {"app-context-jpatests.xml"};
         ApplicationContext ctx = new ClassPathXmlApplicationContext(contextPaths);
 

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/UpgradedKeyTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/UpgradedKeyTest.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -59,7 +58,6 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class UpgradedKeyTest
 {
@@ -105,7 +103,7 @@ public class UpgradedKeyTest
         assertNull(delete);
     }
 
-        @Test
+    @Test
     @Rollback
     public void loadAll()
     {

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/OnlineGame.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/OnlineGame.java
@@ -120,7 +120,7 @@ public class OnlineGame implements BaseModel<Long>, SimpleXMLEncodable
     }
 
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "wgm_id", nullable = false)
     public Long getId()
     {

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/OnlineProfile.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/OnlineProfile.java
@@ -121,7 +121,7 @@ public class OnlineProfile implements BaseModel<Long>
     }
 
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "wpr_id", nullable = false)
     public Long getId()
     {

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentHistory.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentHistory.java
@@ -55,7 +55,7 @@ public class TournamentHistory implements BaseModel<Long>, DataMarshal, SimpleXM
 {
     // members
     @Id()
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "whi_id", nullable = false)
     private Long id;
 

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/dao/impl/OnlineGameImplJpa.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/dao/impl/OnlineGameImplJpa.java
@@ -54,7 +54,7 @@ public class OnlineGameImplJpa extends JpaBaseDao<OnlineGame, Long> implements O
 {
     //private static final Logger logger = Logger.getLogger(OnlineGameImplJpa.class);
 
-    private static final Date END_OF_TIME = new GregorianCalendar(2030, 12, 31, 23, 23, 59).getTime();
+    private static final Date END_OF_TIME = new GregorianCalendar(2099, Calendar.DECEMBER, 31, 23, 23, 59).getTime();
     private static final Date BEGINNING_OF_TIME = new Date(0);
 
     @SuppressWarnings({"unchecked"})
@@ -231,7 +231,7 @@ public class OnlineGameImplJpa extends JpaBaseDao<OnlineGame, Long> implements O
      */
     private String getDateColumn(Integer[] modes)
     {
-        String dateColumn = null;
+        String dateColumn;
 
         // earliest type determines sort order (because start/end date can be null
         // for games not started/not ended)
@@ -276,8 +276,6 @@ public class OnlineGameImplJpa extends JpaBaseDao<OnlineGame, Long> implements O
 
     /**
      * Online game summary
-     *
-     * @return
      */
     @SuppressWarnings({"unchecked"})
     public PagedList<HostSummary> getHostSummary(Integer count, int offset, int pagesize, String nameSearch, Date begin, Date end)
@@ -310,7 +308,7 @@ public class OnlineGameImplJpa extends JpaBaseDao<OnlineGame, Long> implements O
         List<Object[]> results = (List<Object[]>) query.getResultList();
 
         // create summary list, set size and translate results
-        PagedList<HostSummary> list = new PagedList<HostSummary>();
+        PagedList<HostSummary> list = new PagedList<>();
         list.setTotalSize(count);
         for (Object[] a : results)
         {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/ConfigTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/ConfigTest.java
@@ -54,7 +54,6 @@ public class ConfigTest extends TestCase
      */
     public void testSpring() throws FileNotFoundException
     {
-        Log4jConfigurer.initLogging("classpath:log4j.properties");
         String[] contextPaths = new String[] {"app-context-configtest.xml"};
         ApplicationContext ctx = new ClassPathXmlApplicationContext(contextPaths);
         String test = (String) ctx.getBean("test");

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/HibernateTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/HibernateTest.java
@@ -54,9 +54,6 @@ public class HibernateTest extends TestCase
     @SuppressWarnings({"RawUseOfParameterizedType"})
     public void testHibernate() throws FileNotFoundException
     {
-        //log4j looks in base of classpath by default.  Alternative is to initLogging as such:
-        //      we can use the resources directory which is intellij copies to build dir
-        //Log4jConfigurer.initLogging("classpath:"+ConfigTest.CONFIG_CLASSPATH+"log4j.properties");
         Logger logger = Logger.getLogger(HibernateTest.class);
 
         // "poker" is from persistence.xml (aka the persistence unit)

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameServiceTest.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.*;
@@ -54,7 +53,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineGameServiceTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameTest.java
@@ -46,7 +46,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
@@ -65,7 +64,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineGameTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceDummyTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceDummyTest.java
@@ -37,7 +37,6 @@ import org.junit.runner.RunWith;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -50,7 +49,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileServiceDummyTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceTest.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.*;
@@ -55,7 +54,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileServiceTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileTest.java
@@ -43,7 +43,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URL;
@@ -61,7 +60,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
@@ -46,7 +46,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.donohoedigital.games.poker.model.TournamentHistory.*;
@@ -61,7 +60,6 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class TournamentHistoryServiceTest
 {

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryTest.java
@@ -47,7 +47,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
@@ -65,7 +64,6 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@TransactionConfiguration(defaultRollback = false)
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class TournamentHistoryTest
 {

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -68,7 +68,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.2</junit.version>
-    <spring.version>4.3.30.RELEASE</spring.version>
+    <spring.version>5.3.39</spring.version>
+    <hibernate.version>5.6.15.Final</hibernate.version>
+    <slf4j.version>2.0.16</slf4j.version>
   </properties>
 
   <build>

--- a/code/wicket/pom.xml
+++ b/code/wicket/pom.xml
@@ -176,7 +176,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>

--- a/code/wicket/pom.xml
+++ b/code/wicket/pom.xml
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.5.8</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Spring 5.3.39 / Hibernate 5.6.16 / slf4j 2.0.16 upgrade

+ need to specify `@GeneratedValue(strategy = GenerationType.IDENTITY)`
+ `@TransactionConfiguration` not needed anymore
+ `Log4jConfigurer.initLogging` not needed anymore
+ 2030 and 2032 are frighteningly close, move "end" dates to 2099
+ Suppress ManagedQueue debug output in unit tests

Welcome to code from the year 2024!