### PR TITLE
Upgrade to Wicket 6.30.0 (eliminate wicketstuff)

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/RepoUtils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/RepoUtils.java
@@ -2,53 +2,52 @@
  * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  * DD Poker - Source Code
  * Copyright (c) 2003-2024 Doug Donohoe
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * For the full License text, please see the LICENSE.txt file
  * in the root directory of this project.
- * 
- * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
  * graphics, text, and documentation found in this repository (including but not
- * limited to written documentation, website content, and marketing materials) 
- * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
- * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
  * without explicit written permission for any uses not covered by this License.
  * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
  * in the root directory of this project.
- * 
- * For inquiries regarding commercial licensing of this source code or 
- * the use of names, logos, images, text, or other assets, please contact 
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
  * doug [at] donohoe [dot] info.
  * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  */
-package com.donohoedigital.games.poker.wicket.util;
+package com.donohoedigital.base;
 
-import com.donohoedigital.wicket.converters.PercentConverter;
+import java.io.File;
 
-import java.util.Locale;
+public class RepoUtils {
 
-public class PokerPercentConverter extends PercentConverter
-{
-    private static final long serialVersionUID = 42L;
-
-    public PokerPercentConverter(int fractionDigits)
-    {
-        super(fractionDigits);
-    }
-
-    @Override
-    public String convertToString(Double value, Locale locale)
-    {
-        String style = value < 0 ? "poker-number-negative" : "poker-number-positive";
-        return "<span class=\"" + style + "\">" + super.convertToString(value, locale) + "</span>";
+    /**
+     * Get root directory of this git repo (by looking for .git dir)
+     */
+    public static File getRepoRoot() {
+        File parent = new File(System.getProperty("user.dir"));
+        while (parent != null) {
+            File gitDir = new File(parent, ".git");
+            if (gitDir.exists()) {
+                return parent;
+            }
+            parent = parent.getParentFile();
+        }
+        throw new IllegalStateException("Could not find the repository root");
     }
 }

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/PokerWicketApplication.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/PokerWicketApplication.java
@@ -32,6 +32,7 @@
  */
 package com.donohoedigital.games.poker.wicket;
 
+import com.donohoedigital.base.RepoUtils;
 import com.donohoedigital.config.ConfigUtils;
 import com.donohoedigital.games.poker.service.OnlineProfileService;
 import com.donohoedigital.games.poker.wicket.admin.AdminAuthorizationStrategy;
@@ -48,8 +49,10 @@ import org.apache.wicket.Session;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
+import org.apache.wicket.util.file.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.File;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -104,8 +107,11 @@ public class PokerWicketApplication extends BaseWicketApplication
         // seems to tell Wicket to look in the source location for resources.
         // Enable in development mode only.
         if (getConfigurationType().equals(RuntimeConfigurationType.DEVELOPMENT)) {
-            getResourceSettings().addResourceFolder("code/wicket/src/main/java");
-            getResourceSettings().addResourceFolder("code/pokerwicket/src/main/java");
+            File repoRoot = RepoUtils.getRepoRoot();
+            getResourceSettings().getResourceFinders().add(0, new Path(
+                    new File(repoRoot, "code/wicket/src/main/java").getAbsolutePath()));
+            getResourceSettings().getResourceFinders().add(0, new Path(
+                    new File(repoRoot, "code/pokerwicket/src/main/java").getAbsolutePath()));
         }
     }
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
@@ -53,7 +53,6 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.validation.IErrorMessageSource;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidationError;
 import org.apache.wicket.validation.IValidator;
@@ -71,12 +70,11 @@ import java.util.List;
  * Time: 10:39:35 PM
  * To change this template use File | Settings | File Templates.
  */
+@SuppressWarnings("unused")
 @MountPath("admin/ban-list")
 public class BanList extends AdminPokerPage
 {
     private static final long serialVersionUID = 42L;
-
-    public static final int ITEMS_PER_PAGE = 10;
 
     @SpringBean
     private BannedKeyService banService;
@@ -95,7 +93,7 @@ public class BanList extends AdminPokerPage
         add(new WebMarkupContainer("none").setVisible(data.isEmpty()));
 
         // form data
-        CompoundPropertyModel<BanData> formData = new CompoundPropertyModel<BanData>(data);
+        CompoundPropertyModel<BanData> formData = new CompoundPropertyModel<>(data);
 
         // form
         Form<BanData> form = new Form<BanData>("form", formData)
@@ -120,22 +118,21 @@ public class BanList extends AdminPokerPage
         add(form);
 
         // name
-        TextField<String> ban = new TextField<String>("ban");
+        TextField<String> ban = new TextField<>("ban");
         ban.add(new DefaultFocus());
         ban.setRequired(true);
-        ban.add(new StringValidator.MaximumLengthValidator(255));
+        ban.add(StringValidator.maximumLength(255));
         ban.add(new CheckDup());
         form.add(ban);
 
         // until
         DateTextField until = new DateTextField("until");
         form.add(until.add(new DatePicker()));
-        //noinspection unchecked
         until.add(DateValidator.minimum(new Date()));
 
         // comment
-        TextField<String> comment = new TextField<String>("comment");
-        comment.add(new StringValidator.MaximumLengthValidator(128));
+        TextField<String> comment = new TextField<>("comment");
+        comment.add(StringValidator.maximumLength(128));
         form.add(comment);
 
         // error / feedback
@@ -154,14 +151,8 @@ public class BanList extends AdminPokerPage
             if (bannedKey != null)
             {
                 // TODO: use wicket resources for this
-                iValidatable.error(new IValidationError()
-                {
-
-                    public String getErrorMessage(IErrorMessageSource messageSource)
-                    {
-                        return "'" + ban + "' is already banned";
-                    }
-                });
+                iValidatable.error((IValidationError) messageSource ->
+                        "'" + ban + "' is already banned");
             }
         }
     }
@@ -180,7 +171,7 @@ public class BanList extends AdminPokerPage
         private String comment;
 
         @Override
-        public Iterator<BannedKey> iterator(int first, int pagesize)
+        public Iterator<BannedKey> iterator(long first, long pagesize)
         {
             return getList().iterator();
         }
@@ -246,7 +237,7 @@ public class BanList extends AdminPokerPage
 
         private BanListTableView(String id, BanData data)
         {
-            super(id, data, data.size() + 1); // add one in case 0
+            super(id, data, (int) data.size() + 1); // add one in case 0
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
@@ -141,9 +141,9 @@ public class OnlineProfileSearch extends AdminPokerPage
         private String key;
 
         @Override
-        public Iterator<OnlineProfile> iterator(int first, int pagesize)
+        public Iterator<OnlineProfile> iterator(long first, long pagesize)
         {
-            return profileService.getMatchingOnlineProfiles(size(), first, pagesize, name, email, key, true).iterator();
+            return profileService.getMatchingOnlineProfiles((int) size(), (int) first, (int) pagesize, name, email, key, true).iterator();
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
@@ -147,9 +147,9 @@ public class RegistrationSearch extends AdminPokerPage
         private String address;
 
         @Override
-        public Iterator<Registration> iterator(int first, int pagesize)
+        public Iterator<Registration> iterator(long first, long pagesize)
         {
-            return regService.getMatchingRegistrations(size(), first, pagesize, name, email, key, address).iterator();
+            return regService.getMatchingRegistrations((int) size(), (int) first, (int) pagesize, name, email, key, address).iterator();
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/BasePokerPage.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/BasePokerPage.java
@@ -38,7 +38,10 @@ import com.donohoedigital.games.poker.wicket.panels.TopNavigation;
 import com.donohoedigital.games.poker.wicket.util.LoginUtils;
 import com.donohoedigital.wicket.components.VoidContainer;
 import com.donohoedigital.wicket.pages.BasePage;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.resource.JQueryResourceReference;
 
 /**
  * Created by IntelliJ IDEA.
@@ -64,6 +67,13 @@ public abstract class BasePokerPage extends BasePage<Void>
         add(new CurrentProfile(PROFILE_NAME, isLoginPanelVisible()).setVisible(isCurrentProfileDisplayed()));
         add(new VoidContainer("no-profile").setVisible(!isCurrentProfileDisplayed()));
         add(new CopyrightFooter("footer"));
+    }
+
+    @Override
+    public void renderHead(IHeaderResponse response) {
+        super.renderHead(response);
+        // Ensure jQuery is always included in the head
+        response.render(JavaScriptHeaderItem.forReference(JQueryResourceReference.get()));
     }
 
     /**

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GameDetail.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GameDetail.java
@@ -161,7 +161,7 @@ public class GameDetail extends OnlinePokerPage
         }
 
         @Override
-        public Iterator<TournamentHistory> iterator(int first, int pagesize)
+        public Iterator<TournamentHistory> iterator(long first, long pagesize)
         {
             return getList().iterator();
         }
@@ -194,7 +194,7 @@ public class GameDetail extends OnlinePokerPage
 
         private FinishTableView(String id, FinishData data)
         {
-            super(id, data, data.size() + 1); // add one in case size is 0
+            super(id, data, (int) data.size() + 1); // add one in case size is 0
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GamesList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GamesList.java
@@ -279,10 +279,10 @@ public abstract class GamesList extends OnlinePokerPage
         }
 
         @Override
-        public Iterator<OnlineGame> iterator(int first, int pagesize)
+        public Iterator<OnlineGame> iterator(long first, long pagesize)
         {
             DateRange dr = new DateRange(this);
-            return gameService.getOnlineGames(size(), first, pagesize, getModes(category),
+            return gameService.getOnlineGames((int) size(), (int) first, (int) pagesize, getModes(category),
                                               name, dr.getBegin(), dr.getEnd(), date).iterator();
         }
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/History.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/History.java
@@ -263,10 +263,10 @@ public class History extends OnlinePokerPage
         }
 
         @Override
-        public Iterator<TournamentHistory> iterator(int first, int pagesize)
+        public Iterator<TournamentHistory> iterator(long first, long pagesize)
         {
             DateRange dr = new DateRange(this);
-            return histService.getAllTournamentHistoriesForProfile(size(), first, pagesize, user.getId(), name, dr.getBegin(), dr.getEnd()).iterator();
+            return histService.getAllTournamentHistoriesForProfile((int) size(), (int) first, (int) pagesize, user.getId(), name, dr.getBegin(), dr.getEnd()).iterator();
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/HostList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/HostList.java
@@ -134,14 +134,14 @@ public class HostList extends OnlinePokerPage
         private String name;
         private Date begin;
         private Date end;
-        private Date beginDefault = PokerWicketApplication.START_OF_TIME;
-        private Date endDefault = Utils.getDateEndOfDay(new Date());
+        private final Date beginDefault = PokerWicketApplication.START_OF_TIME;
+        private final Date endDefault = Utils.getDateEndOfDay(new Date());
 
         @Override
-        public Iterator<HostSummary> iterator(int first, int pagesize)
+        public Iterator<HostSummary> iterator(long first, long pagesize)
         {
             DateRange dr = new DateRange(this);
-            return gameService.getHostSummary(size(), first, pagesize, name, dr.getBegin(), dr.getEnd()).iterator();
+            return gameService.getHostSummary((int) size(), (int) first, (int) pagesize, name, dr.getBegin(), dr.getEnd()).iterator();
         }
 
         @Override
@@ -216,7 +216,7 @@ public class HostList extends OnlinePokerPage
                                                           row.getIndex() % 2 == 0 ? "odd" : "even")));
 
             // num
-            row.add(new PlaceLabel("num", new IntegerModel(getCurrentPage() * getPageSize() + row.getIndex() + 1)));
+            row.add(new PlaceLabel("num", new IntegerModel(((int) getCurrentPage()) * getPageSize() + row.getIndex() + 1)));
             // link to player details
             Link<?> link = RecentGames.getHostLink("hostLink", summary.getHostName(), data.getBegin(), data.getEnd());
             row.add(link);

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Leaderboard.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Leaderboard.java
@@ -202,11 +202,11 @@ public class Leaderboard extends OnlinePokerPage
         }
 
         @Override
-        public Iterator<LeaderboardSummary> iterator(int first, int pagesize)
+        public Iterator<LeaderboardSummary> iterator(long first, long pagesize)
         {
             if (DEBUG_ZERO_RESULTS) return Collections.emptyIterator();
             DateRange dr = new DateRange(this, false);
-            return histService.getLeaderboard(size(), first, pagesize, type, games, name, dr.getBegin(), dr.getEnd()).iterator();
+            return histService.getLeaderboard((int) size(), (int) first, (int) pagesize, type, games, name, dr.getBegin(), dr.getEnd()).iterator();
         }
 
         @Override

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
@@ -50,7 +50,6 @@ import com.donohoedigital.wicket.models.IntegerModel;
 import com.donohoedigital.wicket.models.StringModel;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
-import org.apache.wicket.behavior.SimpleAttributeModifier;
 import org.apache.wicket.feedback.ContainerFeedbackMessageFilter;
 import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.Form;
@@ -241,7 +240,7 @@ public class MyProfile extends OnlinePokerPage
                         }
                     };
                     Button button = new Button("button");
-                    button.add(new SimpleAttributeModifier("onclick",
+                    button.add(new AttributeModifier("onclick",
                                                            "return confirm('Are you sure you want to retire " +
                                                            Utils.encodeJavascript(p.getName()) + "?');"));
                     form.add(button);

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Search.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Search.java
@@ -59,7 +59,7 @@ import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 
 /**
@@ -69,6 +69,7 @@ import java.util.Iterator;
  * Time: 1:36:58 PM
  * To change this template use File | Settings | File Templates.
  */
+@SuppressWarnings("unused")
 @MountPath("search")
 @MountMixedParam(parameterNames = {Search.PARAM_SEARCH, Search.PARAM_PAGE, Search.PARAM_SIZE})
 public class Search extends OnlinePokerPage
@@ -83,7 +84,6 @@ public class Search extends OnlinePokerPage
 
     public static final int ITEMS_PER_PAGE = 10;
 
-    @SuppressWarnings({"NonSerializableFieldInSerializableClass"})
     @SpringBean
     private OnlineProfileService profileService;
 
@@ -102,7 +102,7 @@ public class Search extends OnlinePokerPage
     {
         String text = params.get(PARAM_SEARCH).toString();
         if (text != null && text.isEmpty()) text = null;
-        final TextField<String> name = new TextField<String>("name", new StringModel(text));
+        final TextField<String> name = new TextField<>("name", new StringModel(text));
         name.add(new DefaultFocus());
 
         // form
@@ -157,16 +157,16 @@ public class Search extends OnlinePokerPage
         }
 
         @Override
-        public Iterator<OnlineProfile> iterator(int first, int pagesize)
+        public Iterator<OnlineProfile> iterator(long first, long pagesize)
         {
-            if (search == null || search.length() == 0) return new ArrayList<OnlineProfile>(0).iterator();
-            return profileService.getMatchingOnlineProfiles(size(), first, pagesize, search, null, null, true).iterator();
+            if (search == null || search.isEmpty()) return Collections.emptyIterator();
+            return profileService.getMatchingOnlineProfiles((int) size(), (int) first, (int) pagesize, search, null, null, true).iterator();
         }
 
         @Override
         public int calculateSize()
         {
-            if (search == null || search.length() == 0) return 0;
+            if (search == null || search.isEmpty()) return 0;
             return profileService.getMatchingOnlineProfilesCount(search, null, null, true);
         }
 
@@ -175,6 +175,7 @@ public class Search extends OnlinePokerPage
             return search;
         }
 
+        @SuppressWarnings("unused")
         public void setSearch(String s)
         {
             search = s;

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/rss/RssAutoDiscoveryHeader.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/rss/RssAutoDiscoveryHeader.java
@@ -33,8 +33,9 @@
 package com.donohoedigital.games.poker.wicket.rss;
 
 import com.donohoedigital.wicket.WicketUtils;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.MetaDataHeaderItem;
 import org.apache.wicket.markup.html.IHeaderContributor;
-import org.apache.wicket.markup.html.IHeaderResponse;
 
 /**
  * @author Doug Donohoe
@@ -52,10 +53,9 @@ public class RssAutoDiscoveryHeader implements IHeaderContributor
 
     public void renderHead(IHeaderResponse response)
     {
-        String buffer = "<link rel=\"alternate\" " +
-                "type=\"" + "application/rss+xml" + "\" " +
-                "title=\"" + FeedTitle.getTitle(clazz) + "\" " +
-                "href=\"" + WicketUtils.absoluteUrlFor(clazz) + "\" />";
-        response.renderString(buffer);
+        MetaDataHeaderItem item = MetaDataHeaderItem.forLinkTag("alternate", WicketUtils.absoluteUrlFor(clazz));
+        item.addTagAttribute("type", "application/rss+xml");
+        item.addTagAttribute("title", FeedTitle.getTitle(clazz));
+        response.render(item);
     }
 }

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/rss/RssLink.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/rss/RssLink.java
@@ -34,7 +34,7 @@ package com.donohoedigital.games.poker.wicket.rss;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.Behavior;
-import org.apache.wicket.markup.html.IHeaderResponse;
+import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 
 /**

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/util/LoginUtils.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/util/LoginUtils.java
@@ -183,7 +183,10 @@ public class LoginUtils
         }
 
         // continue on
-        if (type == PAGE && !page.continueToOriginalDestination())
+        page.continueToOriginalDestination();
+
+        // if didn't continue on...
+        if (type == PAGE)
         {
             // default to page that login form was on
             // need to use "class" so page is re-rendered

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/util/PokerCurrencyConverter.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/util/PokerCurrencyConverter.java
@@ -32,10 +32,10 @@
  */
 package com.donohoedigital.games.poker.wicket.util;
 
-import com.donohoedigital.wicket.converters.*;
+import com.donohoedigital.wicket.converters.GroupingIntegerConverter;
 
-import java.text.*;
-import java.util.*;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 public class PokerCurrencyConverter extends GroupingIntegerConverter
 {
@@ -51,11 +51,10 @@ public class PokerCurrencyConverter extends GroupingIntegerConverter
     }
 
     @Override
-    public String convertToString(Object value, Locale locale)
+    public String convertToString(Integer value, Locale locale)
     {
-        int num = (Integer) value;
-        String style = num < 0 ? "poker-number-negative" : "poker-number-positive";
-        String pad = num < 0 ? "" : "&nbsp;";
+        String style = value < 0 ? "poker-number-negative" : "poker-number-positive";
+        String pad = value < 0 ? "" : "&nbsp;";
         return "<span class=\"" + style + "\">" + super.convertToString(value, locale) + pad + "</span>";
     }
 }

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -76,8 +76,7 @@
     <hibernate.version>5.6.15.Final</hibernate.version>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <junit.version>4.13.2</junit.version>
-    <wicket.version>1.5.17</wicket.version>
-    <wicketstuff.version>1.5.13</wicketstuff.version>
+    <wicket.version>6.30.0</wicket.version>
     <dependency.classpath.outputFile>target/classpath.txt</dependency.classpath.outputFile>
   </properties>
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/DealTester.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/DealTester.java
@@ -38,13 +38,19 @@
 
 package com.donohoedigital.proto.tests;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.udp.*;
-import com.donohoedigital.games.poker.engine.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.BaseCommandLineApp;
+import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.config.Prefs;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Deck;
+import com.donohoedigital.games.poker.engine.Hand;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  *
@@ -53,7 +59,7 @@ import java.util.*;
 public class DealTester extends BaseCommandLineApp
 {
     // logging
-    private Logger logger;
+    private final Logger logger;
 
     /**
      * Run emailer
@@ -66,7 +72,7 @@ public class DealTester extends BaseCommandLineApp
 
         catch (ApplicationError ae)
         {
-            System.err.println("DealTester ending due to ApplicationError: " + ae.toString());
+            System.err.println("DealTester ending due to ApplicationError: " + ae);
             System.exit(1);
         }  
         catch (java.lang.OutOfMemoryError nomem)
@@ -81,16 +87,6 @@ public class DealTester extends BaseCommandLineApp
             System.exit(1);
         }
     }
-    
-    /**
-     * Can be overridden for application specific options
-     */
-    protected void setupApplicationCommandLineOptions()
-    {
-
-    }
-
-    UDPServer udp_;
 
     /**
      * Create War from config file
@@ -114,7 +110,7 @@ public class DealTester extends BaseCommandLineApp
     {
         int[][] hand = new int[52][52];
 
-        boolean ADJUST = true;
+        //boolean ADJUST = true;
         int RUN = 10000000;
 
         Deck d;
@@ -156,7 +152,7 @@ public class DealTester extends BaseCommandLineApp
             }
         }
 
-        ArrayList<DealInfo> sort = new ArrayList<DealInfo>(0);
+        ArrayList<DealInfo> sort = new ArrayList<>(0);
         int min = Integer.MAX_VALUE;
         int max = 0;
         int sum = 0;
@@ -197,7 +193,7 @@ public class DealTester extends BaseCommandLineApp
 
     }
 
-    private class DealInfo implements Comparable
+    private static class DealInfo implements Comparable<DealInfo>
     {
         String sHand;
         int cnt;
@@ -208,9 +204,8 @@ public class DealTester extends BaseCommandLineApp
             cnt = c;
         }
 
-        public int compareTo(Object o)
+        public int compareTo(DealInfo d)
         {
-            DealInfo d = (DealInfo) o;
             return cnt - d.cnt;
         }
     }

--- a/code/wicket/pom.xml
+++ b/code/wicket/pom.xml
@@ -108,28 +108,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.wicketstuff</groupId>
-      <artifactId>wicketstuff-jslibraries</artifactId>
-      <version>${wicketstuff.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.wicketstuff</groupId>
-      <artifactId>wicketstuff-prototype</artifactId>
-      <version>${wicketstuff.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <version>${spring.version}</version>

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/BaseRequestCycleListener.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/BaseRequestCycleListener.java
@@ -32,13 +32,13 @@
  */
 package com.donohoedigital.wicket;
 
+import org.apache.wicket.core.request.handler.PageProvider;
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.protocol.http.PageExpiredException;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.IRequestCycleListener;
 import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.request.handler.PageProvider;
-import org.apache.wicket.request.handler.RenderPageRequestHandler;
 
 /**
  * Not sure if needed, but here to start

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/BaseWicketApplication.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/BaseWicketApplication.java
@@ -61,11 +61,6 @@ public abstract class BaseWicketApplication extends WebApplication implements Ap
         setRequestCycleProvider(new BaseRequestCycleProvider());
         getRequestCycleListeners().add(new BaseRequestCycleListener(this));
 
-        // TODO(WICKET): trying to turn off ?id on each page, but this isn't working yet
-        //               probably due to login form on each page.  Something for another day.
-        // turn off page versioning (a page can override isVersioned)
-        // getPageSettings().setVersionPagesByDefault(false);
-
         // initialize Spring
         getComponentInstantiationListeners().add(new SpringComponentInjector(this, applicationContext));
 

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/ExpirationUtils.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/ExpirationUtils.java
@@ -32,8 +32,8 @@
  */
 package com.donohoedigital.wicket;
 
+import org.apache.wicket.core.request.handler.RenderPageRequestHandler;
 import org.apache.wicket.request.cycle.RequestCycle;
-import org.apache.wicket.request.handler.RenderPageRequestHandler;
 
 import javax.servlet.http.Cookie;
 

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/annotations/DDMountScanner.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/annotations/DDMountScanner.java
@@ -34,16 +34,16 @@ package com.donohoedigital.wicket.annotations;
 
 import com.donohoedigital.config.MatchingResources;
 import org.apache.wicket.Page;
+import org.apache.wicket.core.request.mapper.MountedMapper;
 import org.apache.wicket.request.IRequestMapper;
 import org.apache.wicket.request.component.IRequestablePage;
-import org.apache.wicket.request.mapper.MountedMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 /**
- * This code was originally contributed to wicketstuff as the 'annotation'
+ * This code was originally contributed (by me) to wicketstuff as the 'annotation'
  * library.  When 1.5 was released, its functionality was significantly
  * reduced, removing strategies that DD Poker relied on.  When I upgraded
  * to 1.5, I had to pull this in so we could restore the mount strategies

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/annotations/MixedParamEncoder.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/annotations/MixedParamEncoder.java
@@ -32,14 +32,13 @@
  */
 package com.donohoedigital.wicket.annotations;
 
-import org.apache.wicket.request.IRequestParameters;
-import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.mapper.parameter.IPageParametersEncoder;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import java.lang.reflect.Array;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class MixedParamEncoder implements IPageParametersEncoder {
@@ -117,16 +116,16 @@ public class MixedParamEncoder implements IPageParametersEncoder {
     }
 
     @Override
-    public PageParameters decodePageParameters(Request request) {
+    public PageParameters decodePageParameters(Url url) {
         PageParameters params = new PageParameters();
 
         // add all url query parameters
-        IRequestParameters queryParameters = request.getQueryParameters();
-        queryParameters.getParameterNames().forEach(name ->
-                params.set(name, queryParameters.getParameterValue(name)));
+        List<Url.QueryParameter> queryParameters = url.getQueryParameters();
+        queryParameters.forEach(qp ->
+                params.set(qp.getName(), qp.getValue()));
 
         // add path components
-        String urlPath = request.getUrl().getPath();
+        String urlPath = url.getPath();
         if (urlPath.startsWith("/"))
         {
             urlPath = urlPath.substring(1);

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/AbstractJQueryBehavior.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/AbstractJQueryBehavior.java
@@ -34,28 +34,13 @@ package com.donohoedigital.wicket.behaviors;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.Behavior;
-import org.apache.wicket.markup.html.IHeaderContributor;
-import org.apache.wicket.markup.html.IHeaderResponse;
-import org.wicketstuff.jslibraries.JSLib;
-import org.wicketstuff.jslibraries.Library;
-import org.wicketstuff.jslibraries.VersionDescriptor;
 
 /**
  * @author Doug Donohoe
  */
-public abstract class AbstractPrototypeBehavior extends Behavior
+public abstract class AbstractJQueryBehavior extends Behavior
 {
     private static final long serialVersionUID = 42L;
-
-    /**
-     * Add prototype to header
-     */
-    @Override
-    public void renderHead(Component component, IHeaderResponse response)
-    {
-        IHeaderContributor header = JSLib.getHeaderContribution(VersionDescriptor.alwaysLatest(Library.PROTOTYPE));
-        header.renderHead(response);
-    }
 
     /**
      * Get javascript to render
@@ -67,7 +52,7 @@ public abstract class AbstractPrototypeBehavior extends Behavior
      */
     protected String proto(Component component)
     {
-        return "$('"+component.getMarkupId()+"')";
+        return "$('#" + component.getMarkupId() + "')";
     }
 
     /**

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/AbstractOnClickBehavior.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/AbstractOnClickBehavior.java
@@ -38,11 +38,11 @@ import org.apache.wicket.markup.ComponentTag;
 /**
  * @author Doug Donohoe
  */
-public abstract class AbstractOnClickBehavior extends AbstractPrototypeBehavior
+public abstract class AbstractOnClickBehavior extends AbstractJQueryBehavior
 {
     private static final long serialVersionUID = 42L;
 
-    private boolean noop;
+    private final boolean noop;
 
     /**
      * Construct.

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/DefaultFocus.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/DefaultFocus.java
@@ -33,12 +33,13 @@
 package com.donohoedigital.wicket.behaviors;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.markup.html.IHeaderResponse;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnLoadHeaderItem;
 
 /**
  * @author Doug Donohoe
  */
-public class DefaultFocus extends AbstractPrototypeBehavior
+public class DefaultFocus extends AbstractJQueryBehavior
 {
     private static final long serialVersionUID = 42L;
 
@@ -55,7 +56,7 @@ public class DefaultFocus extends AbstractPrototypeBehavior
     public void renderHead(Component component, IHeaderResponse iHeaderResponse)
     {
         super.renderHead(component, iHeaderResponse);
-        iHeaderResponse.renderOnLoadJavaScript(getJavascript().toString());
+        iHeaderResponse.render(OnLoadHeaderItem.forScript(getJavascript()));
     }
 
     /**

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/HideShowSwapLabel.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/behaviors/HideShowSwapLabel.java
@@ -64,8 +64,8 @@ public class HideShowSwapLabel extends HideShow
     {
         StringBuilder sb = super.getJavascript();
 
-        sb.append(proto(label)).append(".update(");
-        sb.append(proto(hideShow)).append(".visible() ? ");
+        sb.append(proto(label)).append(".text(");
+        sb.append(proto(hideShow)).append(".is(':visible') ? ");
         sb.append(quote(labelWhenVisible));
         sb.append(" : ");
         sb.append(quote(labelWhenHidden));

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/common/PageableServiceProvider.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/common/PageableServiceProvider.java
@@ -59,7 +59,7 @@ public abstract class PageableServiceProvider<T> implements IDataProvider<T>
     /**
      * Fetch 'pagesize' rows starting at index 'first' and return as an Iterator
      */
-    public abstract Iterator<T> iterator(int first, int pagesize);
+    public abstract Iterator<T> iterator(long first, long pagesize);
 
     /**
      * Implementers should implement logic to fetch the total count of all
@@ -74,7 +74,7 @@ public abstract class PageableServiceProvider<T> implements IDataProvider<T>
      *
      * @return total count of all items represented by this provider
      */
-    public int size()
+    public long size()
     {
         if (size == null)
         {
@@ -114,7 +114,7 @@ public abstract class PageableServiceProvider<T> implements IDataProvider<T>
         int n = WicketUtils.getAsInt(params, name, -1);
         if (n == -1)
         {
-            n = size();
+            n = (int) size();
             params.set(name, n);
         }
         else
@@ -138,7 +138,7 @@ public abstract class PageableServiceProvider<T> implements IDataProvider<T>
     @SuppressWarnings("unchecked")
     public IModel<T> model(T object)
     {
-        return new CompoundPropertyModel<T>((IModel<T>) new EntityModel<T>(object));
+        return new CompoundPropertyModel<>((IModel<T>) new EntityModel<>(object));
     }
 
     /**

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/components/CountDataView.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/components/CountDataView.java
@@ -54,11 +54,11 @@ public abstract class CountDataView<T> extends DataView<T> implements CountPagea
 
     public int getTotalItemCount()
     {
-        return internalGetDataProvider().size();
+        return (int) internalGetDataProvider().size();
     }
 
     public int getPageSize()
     {
-        return getItemsPerPage();
+        return (int) getItemsPerPage();
     }
 }

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/converters/GroupingIntegerConverter.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/converters/GroupingIntegerConverter.java
@@ -44,7 +44,7 @@ import java.util.Locale;
  * Time: 2:58:51 PM
  * To change this template use File | Settings | File Templates.
  */
-public class GroupingIntegerConverter extends AbstractIntegerConverter
+public class GroupingIntegerConverter extends AbstractIntegerConverter<Integer>
 {
     private static final long serialVersionUID = 42L;
 

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/converters/PercentConverter.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/converters/PercentConverter.java
@@ -47,11 +47,11 @@ import java.util.Locale;
  * Time: 2:58:51 PM
  * To change this template use File | Settings | File Templates.
  */
-public class PercentConverter extends AbstractDecimalConverter
+public class PercentConverter extends AbstractDecimalConverter<Double>
 {
 	private static final long serialVersionUID = 42L;
 
-    private int fractionDigits;
+    private final int fractionDigits;
 
     public PercentConverter(int fractionDigits)
     {

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/converters/PlaceConverter.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/converters/PlaceConverter.java
@@ -32,9 +32,9 @@
  */
 package com.donohoedigital.wicket.converters;
 
-import com.donohoedigital.config.*;
+import com.donohoedigital.config.PropertyConfig;
 
-import java.util.*;
+import java.util.Locale;
 
 /**
  * Created by IntelliJ IDEA.
@@ -54,7 +54,7 @@ public class PlaceConverter extends GroupingIntegerConverter
     public static final PlaceConverter INSTANCE = new PlaceConverter();
 
     @Override
-    public String convertToString(Object value, Locale locale)
+    public String convertToString(Integer value, Locale locale)
     {
         return PropertyConfig.getPlace((Integer)value, super.convertToString(value, locale));
     }

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
@@ -33,9 +33,9 @@
 package com.donohoedigital.wicket.models;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.IClusterable;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.io.IClusterable;
 
 import java.util.ArrayList;
 

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/panels/BoxPagingNavigator.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/panels/BoxPagingNavigator.java
@@ -81,7 +81,7 @@ public class BoxPagingNavigator extends VoidPanel
         int current = getCurrentPage();
 
         // get counts
-        int pageCount = pageable.getPageCount();
+        int pageCount = (int) pageable.getPageCount();
         int totalItemCount = pageable.getTotalItemCount();
         int rowsPerPage = pageable.getPageSize();
 
@@ -125,7 +125,7 @@ public class BoxPagingNavigator extends VoidPanel
         if (showAnchors) visible += 4; // 2 for anchors, 2 for '...'
 
         int current = getCurrentPage();
-        int end = pageable.getPageCount();
+        int end = (int) pageable.getPageCount();
         int begin = 1;
 
         int first = validatePageNumber(current - padding);
@@ -212,7 +212,7 @@ public class BoxPagingNavigator extends VoidPanel
      */
     protected int getCurrentPage()
     {
-        return pageable.getCurrentPage() + 1;
+        return (int) pageable.getCurrentPage() + 1;
     }
 
     /**
@@ -220,7 +220,7 @@ public class BoxPagingNavigator extends VoidPanel
      */
     private int validatePageNumber(int pg)
     {
-        int count = pageable.getPageCount();
+        int count = (int) pageable.getPageCount();
         if (pg < 1 || count <= 1)
         {
             pg = 1;


### PR DESCRIPTION
Upgrade Wicket 1.5 to Wicket 6 line.  This was a bit easier than 1.4 to 1.5.  Biggest issue was migrating to JQuery from prototype (as the former is now the default in Wicket).  Also had to deal with use of `long` in `IDataProvider` (we just cast back to `int`).