### PR TITLE
Java 17 upgrade; fix deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/Dockerfile.pokerweb.docker
+++ b/Dockerfile.pokerweb.docker
@@ -30,16 +30,16 @@
 # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
 # Use the CentOS 7 base image
-FROM centos:7
+FROM centos:8
 
 # Update mirror list
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-# Install necessary dependencies including Java 11
-RUN yum -y update && yum -y remove java && yum install -y \
-       java-11-openjdk \
-       java-11-openjdk-devel \
+# Install necessary dependencies including Java 17
+RUN yum -y update && yum -y remove java && yum install -y --setopt=skip_missing_names_on_install=False \
+       java-17-openjdk \
+       java-17-openjdk-devel \
        wget
 
 # Download and install Tomcat 8.5.100

--- a/Dockerfile.ubuntu.docker
+++ b/Dockerfile.ubuntu.docker
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
     x11-apps \
     iputils-ping nmap telnet \
     git vim tree \
-    openjdk-11-jdk maven
+    openjdk-17-jdk maven
 
 # Start bash
 CMD ["/bin/bash"]

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -29,7 +29,7 @@ Feel free to submit a PR with any changes to these docs that would help Linux or
 
 Required software:
 
-* Java 11 - [See Adoptium](https://adoptium.net/temurin/releases/?os=any&package=jdk&version=11)
+* Java 17 - [See Adoptium](https://adoptium.net/temurin/releases/?os=any&package=jdk&version=17)
 * Maven 3 - [See Apache Maven](https://maven.apache.org/install.html)
 * Docker (optional, but useful to run some things) - [See Docker](https://docs.docker.com/engine/install/)
 
@@ -51,7 +51,7 @@ source ddpoker.rc
 [Brew](https://brew.sh/) is useful to install Java and Maven:
 
 ```shell
-brew install temurin@11 maven
+brew install temurin@17 maven
 ```
 
 ## Compile Code
@@ -90,9 +90,9 @@ the `code/pom.xml` file and prompt you to load it:
 
 <img src="images/intellij-maven.png" alt="IntelliJ Maven" width="400px">
 
-**NOTE**:  You will probably need to edit the Project Structure to tell IntelliJ to use Java 11.
+**NOTE**:  You will probably need to edit the Project Structure to tell IntelliJ to use Java 17.
 Go to _File -> Project Structure... -> Project Settings -> Project -> SDK_ and
-set to Java 11 (you may need to add it (_+ Add SDK_) as a new SDK if not already there).
+set to Java 17 (you may need to add it (_+ Add SDK_) as a new SDK if not already there).
 
 ## Server Dependencies
 
@@ -167,7 +167,7 @@ of DD Poker was written from 2004-2007, with sporadic updates after that.  The o
 JDK was 1.5.
 
 Most of our dependencies (Swing, Hibernate, Wicket, log4j, etc.) have been updated to the latest versions
-that work with Java 8 (and soon, Java 11).
+that work with Java 8 (and soon, Java 17).
 
 That said, amazingly, it all still seems to work.  If anybody wants to start upgrading dependencies,
 we are happy to take PRs.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ reading all the [developer documentation](README-DEV.md) or worrying
 about servers and databases, follow these steps:
 
 1. Clone this repo
-2. Install [Java 11](https://adoptium.net/temurin/releases/?os=any&package=jdk&version=11)
+2. Install [Java 17](https://adoptium.net/temurin/releases/?os=any&package=jdk&version=17)
    and [Maven 3](https://maven.apache.org/install.html)
 3. Run these commands in the `ddpoker` directory:
 

--- a/code/common/src/main/java/com/donohoedigital/comms/Version.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/Version.java
@@ -38,7 +38,8 @@
 
 package com.donohoedigital.comms;
 
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.ErrorCodes;
 
 /**
  * @author donohoe
@@ -157,6 +158,11 @@ public class Version implements DataMarshal
     public int getMajor()
     {
         return nMajor_;
+    }
+
+    public String getMajorAsString()
+    {
+        return String.valueOf(nMajor_);
     }
 
     public int getMinor()

--- a/code/common/src/main/java/com/donohoedigital/config/Perf.java
+++ b/code/common/src/main/java/com/donohoedigital/config/Perf.java
@@ -40,7 +40,9 @@ package com.donohoedigital.config;
 
 //import com.jprofiler.agent.*;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  *
@@ -148,27 +150,6 @@ public class Perf
             }
             count.num++;
             System.out.println("MEMORY: construct " + sName + " count now " + count.num);
-        }
-    }
-
-    /**
-     * Note finalization of object
-     */
-    public static void finalize(Object o, String sDesc)
-    {
-        if (!MEM || !ON) return;
-        synchronized(count_)
-        {
-            String sName = o.getClass().getName();
-            if (sDesc != null) sName += "-"+sDesc;
-            Counter count = (Counter) count_.get(sName);
-            if (count == null) {
-                System.out.println("MEMORY: WARNING ####### - finalize without construct: " + sName);
-                return;
-            }
-            count.num--;
-            if (count.num == 0) count_.remove(sName);
-            System.out.println("MEMORY: finalize " + sName + " count now " + count.num);
         }
     }
 

--- a/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
+++ b/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
@@ -8,6 +8,7 @@ public class VersionTest extends TestCase {
         // major/minor
         Version v = new Version("3.1");
         assertEquals(3, v.getMajor());
+        assertEquals("3", v.getMajorAsString());
         assertEquals(1, v.getMinor());
 
         // old style patch parsing

--- a/code/db/src/main/java/com/donohoedigital/db/Database.java
+++ b/code/db/src/main/java/com/donohoedigital/db/Database.java
@@ -32,10 +32,12 @@
  */
 package com.donohoedigital.db;
 
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
 
-import java.sql.*;
-import java.text.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.text.MessageFormat;
 
 /**
  * Represents a logical database.
@@ -224,7 +226,7 @@ public class Database
         // Force the driver to load.
         try
         {
-            Class.forName(getDriverClassName()).newInstance();
+            Class.forName(getDriverClassName()).getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GamePiece.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GamePiece.java
@@ -39,10 +39,10 @@
 package com.donohoedigital.games.config;
 
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.config.PropertyConfig;
 
-import java.util.*;
+import java.util.ArrayList;
 
 /**
  *
@@ -68,7 +68,7 @@ public abstract class GamePiece implements Comparable
      */
     public GamePiece(int nType, GamePlayer player, String sName)
     {
-        nType_ = new Integer(nType);
+        nType_ = nType;
         player_ = player;
         sName_ = sName;
         addToken(createToken(false));

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/MapPoint.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/MapPoint.java
@@ -38,11 +38,11 @@
 
 package com.donohoedigital.games.config;
 
-import com.donohoedigital.base.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.config.*;
-
-import org.jdom2.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.config.XMLConfigFileLoader;
+import com.donohoedigital.config.XMLWriter;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
 
 /**
  *
@@ -54,7 +54,7 @@ public class MapPoint
     
     public int x_ = 0;
     public int y_ = 0;
-    protected Integer NO_ANGLE = new Integer(0);
+    protected Integer NO_ANGLE = 0;
     protected Integer angle_ = NO_ANGLE; 
     
     
@@ -84,7 +84,7 @@ public class MapPoint
     public MapPoint(int x, int y, int angle, String sType) {
         x_ = x;
         y_ = y;
-        angle_ = new Integer(angle);
+        angle_ = angle;
         sType_ = sType;
     }
     
@@ -94,8 +94,8 @@ public class MapPoint
     public MapPoint(Element point, Namespace ns, String sAttrErrorDesc)
                 throws ApplicationError
     {
-        x_ = XMLConfigFileLoader.getIntegerAttributeValue(point, "x", true, sAttrErrorDesc).intValue();
-        y_ = XMLConfigFileLoader.getIntegerAttributeValue(point, "y", true, sAttrErrorDesc).intValue();
+        x_ = XMLConfigFileLoader.getIntegerAttributeValue(point, "x", true, sAttrErrorDesc);
+        y_ = XMLConfigFileLoader.getIntegerAttributeValue(point, "y", true, sAttrErrorDesc);
         angle_ = XMLConfigFileLoader.getIntegerAttributeValue(point, "angle", false, sAttrErrorDesc, NO_ANGLE);
         sType_ = XMLConfigFileLoader.getStringAttributeValue(point, "type", false, sAttrErrorDesc, NO_TYPE);
     }
@@ -161,7 +161,7 @@ public class MapPoint
      */
     public void setAngle(int nAngle)
     {
-        angle_ = new Integer(nAngle);
+        angle_ = nAngle;
     }
     
     /**
@@ -188,8 +188,8 @@ public class MapPoint
     {
         writer.printIndent(nIndent);
         writer.printElementStartOpen("point");
-        writer.printAttribute("x", new Integer(x_));
-        writer.printAttribute("y", new Integer(y_));
+        writer.printAttribute("x", x_);
+        writer.printAttribute("y", y_);
         if (angle_ != null && !angle_.equals(NO_ANGLE)) writer.printAttribute("angle", angle_);
         if (sType_ != null && !sType_.equals(NO_TYPE)) writer.printAttribute("type", sType_);
         writer.printElementEndLine();

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/BasePhase.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/BasePhase.java
@@ -38,11 +38,13 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.comms.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.comms.NameValueToken;
+import com.donohoedigital.config.Perf;
 import com.donohoedigital.games.config.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.config.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  *
@@ -64,12 +66,7 @@ public abstract class BasePhase implements Phase
     public BasePhase() {
         if (false) Perf.construct(this, null);
     }
-    
-    @Override
-    protected void finalize() {
-        if (false) Perf.finalize(this, null);
-    }
-    
+
     /**
      * Init phase, storing engine and gamephase
      */

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceBox.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceBox.java
@@ -38,19 +38,16 @@
 
 package com.donohoedigital.games.engine;
 
+import com.donohoedigital.config.ImageConfig;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.GamePlayer;
 import com.donohoedigital.gui.*;
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.games.config.*;
 
-import java.util.*;
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
-import javax.swing.event.*;
-import javax.swing.border.*;
-import java.awt.geom.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
 /**
  *
@@ -155,7 +152,7 @@ public class DiceBox extends DDPanel implements ActionListener
      */
     public int getMod()
     {
-        return nMod_.intValue();
+        return nMod_;
     }
     
     /**
@@ -195,31 +192,31 @@ public class DiceBox extends DDPanel implements ActionListener
         die1_ = (die1 != null) ? die1 : DiceRoller.rollDie(6);
         die2_ = (die2 != null) ? die2 : DiceRoller.rollDie(6);
         
-        nSum_ = die1_.intValue() + die2_.intValue();
+        nSum_ = die1_ + die2_;
         int nTotal = nSum_;
         
         if (nMod_ != null)
         {
-            nTotal = nSum_ + nMod_.intValue();
+            nTotal = nSum_ + nMod_;
             result_.setText(PropertyConfig.getMessage("msg.dicebox.result.mod",
-                                                new Integer(nSum_),
+                                                nSum_,
                                                 nMod_,
-                                                new Integer(nTotal)));
+                                                nTotal));
         }
         else
         {
             result_.setText(PropertyConfig.getMessage("msg.dicebox.result",
-                                                new Integer(nSum_)));
+                                                nSum_));
         }
         
-        DieImage img1 = new DieImage(die1_.intValue(), nDieSize_, nDieSize_);
-        DieImage img2 = new DieImage(die2_.intValue(), nDieSize_, nDieSize_);
+        DieImage img1 = new DieImage(die1_, nDieSize_, nDieSize_);
+        DieImage img2 = new DieImage(die2_, nDieSize_, nDieSize_);
         
         int INDENT = 10;
         
         int yRange = (box_.getHeight() - img1.getHeight()) - (2*INDENT);
-        int y1 = DiceRoller.rollDie(yRange).intValue() + INDENT - 1;
-        int y2 = DiceRoller.rollDie(yRange).intValue() + INDENT - 1;
+        int y1 = DiceRoller.rollDie(yRange) + INDENT - 1;
+        int y2 = DiceRoller.rollDie(yRange) + INDENT - 1;
         
         int xRange = (box_.getWidth() - img2.getWidth()) - (2 * INDENT);
         
@@ -228,8 +225,8 @@ public class DiceBox extends DDPanel implements ActionListener
         int x2 = 0;
         while (!bOkay)
         {
-            x1 = DiceRoller.rollDie(xRange).intValue() + INDENT - 1;
-            x2 = DiceRoller.rollDie(xRange).intValue() + INDENT - 1;
+            x1 = DiceRoller.rollDie(xRange) + INDENT - 1;
+            x2 = DiceRoller.rollDie(xRange) + INDENT - 1;
             
             // if x's are more than a width apart, its okay
             if (Math.abs(x1 - x2) > (img1.getWidth()+1))

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
@@ -38,7 +38,8 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.MersenneTwisterFast;
+import com.donohoedigital.base.Utils;
 
 /**
  *
@@ -80,8 +81,7 @@ public class DiceRoller {
      */
     public static Integer rollDie(int nSides)
     {
-        int nNum = rollDieInt(nSides);
-        return new Integer(nNum);
+        return rollDieInt(nSides);
     }
     
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DieRoll6x2.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DieRoll6x2.java
@@ -38,7 +38,9 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.comms.*;
+import com.donohoedigital.comms.DataCoder;
+import com.donohoedigital.comms.DataMarshal;
+import com.donohoedigital.comms.MsgState;
 
 /**
  *
@@ -55,7 +57,7 @@ public class DieRoll6x2 implements DataMarshal
     {
         this.nFirst=DiceRoller.rollDie6();
         this.nSecond=DiceRoller.rollDie6();
-        nSum = nFirst.intValue() + nSecond.intValue();
+        nSum = nFirst + nSecond;
     }
 
     public String toString()
@@ -70,19 +72,19 @@ public class DieRoll6x2 implements DataMarshal
     
     public int getFirst()
     {
-        return nFirst.intValue();
+        return nFirst;
     }
     
     public int getSecond()
     {
-        return nSecond.intValue();
+        return nSecond;
     }
     
     public void demarshal(MsgState state, String sData)
     {
-        nFirst = new Integer(Integer.parseInt(sData.substring(0,1)));
-        nSecond = new Integer(Integer.parseInt(sData.substring(1)));
-        nSum = nFirst.intValue() + nSecond.intValue();
+        nFirst = Integer.parseInt(sData.substring(0,1));
+        nSecond = Integer.parseInt(sData.substring(1));
+        nSum = nFirst + nSecond;
     }
     
     public String marshal(MsgState state)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DisplayTimedMessage.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DisplayTimedMessage.java
@@ -32,10 +32,12 @@
  */
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.gui.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.GameButton;
+import com.donohoedigital.gui.DDLabel;
+import com.donohoedigital.gui.GuiManager;
+import com.donohoedigital.gui.GuiUtils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -141,7 +143,7 @@ public class DisplayTimedMessage extends DisplayMessage implements CancelablePha
         GuiUtils.invoke(new Runnable() {
             public void run() {
                 String sSeconds = PropertyConfig.getMessage(nSecondsLeft_ == 1 ? "msg.seconds.singular" : "msg.seconds.plural",
-                                                            new Integer(nSecondsLeft_));
+                                                            nSecondsLeft_);
 
                 timer_.setText(PropertyConfig.getMessage("msg.dialog.timer", sSeconds));
             }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePieceComponent.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePieceComponent.java
@@ -38,7 +38,7 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.gui.*;
+import com.donohoedigital.gui.ImageComponent;
 
 import javax.swing.*;
 import java.awt.*;
@@ -90,7 +90,7 @@ public class EngineGamePieceComponent extends JComponent
     
     public void setQuantityToDisplay(int n)
     {
-        nQuantityToDisplay_ = new Integer(n);
+        nQuantityToDisplay_ = n;
     }
     
     public void setEngineGamePiece(EngineGamePiece piece)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -38,15 +38,22 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.AudioConfig;
+import com.donohoedigital.config.AudioPlayer;
+import com.donohoedigital.config.ImageConfig;
+import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.config.*;
-import com.donohoedigital.gui.*;
+import com.donohoedigital.gui.DDButton;
+import com.donohoedigital.gui.DDLabel;
+import com.donohoedigital.gui.GuiUtils;
 
 import javax.swing.*;
-import javax.swing.text.*;
+import javax.swing.text.JTextComponent;
 import java.awt.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -292,7 +299,7 @@ public class EngineUtils
         }
         if (nTimeoutSeconds > 0)
         {
-            params.setInteger(DisplayTimedMessage.PARAM_SECONDS, new Integer(nTimeoutSeconds));
+            params.setInteger(DisplayTimedMessage.PARAM_SECONDS, nTimeoutSeconds);
         }
         Phase confirm = context.processPhaseNow(sPhase, params);
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
@@ -32,18 +32,28 @@
  */
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.ErrorCodes;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.config.*;
-import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.gui.DDWindow;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
-import javax.swing.event.*;
+import javax.swing.event.InternalFrameAdapter;
+import javax.swing.event.InternalFrameEvent;
 import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Stack;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 
 /**
@@ -964,7 +974,7 @@ public class GameContext
                                                "Make sure class exists");
                 }
 
-                phase = cClass.newInstance();
+                phase = cClass.getDeclaredConstructor().newInstance();
 
                 // otherwise init
                 phase.init(engine_, this, gamephase);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GamePlayerLoopPhase.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GamePlayerLoopPhase.java
@@ -38,8 +38,11 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.games.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.games.config.GamePhase;
+import com.donohoedigital.games.config.GameState;
+import com.donohoedigital.games.config.GameStateEntry;
 
 /**
  *
@@ -241,7 +244,7 @@ public class GamePlayerLoopPhase extends BasePhase
     public GameStateEntry addGameStateEntry(GameState state)
     {
         GameStateEntry entry = super._addGameStateEntry(state);
-        entry.addNameValueToken(PARAM_STARTING_INDEX, new Integer(nPlayerIndex_));
+        entry.addNameValueToken(PARAM_STARTING_INDEX, nPlayerIndex_);
         entry.addNameValueToken(PARAM_SAVE_LOOP_PHASE, context_.getCurrentPhase().getGamePhase().getName());
         return entry;
     }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
@@ -38,20 +38,25 @@
 
 package com.donohoedigital.games.engine;
 
-import com.donohoedigital.base.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.Perf;
 import com.donohoedigital.games.config.*;
-import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.gui.GuiUtils;
+import com.donohoedigital.gui.ImageComponent;
+import com.donohoedigital.gui.TextUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
-import java.awt.geom.*;
-import java.util.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.GeneralPath;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.prefs.*;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 /**
  *
@@ -85,13 +90,7 @@ public class Gameboard extends ImageComponent implements Scrollable,
     
     protected boolean bUseImage_ = true;
     protected GameEngine engine_;
-    
-    @SuppressWarnings({"FinalizeDoesntCallSuperFinalize"})
-    @Override
-    protected void finalize() {
-        Perf.finalize(this, null);
-    }
-    
+
     public void cleanup()
     {
         tlisteners_.clear();

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
@@ -38,17 +38,11 @@
 
 package com.donohoedigital.games.server;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.comms.*;
-import com.donohoedigital.server.*;
-import com.donohoedigital.games.comms.*;
-import com.donohoedigital.games.config.*;
+import com.donohoedigital.comms.DMArrayList;
+import com.donohoedigital.config.ConfigUtils;
+import com.donohoedigital.games.comms.EngineMessage;
 
 import java.io.*;
-import java.util.*;
-import java.text.SimpleDateFormat;
 
 /**
  *
@@ -105,8 +99,8 @@ public class PlayerQueue extends ServerDataFile
         
         dir_ = dir;
         sFileNum_ = sFileNum;
-        nPlayerID_ = new Integer(nPlayerID);
-        file_ = getPlayerQueueFile(dir_, sFileNum_, nPlayerID_.intValue(), false);
+        nPlayerID_ = nPlayerID;
+        file_ = getPlayerQueueFile(dir_, sFileNum_, nPlayerID_, false);
         
         if (bNew)
         {
@@ -126,7 +120,7 @@ public class PlayerQueue extends ServerDataFile
      */
     public int getPlayerID()
     {
-        return nPlayerID_.intValue();
+        return nPlayerID_;
     }
     
     /**

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDComboBoxUI.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDComboBoxUI.java
@@ -39,11 +39,14 @@
 package com.donohoedigital.gui;
 
 import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
-import javax.swing.plaf.metal.*;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicComboBoxUI;
+import javax.swing.plaf.basic.BasicComboPopup;
+import javax.swing.plaf.basic.ComboPopup;
+import javax.swing.plaf.metal.MetalComboBoxEditor;
 import java.awt.*;
-import java.beans.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 /**
  * Copied MetalComboBoxUI and made tweaks - for
@@ -113,15 +116,6 @@ public class DDComboBoxUI extends BasicComboBoxUI
         }
     }
 
-    /**
-     * As of Java 2 platform v1.4 this method is no longer used. Do not call or
-     * override. All the functionality of this method is in the
-     * MetalPropertyChangeListener.
-     *
-     * @deprecated As of Java 2 platform v1.4.
-     */
-    protected void editablePropertyChanged( PropertyChangeEvent e ) { }
-
     protected LayoutManager createLayoutManager() {
         return new MetalComboBoxLayoutManager();
     }
@@ -159,24 +153,12 @@ public class DDComboBoxUI extends BasicComboBoxUI
         }
     }
 
-    /**
-     * As of Java 2 platform v1.4 this method is no
-     * longer used.
-     *
-     * @deprecated As of Java 2 platform v1.4.
-     */
-    protected void removeListeners() {
-        if ( propertyChangeListener != null ) {
-            comboBox.removePropertyChangeListener( propertyChangeListener );
-        }
-    }
-
     public Dimension getMinimumSize( JComponent c ) {
         if ( !isMinimumSizeDirty ) {
             return new Dimension( cachedMinimumSize );
         }
 
-        Dimension size = null;
+        Dimension size;
 
         if ( !comboBox.isEditable() &&
              arrowButton != null &&

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDPagingTable.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDPagingTable.java
@@ -32,11 +32,12 @@
  */
 package com.donohoedigital.gui;
 
-import com.donohoedigital.config.*;
+import com.donohoedigital.config.PropertyConfig;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class DDPagingTable extends DDPanel implements ActionListener
 {
@@ -163,9 +164,9 @@ public class DDPagingTable extends DDPanel implements ActionListener
             }
 
             Object[] params = new Object[3];
-            params[0] = new Integer(offset_ + 1);
-            params[1] = new Integer(offset_ + model.getRowCount());
-            params[2] = new Integer(totalCount);
+            params[0] = offset_ + 1;
+            params[1] = offset_ + model.getRowCount();
+            params[2] = totalCount;
             String text = PropertyConfig.getMessage(("msg." + pagingMsg_ + ".paging"), params);
             label_.setText(text);
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
@@ -32,27 +32,40 @@
  */
 package com.donohoedigital.gui;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.StylesConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.metal.*;
-import javax.swing.text.*;
+import javax.swing.border.AbstractBorder;
+import javax.swing.border.Border;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import javax.swing.plaf.metal.MetalTheme;
+import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.JTextComponent;
 import java.awt.*;
-import java.awt.datatransfer.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.*;
-import java.awt.geom.*;
-import java.awt.image.*;
-import java.beans.*;
-import java.io.*;
-import java.lang.reflect.*;
-import java.util.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.StringTokenizer;
 
 public class GuiUtils
 {
@@ -64,13 +77,13 @@ public class GuiUtils
     public static final Color TRANSPARENT = new Color(255, 255, 255, 0);
     static final JTextComponent.KeyBinding[] MAC_CUT_COPY_PASTE = {
             new JTextComponent.KeyBinding(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_MASK),
+                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_DOWN_MASK),
                     DefaultEditorKit.copyAction),
             new JTextComponent.KeyBinding(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_MASK),
+                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_DOWN_MASK),
                     DefaultEditorKit.pasteAction),
             new JTextComponent.KeyBinding(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_MASK),
+                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_DOWN_MASK),
                     DefaultEditorKit.cutAction),
     };
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
@@ -38,15 +38,23 @@
 
 package com.donohoedigital.gui;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.ErrorCodes;
+import com.donohoedigital.config.ImageConfig;
+import com.donohoedigital.config.ImageDef;
+import com.donohoedigital.config.PropertyConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
-import java.awt.image.*;
-import java.util.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.image.BufferedImage;
+import java.awt.image.FilteredImageSource;
+import java.awt.image.ImageProducer;
+import java.awt.image.RGBImageFilter;
+import java.util.HashMap;
 
 /**
  * @author Doug Donohoe
@@ -482,7 +490,7 @@ public class ImageComponent extends JComponent implements Icon
                             long free = Runtime.getRuntime().freeMemory();
                             if (free < estimate)
                             {
-                                logger.warn(PropertyConfig.getMessage("msg.needmem.debug", new Integer(estimate), new Long(free)));
+                                logger.warn(PropertyConfig.getMessage("msg.needmem.debug", estimate, free));
                             }
                             buffer_ = ImageDef.createBufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_RGB);
                             //LoggingConfig.debugPrintMemory("After new buffer");

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionInteger.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionInteger.java
@@ -38,11 +38,12 @@
 
 package com.donohoedigital.gui;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.config.PropertyConfig;
 
-import javax.swing.event.*;
 import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.*;
 
 /**
@@ -89,7 +90,7 @@ public class OptionInteger extends DDOption implements ChangeListener
         }
         else
         {
-            nDefault_ = new Integer(PropertyConfig.getRequiredIntegerProperty(getDefaultKey()));
+            nDefault_ = PropertyConfig.getRequiredIntegerProperty(getDefaultKey());
         }
         
         int nStep = PropertyConfig.getIntegerProperty("option." + sName_ + ".step", 1);
@@ -102,8 +103,8 @@ public class OptionInteger extends DDOption implements ChangeListener
         spinner_ = new DDNumberSpinner(nMin, nMax, nStep, GuiManager.DEFAULT, STYLE);
         Dimension pref = spinner_.getPreferredSize(); // tweak size
         if (nWidth > 0) spinner_.setPreferredSize(new Dimension(nWidth,pref.height-4));
-        spinner_.setValue(nDefaultOverride != null ? nDefaultOverride.intValue() :
-                                prefs_.getInt(sName_, nDefault_.intValue()));
+        spinner_.setValue(nDefaultOverride != null ? nDefaultOverride :
+                                prefs_.getInt(sName_, nDefault_));
         spinner_.setBigStep(nBigStep);
         spinner_.addChangeListener(this);
         spinner_.addMouseListener(this);
@@ -231,7 +232,7 @@ public class OptionInteger extends DDOption implements ChangeListener
      */
     public void saveToMap()
     {
-        map_.setInteger(sName_, new Integer(spinner_.getValue()));
+        map_.setInteger(sName_, spinner_.getValue());
     }
     
     /** reset to default value (triggers stateChanged())
@@ -239,12 +240,12 @@ public class OptionInteger extends DDOption implements ChangeListener
      */
     public void resetToDefault()
     {
-        spinner_.setValue(nDefault_.intValue());
+        spinner_.setValue(nDefault_);
     }
 
     public void resetToPrefs()
     {
-        spinner_.setValue(prefs_.getInt(sName_, nDefault_.intValue()));
+        spinner_.setValue(prefs_.getInt(sName_, nDefault_));
     }
 
     /**
@@ -252,7 +253,7 @@ public class OptionInteger extends DDOption implements ChangeListener
      */
     public void resetToMap()
     {
-        spinner_.setValue(map_.getInteger(sName_, nDefault_.intValue()));
+        spinner_.setValue(map_.getInteger(sName_, nDefault_));
     }
     
 }

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionRadio.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionRadio.java
@@ -38,13 +38,15 @@
 
 package com.donohoedigital.gui;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.config.PropertyConfig;
 
 import javax.swing.*;
-import javax.swing.event.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 /**
  *
@@ -161,7 +163,7 @@ public class OptionRadio extends DDOption implements ActionListener, ChangeListe
     {
         if (radio_.isSelected())
         {
-            map_.setInteger(sOptionName_, new Integer(nValue_));
+            map_.setInteger(sOptionName_, nValue_);
         }
     }
     

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionSlider.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionSlider.java
@@ -38,11 +38,12 @@
 
 package com.donohoedigital.gui;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.config.PropertyConfig;
 
-import javax.swing.event.*;
 import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.*;
 
 /**
@@ -71,7 +72,7 @@ public class OptionSlider extends DDOption implements ChangeListener
         }
         else
         {
-            nDefault_ = new Integer(PropertyConfig.getRequiredIntegerProperty(getDefaultKey()));
+            nDefault_ = PropertyConfig.getRequiredIntegerProperty(getDefaultKey());
         }
         
         int nStep = PropertyConfig.getIntegerProperty("option." + sName_ + ".step", 10);
@@ -161,7 +162,7 @@ public class OptionSlider extends DDOption implements ChangeListener
      */
     public void saveToMap()
     {
-        map_.setInteger(sName_, new Integer(slider_.getValue()));
+        map_.setInteger(sName_, slider_.getValue());
     }
     
     /** reset to default value

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUp.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUp.java
@@ -38,13 +38,16 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.config.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.engine.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.ChainPhase;
+import com.donohoedigital.games.engine.EngineUtils;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 /**
  *
@@ -81,7 +84,7 @@ public class ColorUp extends ChainPhase
             if (!TESTING(PokerConstants.TESTING_AUTOPILOT) && !game_.isOnlineGame())
             {
                 EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.colorup",
-                            new Integer(table_.getMinChip()), new Integer(table_.getNextMinChip())),
+                            table_.getMinChip(), table_.getNextMinChip()),
                             "msg.windowtitle.colorup", "colorup", "colorup");
             }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GameInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GameInfoDialog.java
@@ -38,19 +38,24 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.db.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.online.*;
-import com.donohoedigital.games.poker.model.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.db.BindArray;
+import com.donohoedigital.games.config.GamePhase;
+import com.donohoedigital.games.engine.DialogPhase;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.engine.OptionMenu;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import com.donohoedigital.games.poker.online.Lobby;
 import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;
-import java.sql.*;
+import java.sql.Types;
 
 /**
  *
@@ -78,7 +83,7 @@ public class GameInfoDialog extends DialogPhase
         if (!game_.isClockMode() && !bLobbyMode_) profile_.setPrizePool(game_.getPrizePool(), true); // update to current
         ic_.setScaleToFit(false);
         ic_.setIconWidth(GamePrefsPanel.ICWIDTH);
-        ic_.setIconHeight(new Integer(GamePrefsPanel.ICHEIGHT.intValue() + 6)); // need to be slightly higher for focus
+        ic_.setIconHeight(GamePrefsPanel.ICHEIGHT + 6); // need to be slightly higher for focus
         super.init(engine, context, gamephase);
     }
     
@@ -212,7 +217,7 @@ public class GameInfoDialog extends DialogPhase
             setPreferredSize(new Dimension(650, 363));
 
             BindArray bindArray = new BindArray();
-            bindArray.addValue(Types.INTEGER, new Integer(PokerDatabase.storeTournament(game_)));
+            bindArray.addValue(Types.INTEGER, PokerDatabase.storeTournament(game_));
 
             HoldemHand hhand = game_.getCurrentTable().getHoldemHand();
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandAction.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandAction.java
@@ -38,10 +38,14 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.comms.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.comms.DataCoder;
+import com.donohoedigital.comms.DataMarshal;
+import com.donohoedigital.comms.MsgState;
+import com.donohoedigital.comms.TokenizedList;
+import com.donohoedigital.config.PropertyConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  *
@@ -405,8 +409,8 @@ public class HandAction implements DataMarshal
         if (isAllIn()) nAmount += nCall;
 
         Object[] params = new Object[4 + (extraParams != null ? extraParams.length : 0)];
-        params[0] = new Integer(nAmount);
-        params[1] = new Integer(nCall);
+        params[0] = nAmount;
+        params[1] = nCall;
         params[2] = sIcon;
         params[3] = Utils.encodeHTML(getPlayer().getName());
         if (extraParams != null && extraParams.length > 0)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
@@ -38,12 +38,16 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.poker.engine.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.Format;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.EngineConstants;
+import com.donohoedigital.games.poker.engine.Deck;
+import com.donohoedigital.games.poker.engine.Hand;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 /**
  *
@@ -162,7 +166,7 @@ public class HandStrength
         for (int i = 1; i <= nOpponents; i++)
         {
             oppStrength = getStrength(dStrength, i) * 100;
-            sb.append(PropertyConfig.getMessage("msg.strength.row", new Integer(i),
+            sb.append(PropertyConfig.getMessage("msg.strength.row", i,
                                                 HandStat.fPerc.form(oppStrength)));
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HistoryExportDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HistoryExportDialog.java
@@ -38,19 +38,26 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.impexp.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.db.BindArray;
+import com.donohoedigital.games.config.GameButton;
+import com.donohoedigital.games.engine.FileChooserDialog;
+import com.donohoedigital.games.poker.impexp.ImpExp;
+import com.donohoedigital.games.poker.impexp.ImpExpHand;
+import com.donohoedigital.games.poker.impexp.ImpExpParadise;
 import com.donohoedigital.gui.*;
-import com.donohoedigital.db.*;
-import com.donohoedigital.config.*;
 
 import javax.swing.*;
-import java.io.*;
-import java.util.*;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
 
 public class HistoryExportDialog extends FileChooserDialog
 {
@@ -181,14 +188,14 @@ public class HistoryExportDialog extends FileChooserDialog
 
                 cbxHands_.setText(PropertyConfig.getMessage(
                                     "msg.handtranscriptcount" + (exp_.handIDs.size() != 1 ? ".plural" : ".singular"),
-                                    new Integer(exp_.handIDs.size())));
+                                    exp_.handIDs.size()));
                 cbxHands_.setSelected(true);
 
                 cbxHands_.addActionListener(actionListener);
 
                 cbxTournaments_.setText(PropertyConfig.getMessage(
                                     "msg.tourneysummarycount" + (exp_.tournamentCount != 1 ? ".plural" : ".singular"),
-                                    new Integer(exp_.tournamentCount)));
+                                    exp_.tournamentCount));
 
                 cbxTournaments_.addActionListener(actionListener);
 
@@ -268,15 +275,15 @@ public class HistoryExportDialog extends FileChooserDialog
 
                         for (int i = 0; i < exp_.handIDs.size() && !cancel_; ++i)
                         {
-                            ieHand = PokerDatabase.getHandForExport(((Integer)exp_.handIDs.get(i)).intValue());
+                            ieHand = PokerDatabase.getHandForExport((Integer) exp_.handIDs.get(i));
 
                             if (cbxTournaments_.isSelected() &&
                                 (summariesExported.size() < exp_.tournamentCount) &&
-                                !summariesExported.contains(new Integer(ieHand.tournamentID)))
+                                !summariesExported.contains(ieHand.tournamentID))
                             {
                                 w.write(ie.exportTournament(ieHand));
                                 w.write("\r\n\r\n");
-                                summariesExported.add(new Integer(ieHand.tournamentID));
+                                summariesExported.add(ieHand.tournamentID);
                             }
 
                             if (cbxHands_.isSelected())

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -38,29 +38,43 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.CommandLine;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
 import com.donohoedigital.comms.*;
 import com.donohoedigital.config.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.games.config.*;
+import com.donohoedigital.games.config.EngineConstants;
+import com.donohoedigital.games.config.GameConfigUtils;
+import com.donohoedigital.games.config.GameState;
+import com.donohoedigital.games.config.GameStateFactory;
 import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.network.*;
-import com.donohoedigital.games.poker.online.*;
-import com.donohoedigital.gui.*;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import com.donohoedigital.games.poker.network.OnlineMessage;
+import com.donohoedigital.games.poker.network.PokerConnection;
+import com.donohoedigital.games.poker.network.PokerConnectionServer;
+import com.donohoedigital.games.poker.network.PokerUDPTransporter;
+import com.donohoedigital.games.poker.online.ChatHandler;
+import com.donohoedigital.games.poker.online.ListGames;
+import com.donohoedigital.games.poker.online.OnlineManager;
+import com.donohoedigital.gui.DDHtmlEditorKit;
 import com.donohoedigital.p2p.*;
 import com.donohoedigital.udp.*;
-import org.apache.logging.log4j.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;
 import java.io.*;
-import java.net.*;
-import java.nio.channels.*;
-import java.sql.*;
-import java.util.*;
+import java.net.URL;
+import java.nio.channels.SocketChannel;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 /**
  * @author Doug Donohoe
@@ -86,7 +100,8 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
         //	at javax.swing.plaf.metal.MetalSliderUI.installUI(MetalSliderUI.java:110)
         System.setProperty("swing.defaultlaf", "javax.swing.plaf.metal.MetalLookAndFeel");
 
-        // initialize logging before anything else
+        // initialize logging before anything else (need version string for log file directory)
+        Utils.setVersionString(PokerConstants.VERSION.getMajorAsString());
         LoggingConfig loggingConfig = new LoggingConfig(APP_NAME, ApplicationType.CLIENT);
         loggingConfig.init();
         logger = LogManager.getLogger(PokerMain.class);
@@ -147,7 +162,7 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
     public PokerMain(String sConfigName, String sMainModule, String[] args, boolean bHeadless, boolean bLoadNames)
             throws ApplicationError
     {
-        super(sConfigName, sMainModule, "" + PokerConstants.VERSION.getMajor(), args, bHeadless);
+        super(sConfigName, sMainModule, PokerConstants.VERSION.getMajorAsString(), args, bHeadless);
         this.bLoadNames = bLoadNames;
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerNight.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerNight.java
@@ -38,12 +38,15 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.engine.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.config.AudioConfig;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.BasePhase;
+import com.donohoedigital.games.engine.DisplayMessage;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 
@@ -167,8 +170,8 @@ public class PokerNight extends BasePhase implements GameClockListener
                     game_.getMinChip() > nMinBefore)
                 {
                     sChipRace = PropertyConfig.getMessage("msg.finish.color",
-                            new Integer(game_.getLastMinChip()),
-                            new Integer(game_.getMinChip()));
+                            game_.getLastMinChip(),
+                            game_.getMinChip());
                     if (bRebuy || bAddon) sChipRace = "<BR><BR>" + sChipRace;
                 }
 
@@ -185,19 +188,19 @@ public class PokerNight extends BasePhase implements GameClockListener
                     }
                     else if (bRebuy && bAddon)
                     {
-                        sMsg = PropertyConfig.getMessage("msg.finish.both", new Integer(nLevel), sChipRace);
+                        sMsg = PropertyConfig.getMessage("msg.finish.both", nLevel, sChipRace);
                     }
                     else if (bRebuy)
                     {
-                        sMsg = PropertyConfig.getMessage("msg.finish.rebuy", new Integer(nLevel), sChipRace);
+                        sMsg = PropertyConfig.getMessage("msg.finish.rebuy", nLevel, sChipRace);
                     }
                     else if (bAddon)
                     {
-                        sMsg = PropertyConfig.getMessage("msg.finish.addon", new Integer(nLevel), sChipRace);
+                        sMsg = PropertyConfig.getMessage("msg.finish.addon", nLevel, sChipRace);
                     }
                     else
                     {
-                        sMsg = PropertyConfig.getMessage("msg.finish.colorup", new Integer(nLevel), sChipRace);
+                        sMsg = PropertyConfig.getMessage("msg.finish.colorup", nLevel, sChipRace);
                     }
 
                     // show message

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
@@ -32,13 +32,15 @@
  */
 package com.donohoedigital.games.poker;
 
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
 import com.donohoedigital.gui.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.poker.engine.*;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class PokerSimulatorPanel extends DDTabPanel implements DDProgressFeedback
 {
@@ -148,7 +150,7 @@ public class PokerSimulatorPanel extends DDTabPanel implements DDProgressFeedbac
         nNumComm = community.size();
         header_.setText(PropertyConfig.getMessage(sKey, pocket.toHTML(),
                                                   community.toHTML(),
-                                                  new Integer((2+nNumComm) * 23 + 5)));
+                                                  (2+nNumComm) * 23 + 5));
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStatsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStatsPanel.java
@@ -32,11 +32,13 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.config.*;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
 import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.engine.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.*;
@@ -154,7 +156,7 @@ public class PokerStatsPanel extends DDTabPanel
         header_.setText(PropertyConfig.getMessage("msg.sim.header.generic",
                                                      pocket.toHTML(),
                                                      "&nbsp;&nbsp;" + community.toHTML(),
-                                                     new Integer((2+nNumComm) * 23 + 5),
+                                                     (2+nNumComm) * 23 + 5,
                                                      sMsg));
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PreShowdown.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PreShowdown.java
@@ -38,10 +38,11 @@
 
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.online.*;
-import com.donohoedigital.comms.*;
+import com.donohoedigital.comms.DMArrayList;
+import com.donohoedigital.games.config.GameButton;
+import com.donohoedigital.games.engine.ChainPhase;
+import com.donohoedigital.games.engine.EngineUtils;
+import com.donohoedigital.games.poker.online.TournamentDirector;
 
 /**
  *
@@ -69,7 +70,7 @@ public class PreShowdown extends ChainPhase
             // the local player, then that player is a winner
             DMArrayList winners = (DMArrayList) gamephase_.getObject(PARAM_WINNERS);
             boolean bWinner = false;
-            if (winners != null && winners.contains(new Integer(player.getID())))
+            if (winners != null && winners.contains(player.getID()))
             {
                 bWinner = true;
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
@@ -32,17 +32,24 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.model.*;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.config.StylesConfig;
+import com.donohoedigital.games.config.GamePhase;
+import com.donohoedigital.games.engine.EngineUtils;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.engine.Phase;
+import com.donohoedigital.games.engine.ProfileList;
+import com.donohoedigital.games.poker.model.TournamentProfile;
 import com.donohoedigital.gui.*;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
-import java.beans.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 public class ShowPokerNightTable extends ShowPokerTable implements PropertyChangeListener, GameClockListener, SwingConstants
 {
@@ -426,7 +433,7 @@ public class ShowPokerNightTable extends ShowPokerTable implements PropertyChang
     {
         int key = event.getKeyCode();
 
-        if (event.getModifiers() == 0 || event.isShiftDown())
+        if (event.getModifiersEx() == 0 || event.isShiftDown())
         {
             switch (key)
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -32,17 +32,22 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.base.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.ErrorCodes;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.ImageConfig;
+import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.config.*;
 import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.ai.*;
+import com.donohoedigital.games.poker.ai.PlayerType;
+import com.donohoedigital.games.poker.ai.PokerAI;
 import com.donohoedigital.games.poker.dashboard.*;
 import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.network.*;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
+import com.donohoedigital.games.poker.event.PokerTableListener;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import com.donohoedigital.games.poker.network.OnlineMessage;
 import com.donohoedigital.games.poker.online.*;
 import com.donohoedigital.gui.*;
 
@@ -50,9 +55,13 @@ import javax.swing.*;
 import javax.swing.event.*;
 import java.awt.*;
 import java.awt.event.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.List;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
+import static com.donohoedigital.config.DebugConfig.TOGGLE;
 
 public class ShowTournamentTable extends ShowPokerTable implements
                                                         PokerTableInput,
@@ -1554,7 +1563,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
 
         int key = event.getKeyCode();
 
-        if (event.getModifiers() == 0 || event.isShiftDown())
+        if (event.getModifiersEx() == 0 || event.isShiftDown())
         {
             switch (key)
             {
@@ -2811,7 +2820,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         public void mousePressed(MouseEvent e)
         {
             Point p = SwingUtilities.convertPoint((Component) e.getSource(), e.getX(), e.getY(), board_);
-            board_.mousePressed(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiers(),
+            board_.mousePressed(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiersEx(),
                                                p.x, p.y, e.getClickCount(), e.isPopupTrigger()));
         }
 
@@ -2822,7 +2831,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         public void mouseReleased(MouseEvent e)
         {
             Point p = SwingUtilities.convertPoint((Component) e.getSource(), e.getX(), e.getY(), board_);
-            board_.mouseReleased(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiers(),
+            board_.mouseReleased(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiersEx(),
                                                 p.x, p.y, e.getClickCount(), e.isPopupTrigger()));
         }
 
@@ -2837,7 +2846,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         public void mouseDragged(MouseEvent e)
         {
             Point p = SwingUtilities.convertPoint((Component) e.getSource(), e.getX(), e.getY(), board_);
-            board_.mouseDragged(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiers(),
+            board_.mouseDragged(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiersEx(),
                                                p.x, p.y, e.getClickCount(), e.isPopupTrigger()));
         }
 
@@ -2848,7 +2857,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         public void mouseMoved(MouseEvent e)
         {
             Point p = SwingUtilities.convertPoint((Component) e.getSource(), e.getX(), e.getY(), board_);
-            board_.mouseMoved(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiers(),
+            board_.mouseMoved(new MouseEvent(board_, e.getID(), e.getWhen(), e.getModifiersEx(),
                                              p.x, p.y, e.getClickCount(), e.isPopupTrigger()));
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/StatResult.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/StatResult.java
@@ -33,7 +33,8 @@
 package com.donohoedigital.games.poker;
 
 import com.donohoedigital.config.PropertyConfig;
-import com.donohoedigital.games.poker.engine.*;
+import com.donohoedigital.games.poker.engine.Hand;
+import com.donohoedigital.games.poker.engine.PokerConstants;
 
 public class StatResult
 {
@@ -156,8 +157,7 @@ public class StatResult
                        PokerConstants.formatPercent(winPercent_),
                        PokerConstants.formatPercent(tiePercent_),
                        PokerConstants.formatPercent(losePercent_),
-                       new Integer(handCount_)
-                        );
+                       handCount_);
     }
 
     public String toString() {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/StatResults.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/StatResults.java
@@ -32,11 +32,12 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.config.*;
-import com.donohoedigital.base.*;
-import com.donohoedigital.games.poker.engine.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.poker.engine.PokerConstants;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 
 public class StatResults extends LinkedHashMap
 {
@@ -67,8 +68,7 @@ public class StatResults extends LinkedHashMap
                        PokerConstants.formatPercent(result.getWinPercent()),
                        PokerConstants.formatPercent(result.getLosePercent()),
                        PokerConstants.formatPercent(result.getTiePercent()),
-                       new Integer(result.getHandCount())
-                        ));
+                       result.getHandCount()));
         }
         buf.append(PropertyConfig.getMessage("msg.simresult.footer"));
         return buf.toString();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AIStrategyNode.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AIStrategyNode.java
@@ -32,11 +32,12 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.config.PropertyConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
 
 public class AIStrategyNode
 {
@@ -175,7 +176,7 @@ public class AIStrategyNode
 
         if (value < 0)
         {
-            profile.getMap().setInteger("strat." + name_, new Integer(defval));
+            profile.getMap().setInteger("strat." + name_, defval);
             value = defval;
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/BooleanTracker.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/BooleanTracker.java
@@ -38,7 +38,7 @@ public class BooleanTracker
     private int next_;
     private boolean full_;
     private int countTrue_;
-    private boolean entries_[];
+    private boolean[] entries_;
 
     public BooleanTracker(int length, int min)
     {
@@ -218,11 +218,11 @@ public class BooleanTracker
 
         String s = (String)o;
 
-        String a[] = s.split(",");
+        String[] a = s.split(",");
 
         min_ = Integer.parseInt(a[0]);
         next_ = Integer.parseInt(a[1]);
-        full_ = new Boolean(a[2]).booleanValue();
+        full_ = Boolean.parseBoolean(a[2]);
         countTrue_ = Integer.parseInt(a[3]);
         entries_ = new boolean[Integer.parseInt(a[4])];
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/FloatTracker.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/FloatTracker.java
@@ -38,7 +38,7 @@ public class FloatTracker
     private int next_;
     private boolean full_;
     private float weightedAverage_;
-    private float entries_[];
+    private float[] entries_;
 
     public FloatTracker(int length, int min)
     {
@@ -64,7 +64,7 @@ public class FloatTracker
     {
         if (f == null) return;
 
-        float fv = f.floatValue();
+        float fv = f;
 
         entries_[next_] = fv;
 
@@ -202,14 +202,14 @@ public class FloatTracker
 
         String s = (String)o;
 
-        String a[] = s.split(",");
+        String[] a = s.split(",");
 
         min_ = Integer.parseInt(a[0]);
         next_ = Integer.parseInt(a[1]);
-        full_ = new Boolean(a[2]).booleanValue();
+        full_ = Boolean.parseBoolean(a[2]);
         entries_ = new float[Integer.parseInt(a[4])];
 
-        String v[] = a[5].split(":");
+        String[] v = a[5].split(":");
 
         for (int i = 0; i < entries_.length && i < v.length; ++i)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/OpponentModel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/OpponentModel.java
@@ -32,10 +32,12 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.comms.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.comms.DMTypedHashMap;
+import com.donohoedigital.games.poker.HandAction;
+import com.donohoedigital.games.poker.HoldemHand;
+import com.donohoedigital.games.poker.PokerPlayer;
+import com.donohoedigital.games.poker.engine.Hand;
 
 public class OpponentModel
 {
@@ -426,7 +428,7 @@ public class OpponentModel
 
     public void saveToMap(DMTypedHashMap map, String sPrefix)
     {
-        map.setInteger(sPrefix + "handsPlayed", new Integer(handsPlayed));
+        map.setInteger(sPrefix + "handsPlayed", handsPlayed);
         map.setObject(sPrefix + "handsPaid", handsPaid.encode());
         map.setObject(sPrefix + "handsLimped", handsLimped.encode());
         map.setObject(sPrefix + "handsFoldedUnraised", handsFoldedUnraised.encode());
@@ -451,7 +453,7 @@ public class OpponentModel
             map.setObject(sPrefix + "aggression" + i, aggression[i].encode());
         }
 
-        map.setBoolean("overbetPotPostFlop", new Boolean(overbetPotPostFlop));
+        map.setBoolean("overbetPotPostFlop", overbetPotPostFlop);
     }
 
     public void loadFromMap(DMTypedHashMap map, String sPrefix)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PlayerType.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PlayerType.java
@@ -32,16 +32,24 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.comms.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.comms.DMTypedHashMap;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.BaseProfile;
+import com.donohoedigital.games.config.SaveFile;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.poker.PlayerProfile;
+import com.donohoedigital.games.poker.PlayerProfileOptions;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.engine.PokerSaveDetails;
 
 import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class PlayerType extends BaseProfile
 {
@@ -635,7 +643,7 @@ public class PlayerType extends BaseProfile
 
     public void setStratValue(String name, int value)
     {
-        getMap().setInteger("strat." + name, new Integer(value));
+        getMap().setInteger("strat." + name, value);
     }
 
     public ArrayList getSummaryNodes(boolean bIncludeDisabled)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketOdds.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketOdds.java
@@ -32,11 +32,12 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.games.poker.PokerUtils;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
 
-import java.util.*;
+import java.util.HashMap;
 
 /**
  * Reusable computation of odds of winning (Effective Hand Strength) with a given pocket hand, board, and cards to come.
@@ -102,7 +103,7 @@ public class PocketOdds
             fpBoard_ = fpBoard;
         }
 
-        Object key = new Long(pocket.fingerprint());
+        Object key = pocket.fingerprint();
 
         PocketOdds odds = (PocketOdds)cache_.get(key);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketRanks.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketRanks.java
@@ -32,10 +32,11 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
 
-import java.util.*;
+import java.util.HashMap;
 
 /**
  * Reusable computation of relative ranking of hands (Raw Hand Strength) with a given board.
@@ -82,7 +83,7 @@ public class PocketRanks
             fpFlop_ = fpFlop;
         }
 
-        Object key = new Long(community.fingerprint());
+        Object key = community.fingerprint();
 
         PocketRanks ranks = (PocketRanks)cache_.get(key);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
@@ -32,11 +32,12 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.base.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.games.poker.HandInfoFaster;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
 
-import java.util.*;
+import java.util.HashMap;
 
 /**
  * Reusable computation of hand scores with a given board.
@@ -86,7 +87,7 @@ public class PocketScores
             fpFlop_ = fpFlop;
         }
 
-        Object key = new Long(community.fingerprint());
+        Object key = community.fingerprint();
 
         PocketScores scores = (PocketScores)cache_.get(key);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PokerAI.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PokerAI.java
@@ -32,18 +32,28 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.ddpoker.holdem.*;
-import com.donohoedigital.base.*;
-import com.donohoedigital.comms.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.engine.*;
+import com.ddpoker.holdem.PlayerAction;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.ErrorCodes;
+import com.donohoedigital.comms.DMTypedHashMap;
+import com.donohoedigital.comms.DataCoder;
+import com.donohoedigital.comms.MsgState;
+import com.donohoedigital.comms.TokenizedList;
+import com.donohoedigital.config.ConfigUtils;
+import com.donohoedigital.config.Perf;
+import com.donohoedigital.games.config.GameState;
+import com.donohoedigital.games.engine.EngineGameAI;
 import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.games.config.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.games.poker.engine.Hand;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.engine.PokerSaveDetails;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
+import com.donohoedigital.games.poker.event.PokerTableListener;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.beans.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 // TODO: provide APIs for logging that don't require DDLogger
 // TODO: provide generic idiot-proof marshal/demarshal interface
@@ -82,14 +92,6 @@ public class PokerAI extends EngineGameAI implements PokerTableListener, Propert
     {
         super(false);
         if (false) Perf.construct(this, null);
-    }
-
-    /**
-     * finalize
-     */
-    protected void finalize()
-    {
-        if (false) Perf.finalize(this, null);
     }
 
     public void propertyChange(PropertyChangeEvent evt)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
@@ -32,15 +32,21 @@
  */
 package com.donohoedigital.games.poker.ai;
 
-import com.ddpoker.holdem.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.ddpoker.holdem.PlayerAction;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.DebugConfig;
+import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.games.poker.engine.Card;
+import com.donohoedigital.games.poker.engine.Hand;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 public class RuleEngine implements AIConstants
 {
@@ -3155,17 +3161,17 @@ public class RuleEngine implements AIConstants
 
             for (index = 0; index < outcomes.size(); ++index)
             {
-                if (score_[((Integer)outcomes.get(index)).intValue()] < score_[i]) break;
+                if (score_[(Integer) outcomes.get(index)] < score_[i]) break;
             }
 
-            outcomes.add(index, new Integer(i));
+            outcomes.add(index, i);
         }
 
         StringBuilder buf = new StringBuilder();
 
         for (int i = 0; i < outcomes.size(); ++i)
         {
-            buf.append(getReasoningHTML(((Integer)outcomes.get(i)).intValue()));
+            buf.append(getReasoningHTML((Integer) outcomes.get(i)));
             buf.append("<br><br>");
         }
 
@@ -3216,17 +3222,17 @@ public class RuleEngine implements AIConstants
 
             for (index = 0; index < adjustments.size(); index+=2)
             {
-                if (((Float)adjustments.get(index+1)).floatValue() < total)
+                if ((Float) adjustments.get(index + 1) < total)
                 {
                     break;
                 }
             }
 
-            adjustments.add(index, new Float(total));
-            adjustments.add(index, new Integer(i));
+            adjustments.add(index, total);
+            adjustments.add(index, i);
         }
 
-        if (adjustments.size() > 0)
+        if (!adjustments.isEmpty())
         {
             buf.append(PropertyConfig.getMessage("msg.aireason.heading", getOutcomeLabel(outcome),
                     getStrengthColor(score_[outcome] - 0.5f)));
@@ -3234,8 +3240,8 @@ public class RuleEngine implements AIConstants
 
         for (int i = 0; i < adjustments.size(); i +=2)
         {
-            int factor = ((Integer)(adjustments.get(i))).intValue();
-            float value = ((Float)(adjustments.get(i+1))).floatValue();
+            int factor = (Integer) (adjustments.get(i));
+            float value = (Float) (adjustments.get(i + 1));
 
             String display = PropertyConfig.getMessage
                         ("msg.aireason." + factorNames_.get(factor));

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
@@ -38,24 +38,36 @@
 
 package com.donohoedigital.games.poker.ai.gui;
 
-import com.donohoedigital.config.*;
-import static com.donohoedigital.config.DebugConfig.*;
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.GamePhase;
+import com.donohoedigital.games.engine.DialogPhase;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.GameEngine;
 import com.donohoedigital.games.poker.*;
+import com.donohoedigital.games.poker.ai.AIOutcome;
+import com.donohoedigital.games.poker.ai.PlayerType;
+import com.donohoedigital.games.poker.ai.RuleEngine;
+import com.donohoedigital.games.poker.ai.V2Player;
 import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.ai.*;
-import com.donohoedigital.games.poker.event.*;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
+import com.donohoedigital.games.poker.model.TournamentProfile;
 import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.base.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
-import javax.swing.event.*;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.util.Collections;
+import java.util.Comparator;
+
+import static com.donohoedigital.config.DebugConfig.TESTING;
 
 public class AdvisorInfoDialog extends DialogPhase
 {
@@ -81,7 +93,7 @@ public class AdvisorInfoDialog extends DialogPhase
         if (!game_.isClockMode()) profile_.setPrizePool(game_.getPrizePool(), true); // update to current
         ic_.setScaleToFit(false);
         ic_.setIconWidth(GamePrefsPanel.ICWIDTH);
-        ic_.setIconHeight(new Integer(GamePrefsPanel.ICHEIGHT.intValue())); // need to be slightly higher for focus
+        ic_.setIconHeight(GamePrefsPanel.ICHEIGHT); // need to be slightly higher for focus
         super.init(engine, context, gamephase);
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
@@ -32,18 +32,21 @@
  */
 package com.donohoedigital.games.poker.dashboard;
 
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.DiceRoller;
+import com.donohoedigital.games.engine.GameContext;
 import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.games.engine.*;
+import com.donohoedigital.games.poker.engine.Hand;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
 import com.donohoedigital.gui.*;
-import com.donohoedigital.base.*;
 
 import javax.swing.*;
-import java.awt.event.*;
 import java.awt.*;
-import java.util.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
 
 
 /**
@@ -296,7 +299,7 @@ public class AdvanceAction extends DashboardItem implements ActionListener
             {
                 nCallAmount_ = nToCall;
                 call_.setSelected(false);
-                call_.setText(PropertyConfig.getMessage("checkbox.call$.label", new Integer(nCallAmount_)));
+                call_.setText(PropertyConfig.getMessage("checkbox.call$.label", nCallAmount_));
             }
             call_.setEnabled(true);
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
@@ -32,12 +32,12 @@
  */
 package com.donohoedigital.games.poker.dashboard;
 
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.GameContext;
 import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.games.engine.*;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
+import com.donohoedigital.games.poker.model.TournamentProfile;
 import com.donohoedigital.gui.*;
-import com.donohoedigital.config.*;
 import com.zookitec.layout.*;
 
 import javax.swing.*;
@@ -171,7 +171,7 @@ public class DashboardClock extends DashboardItem implements GameClockListener
         PokerTable table = game_.getCurrentTable();
         if (table != null) nLevel = table.getLevel();
 
-        String sLevel = PropertyConfig.getMessage("msg.dash.level", new Integer(nLevel));
+        String sLevel = PropertyConfig.getMessage("msg.dash.level", nLevel);
         labelLevel_.setText(sLevel);
         TournamentProfile profile = game_.getProfile();
 
@@ -179,22 +179,22 @@ public class DashboardClock extends DashboardItem implements GameClockListener
         if (profile.isBreak(nLevel))
         {
             labelBlinds_.setText(PropertyConfig.getMessage("msg.dash.break",
-                                                           new Integer(profile.getMinutes(nLevel))));
+                                                           profile.getMinutes(nLevel)));
         }
         // ante and blinds
         else
         {
             // show gametype if different from default
             String sGameType = profile.getGameTypeDisplay(nLevel);
-            if (sGameType.length() > 0) sGameType = PropertyConfig.getMessage("msg.dash.gametype", sGameType);
+            if (!sGameType.isEmpty()) sGameType = PropertyConfig.getMessage("msg.dash.gametype", sGameType);
             
             int nAnte = profile.getAnte(nLevel);
             int nBig = profile.getBigBlind(nLevel);
             int nSmall = profile.getSmallBlind(nLevel);
             labelBlinds_.setText(PropertyConfig.getMessage(nAnte == 0 ? "msg.dash.blinds" : "msg.dash.blinds.a",
-                                                       new Integer(nSmall),
-                                                       new Integer(nBig),
-                                                       nAnte == 0 ? null : new Integer(nAnte),
+                                                       nSmall,
+                                                       nBig,
+                                                       nAnte == 0 ? null : nAnte,
                                                        sGameType));
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/MyTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/MyTable.java
@@ -32,15 +32,17 @@
  */
 package com.donohoedigital.games.poker.dashboard;
 
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.games.engine.*;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.poker.PokerPlayer;
+import com.donohoedigital.games.poker.PokerTable;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
 import com.donohoedigital.gui.*;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 /**
  * Created by IntelliJ IDEA.
@@ -90,7 +92,7 @@ public class MyTable extends DashboardItem implements ActionListener
     protected Object getDynamicTitleParam()
     {
         PokerTable table = game_.getCurrentTable();
-        return new Integer(table.getNumber());
+        return table.getNumber();
     }
 
     ///
@@ -119,8 +121,8 @@ public class MyTable extends DashboardItem implements ActionListener
         }
 
         labelInfo_.setText(PropertyConfig.getMessage(sMsgKey,
-                                new Integer(human.getTable().getNumber()),
-                                bObs ? null : new Integer(human.getSeat() + 1),
+                                human.getTable().getNumber(),
+                                bObs ? null : human.getSeat() + 1,
                                 ""+nHandNum) // use "" + to not get commas
                                 );
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -32,17 +32,22 @@
  */
 package com.donohoedigital.games.poker.dashboard;
 
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.model.*;
-import com.donohoedigital.games.poker.event.*;
-import com.donohoedigital.gui.*;
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.Territory;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.Gameboard;
+import com.donohoedigital.games.engine.TerritorySelectionListener;
+import com.donohoedigital.games.poker.PokerPlayer;
+import com.donohoedigital.games.poker.PokerTable;
+import com.donohoedigital.games.poker.PokerUtils;
+import com.donohoedigital.games.poker.event.PokerTableEvent;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import com.donohoedigital.gui.DDLabel;
+import com.donohoedigital.gui.GuiManager;
 
 import javax.swing.*;
-import java.awt.event.*;
+import java.awt.event.MouseEvent;
 
 /**
  * Created by IntelliJ IDEA.
@@ -115,7 +120,7 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
                     }
                     else if (nLeft > 0)
                     {                        
-                        what = new Integer(nLeft);
+                        what = nLeft;
                     }
                 }
 
@@ -132,11 +137,11 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             if (numLeft == 0) numLeft = game_.getNumPlayers();
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo",
                                       Utils.encodeHTML(last_.getName()),
-                                      new Integer(last_.getHandsPlayedDisconnected()),
-                                      new Integer(last_.getHandsPlayedSitout()),
+                                      last_.getHandsPlayedDisconnected(),
+                                      last_.getHandsPlayedSitout(),
                                       sRebuy,
                                       PropertyConfig.getPlace(game_.getRank(last_)),
-                                      new Integer(numLeft)
+                                      numLeft
             ));
         }
         else

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
@@ -32,21 +32,31 @@
  */
 package com.donohoedigital.games.poker.online;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
+import com.donohoedigital.base.SecurityUtils;
+import com.donohoedigital.base.TypedHashMap;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.ConfigUtils;
+import com.donohoedigital.config.ImageConfig;
+import com.donohoedigital.config.Perf;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.FileChooserDialog;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.engine.Phase;
+import com.donohoedigital.games.poker.PokerGame;
+import com.donohoedigital.games.poker.engine.PokerConstants;
 import com.donohoedigital.gui.*;
-import org.apache.logging.log4j.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.text.*;
+import javax.swing.border.Border;
+import javax.swing.text.BadLocationException;
 import java.awt.*;
 import java.awt.event.*;
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
 
 /**
  * subclass to handle selection and copy
@@ -298,16 +308,16 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
                 {
                     if (bounds.contains(botright))
                     {
-                        html.select(html.viewToModel(adjtopleft), html.viewToModel(adjbotright));
+                        html.select(html.viewToModel2D(adjtopleft), html.viewToModel2D(adjbotright));
                     }
                     else
                     {
-                        html.select(html.viewToModel(adjtopleft), Integer.MAX_VALUE);
+                        html.select(html.viewToModel2D(adjtopleft), Integer.MAX_VALUE);
                     }
                 }
                 else if (bounds.contains(botright))
                 {
-                    html.select(0, html.viewToModel(adjbotright));
+                    html.select(0, html.viewToModel2D(adjbotright));
                 }
                 else
                 {
@@ -341,7 +351,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
             adjstart = SwingUtilities.convertPoint(getListParent(), start_, html);
             if (bounds.contains(start_))
             {
-                int pos = html.viewToModel(adjstart);
+                int pos = html.viewToModel2D(adjstart);
                 int length = html.getDocument().getLength();
                 int start = pos - 1;
                 int end = pos + 1;
@@ -588,12 +598,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
             setEnabled(false);
             setUseEmptyBorder(true);
         }
-
-        public void finalize()
-        {
-            if (false) Perf.finalize(this, "Chat");
-        }
-
+        
         public void update()
         {
             ChatPanel.ChatMessage msg = getMessage();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStart.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStart.java
@@ -38,14 +38,17 @@
 
 package com.donohoedigital.games.poker.online;
 
-import com.donohoedigital.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.*;
-import com.donohoedigital.games.poker.engine.*;
-import com.donohoedigital.games.poker.model.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.ChainPhase;
+import com.donohoedigital.games.poker.PokerGame;
+import com.donohoedigital.games.poker.PokerMain;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 /**
  *
@@ -120,7 +123,7 @@ public class HostStart extends ChainPhase implements ActionListener
         {
             mgr_.sendDirectorChat(PropertyConfig.getMessage(
                     (nNumAI > 1 ? "msg.chat.ai.added.plural" : "msg.chat.ai.added.singular"),
-                    new Integer(nNumAI)), null);
+                    nNumAI), null);
         }
         
         // set current table for host
@@ -137,7 +140,7 @@ public class HostStart extends ChainPhase implements ActionListener
         // do countdown
         mgr_.sendDirectorChat(PropertyConfig.getMessage(
                     (DELAY > 1 ? "msg.chat.starts.plural" : "msg.chat.starts.singular"),
-                    new Integer(DELAY)), null);
+                    DELAY), null);
         
         timer_ = new javax.swing.Timer(ONE_SEC,  this);
         timer_.start();
@@ -163,7 +166,7 @@ public class HostStart extends ChainPhase implements ActionListener
             {
                 mgr_.sendDirectorChat(PropertyConfig.getMessage(
                     (left > 1 ? "msg.chat.starts.plural" : "msg.chat.starts.singular"),
-                    new Integer(left)), null);
+                    left), null);
             }
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/PokerErrorDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/PokerErrorDialog.java
@@ -32,12 +32,16 @@
  */
 package com.donohoedigital.games.poker.online;
 
-import com.donohoedigital.games.config.*;
-import com.donohoedigital.games.engine.*;
-import com.donohoedigital.games.poker.network.*;
-import com.donohoedigital.gui.*;
-import com.donohoedigital.comms.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.comms.DDMessage;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.GamePhase;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.engine.MessageErrorDialog;
+import com.donohoedigital.games.poker.network.PokerURL;
+import com.donohoedigital.gui.DDLabel;
+import com.donohoedigital.gui.GuiManager;
+import com.donohoedigital.gui.InternalDialog;
 
 import javax.swing.*;
 import java.awt.*;
@@ -96,7 +100,7 @@ public class PokerErrorDialog extends MessageErrorDialog
     public void messageReceived(DDMessage message)
     {
         int n = gamephase_.getInteger(PARAM_ATTEMPT, 1);
-        attempts_.setText(PropertyConfig.getMessage("msg.reconnect.attempts", new Integer(n)));
+        attempts_.setText(PropertyConfig.getMessage("msg.reconnect.attempts", n));
         super.messageReceived(message);
     }
 

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -41,6 +41,26 @@
 </table>
 <br>
 
+<!-- 3.1.4 -->
+
+<table width="100%" border="1">
+    <tr bgcolor="#1D4A07">
+        <td>
+            <div align="center"><strong><font color="#FFFF00" size="+1">
+                Version 3.1.4 - November 10, 2024
+            </font></strong></div>
+        </td>
+    </tr>
+</table>
+<ul>
+    <li>
+        Upgrade to Java 17.
+    </li>
+    <li>
+        Incorporating updates to various software dependencies.
+    </li>
+</ul>
+
 <!-- 3.1.3 -->
 
 <table width="100%" border="1">

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDatabaseTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDatabaseTest.java
@@ -32,11 +32,9 @@
  */
 package com.donohoedigital.games.poker;
 
+import com.donohoedigital.base.Utils;
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
-import com.donohoedigital.config.PropertyConfig;
-import com.donohoedigital.db.BindArray;
-import com.donohoedigital.games.engine.GameContext;
 import com.donohoedigital.games.poker.model.TournamentProfile;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,7 +43,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /*
  * The purpose of this test is to provide a rudimentary way to very our hsqldb
@@ -71,6 +70,7 @@ public class PokerDatabaseTest {
      */
     @Test
     public void testBasics() throws IOException {
+        Utils.setVersionString("-db-test");
         // init properties like poker client, but headless for test
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
 

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -64,7 +64,8 @@ public class PokerConstants
     //public static final Version VERSION = new Version(3, 1, 0, true); // release 3.1 (open sourced!)
     //public static final Version VERSION = new Version(3, 1, 1, true); // release 3.1.1 (add Windows installer)
     //public static final Version VERSION = new Version(3, 1, 2, true); // release 3.1.2 (dependency updates)
-    public static final Version VERSION = new Version(3, 1, 3, true); // release 3.1.3 (Java 11, dependency updates)
+    //public static final Version VERSION = new Version(3, 1, 3, true); // release 3.1.3 (Java 11, dependency updates)
+    public static final Version VERSION = new Version(3, 1, 4, true); // release 3.1.4 (Java 17, dependency updates)
 
     // OS versions (can be different if specific patches released)
     public static final Version LATEST_MAC = VERSION;

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -89,8 +89,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
           <fork>true</fork>
         </configuration>
       </plugin>
@@ -117,6 +117,13 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+
     </plugins>
 
     <resources>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -121,7 +121,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
       </plugin>
 
     </plugins>

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanClientInfo.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanClientInfo.java
@@ -38,8 +38,9 @@
 
 package com.donohoedigital.p2p;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.comms.*;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.comms.DDMessage;
+import com.donohoedigital.comms.DataMarshal;
 
 /**
  * Wrapper of DDMessage for lan client messages
@@ -170,7 +171,7 @@ public class LanClientInfo
     
     public void setAliveMillis(long s)
     {
-        data_.setLong(LAN_ALIVE_MILLIS, new Long(s));
+        data_.setLong(LAN_ALIVE_MILLIS, s);
     }
     
     public DataMarshal getGameData()

--- a/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
@@ -32,11 +32,15 @@
  */
 package com.donohoedigital.server;
 
-import com.donohoedigital.base.*;
-import com.donohoedigital.config.*;
-import org.apache.logging.log4j.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.ConfigUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author Doug Donohoe
@@ -91,7 +95,7 @@ public class ThreadPool
         {
             // create new thread
             try {
-                thread = (SocketThread) socketClass_.newInstance();
+                thread = (SocketThread) socketClass_.getDeclaredConstructor().newInstance();
             }
             catch (Exception e) {
                 throw new ApplicationError(e);

--- a/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
@@ -32,11 +32,15 @@
  */
 package com.donohoedigital.server;
 
-import com.donohoedigital.base.*;
-import org.apache.logging.log4j.*;
-import com.donohoedigital.config.*;
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.ConfigUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author Doug Donohoe
@@ -89,7 +93,7 @@ public class WorkerPool
         {
             // create new thread
             try {
-                thread = (WorkerThread) socketClass_.newInstance();
+                thread = (WorkerThread) socketClass_.getDeclaredConstructor().newInstance();
             }
             catch (Exception e) {
                 throw new ApplicationError(e);

--- a/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
@@ -32,11 +32,15 @@
  */
 package com.donohoedigital.tools;
 
-import org.xml.sax.*;
-import org.xml.sax.helpers.*;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.SAXParserFactory;
 
 public class SchemaValidate extends DefaultHandler {
-    StringBuilder result = new StringBuilder("");
+    StringBuilder result = new StringBuilder();
 
     /** Warning. */
     public void warning(SAXParseException ex) {
@@ -86,7 +90,7 @@ public class SchemaValidate extends DefaultHandler {
     public static String process(String xmlFileURL) {
         try {
             SchemaValidate validate = new SchemaValidate();
-            XMLReader parser = XMLReaderFactory.createXMLReader();
+            XMLReader parser = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
             parser.setContentHandler(validate);
             parser.setErrorHandler(validate);
             parser.setFeature("http://xml.org/sax/features/validation", true);

--- a/ddpoker.rc
+++ b/ddpoker.rc
@@ -56,27 +56,27 @@ alias act-ddpoker='act --platform ubuntu-latest=ddpoker-act-runner --pull=false 
   --container-options "-v $HOME/.m2:/home/runner/.m2" \
   --job test pull_request'
 
-# attempt to auto-set JAVA_HOME to 11 if on mac
+# attempt to auto-set JAVA_HOME to 17 if on mac
 if [[ "${OSTYPE:0:6}" == "darwin" ]]; then
-  JAVA11_HOME=$(/usr/libexec/java_home -F -v 11 2>/dev/null || echo "/java11/not/found")
-  if [[ -d "${JAVA11_HOME}" && "${JAVA11_HOME}" != "${JAVA_HOME}" ]]; then
-    export JAVA_HOME="${JAVA11_HOME}"
-    export PATH="${JAVA11_HOME}/bin:${PATH}"
+  JAVA17_HOME=$(/usr/libexec/java_home -F -v 17 2>/dev/null || echo "/java17/not/found")
+  if [[ -d "${JAVA17_HOME}" && "${JAVA17_HOME}" != "${JAVA_HOME}" ]]; then
+    export JAVA_HOME="${JAVA17_HOME}"
+    export PATH="${JAVA17_HOME}/bin:${PATH}"
     echo "JAVA_HOME changed, version now '$(java -version 2>&1 | head -1)'"
   fi
 fi
 
-# See if java 11 is installed
+# See if java 17 is installed
 if ! test -x "$(command -v java)"; then
   if [[ "${OSTYPE:0:6}" == "darwin" ]]; then
-    echo "WARNING: Java 11 is not installed. Have your run 'brew install temurin@11'?"
+    echo "WARNING: Java 17 is not installed. Have your run 'brew install temurin@17'?"
   else
-    echo "WARNING: Java 11 is not installed."
+    echo "WARNING: Java 17 is not installed."
   fi
 else
-  # Java is installed, check version is 11
-  if ! java -version 2>&1 | head -1 | grep -q "\"11\."; then
-    echo "WARNING: Java version is not 11 (which DD Poker requires).  Version is:"
+  # Java is installed, check version is 17
+  if ! java -version 2>&1 | head -1 | grep -q "\"17\."; then
+    echo "WARNING: Java version is not 17 (which DD Poker requires).  Version is:"
     java -version
   fi
 fi

--- a/installer/install4j/poker.install4j
+++ b/installer/install4j/poker.install4j
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="10.0.8" transformSequenceNumber="10">
   <directoryPresets config="./custom" />
-  <application name="DD Poker 3" applicationId="5571-3951-3041-7888" mediaDir="../builds" mediaFilePattern="ddpoker${compiler:sys.version}" shortName="ddpoker3" publisher="DD Poker" publisherWeb="http://www.ddpoker.com/" version="3.0" allPathsRelative="true" macVolumeId="d24c5a0cf4cff0ab" javaMinVersion="11" javaMaxVersion="11">
+  <application name="DD Poker 3" applicationId="5571-3951-3041-7888" mediaDir="../builds" mediaFilePattern="ddpoker${compiler:sys.version}" shortName="ddpoker3" publisher="DD Poker" publisherWeb="http://www.ddpoker.com/" version="3.0" allPathsRelative="true" macVolumeId="d24c5a0cf4cff0ab" javaMinVersion="17" javaMaxVersion="17">
     <languages>
       <principalLanguage id="en" customLocalizationFile="./custom/override.messages.utf8" />
     </languages>
     <codeSigning macEnabled="true" macPkcs12File="../../target/developerID_application.p12" windowsEnabled="true" windowsKeySource="pkcs11" windowsPkcs11Library="/usr/local/lib/libeTPkcs11.dylib">
       <windowsPkcs11Identifier issuer="Sectigo Public Code Signing CA R36" serial="b188553e484920219014bcbae1b277c5" subject="Donohoe Digital LLC" />
     </codeSigning>
-    <jreBundles jdkProviderId="Corretto" release="11/11.0.25.9.1" />
+    <jreBundles jdkProviderId="Corretto" release="17/17.0.13.11.1" />
   </application>
   <files>
     <mountPoints>


### PR DESCRIPTION
Upgrade from Java 11 to Java 17.  Only real change necessary was bumping the Maven war plugin to 3.4.0.

Also fixed deprecations (mostly originating in Java 9 and not fixed when I migrated to Java 11).

Bump to version 3.1.4