### PR TITLE
Fix OutOfMemoryError by raising client max heap (was 64-68 MB)

### DIFF
--- a/installer/install4j/poker.install4j
+++ b/installer/install4j/poker.install4j
@@ -24,7 +24,7 @@
       <executable name="ddpoker" iconSet="true" iconFile="./custom/pokericon16to64.ico" executableDir="." redirectStderr="false" stderrFile="log/err.txt" stdoutFile="log/out.txt" failOnStderrOutput="false" executableMode="gui">
         <versionInfo include="true" fileVersion="3.0.0.0" fileDescription="http://www.ddpoker.com/" legalCopyright="Copyright © 2004-2026. Donohoe Digital LLC." internalName="DD Poker" />
       </executable>
-      <java mainClass="com.donohoedigital.games.poker.PokerMain" vmParameters="&quot;-Dcom.donohoedigital.classpath=${launcher:sys.launcherDirectory}&quot; -Dsun.java2d.noddraw=true  -Xms32m -Xmx68m" preferredVM="client">
+      <java mainClass="com.donohoedigital.games.poker.PokerMain" vmParameters="&quot;-Dcom.donohoedigital.classpath=${launcher:sys.launcherDirectory}&quot; -Dsun.java2d.noddraw=true  -Xms32m -Xmx512m" preferredVM="client">
         <classPath>
           <directory location="." failOnError="false" />
           <scanDirectory location="." failOnError="false" />

--- a/tools/bin/poker
+++ b/tools/bin/poker
@@ -51,5 +51,5 @@ runjava poker \
   $JAVAOPTS \
   -Dsun.java2d.noddraw=true -Dverbose:gc \
   -Dlog4j.rootLogger="DEBUG, Console" \
-  -Xms32m -Xmx64m com.donohoedigital.games.poker.PokerMain "$@"
+  -Xms32m -Xmx512m com.donohoedigital.games.poker.PokerMain "$@"
 echo


### PR DESCRIPTION
The DD Poker client can exhaust its heap during large-field tournaments,
producing java.lang.OutOfMemoryError. It surfaces in two ways:

  1. The game crashes while dealing. ImageComponent.paintComponent sizes
     the gameboard's offscreen buffer as width*height*4 bytes and
     allocates it via ImageDef.createBufferedImage; on a large display
     that is ~8 MB. With only a few MB free the allocation fails and
     DealDisplay dies mid-hand.

  2. Saving silently does nothing. SaveGame.processButton serialises
     every player into a TokenizedList; the backing ArrayList cannot
     grow, Arrays.copyOf throws, and the error is logged at DEBUG and
     swallowed. The user gets no dialog and no indication that the
     tournament was not saved.

Root cause: the client's max heap has been hard-coded at 64-68 MB since
2004 and never raised - -Xmx has never changed in either file. A large
field means hundreds of simulated all-computer tables continuously
allocating HoldemHand/HandAction/HandInfo objects under that ceiling, so
the GC thrashes at a near-full heap and whichever allocation arrives next
is the one that fails.

The working set is bounded, so raising the ceiling is a genuine fix and
not a delay: completed hands are flushed to HSQLDB or skipped entirely
for all-computer tables, PokerTable keeps a single HoldemHand that is
replaced each hand, and the paint buffer is size-cached and reused. Under
continuous play the live set climbs and then plateaus.

Why it appears intermittent: the buffer is sized by the board, which
scales with the display. On a 1920x1080 screen it caps at ~4.3 MB and
68 MB is never seriously stressed. On a 2560x1440 screen the same board
needs 8,339,232 bytes and the ceiling is reached routinely. So the bug
only affects users on larger displays, and only after a long session in a
big field - a fresh tournament always saves correctly, which is why the
obvious test passes and the fault reads as flakiness.

Fix: raise -Xmx from 68m/64m to 512m in

  - installer/install4j/poker.install4j  (shipped installer launcher)
  - tools/bin/poker                      (dev run script)

512m is roughly double the observed peak: a 5,625-player field on a
1920x1080 display grew the committed heap to 266 MB, which leaves
headroom for the larger displays where the paint buffer is twice the
size.

Users cannot currently work around this themselves - the launcher sets
<vmOptionsFile mode="none"/>, so no .vmoptions file is read.

Verified by:

  - 2560x1440, shipped 68m: reproduced on demand. Six consecutive save
    attempts failed with OutOfMemoryError in GameState.savePlayers, and
    an earlier session crashed in DealDisplay, both against an 8,339,232
    byte buffer request with only 0.8-7.8 MB free.

  - 1920x1080, forced 38m: OutOfMemoryError after 667 full GCs in 4.4
    minutes, with the event dispatch thread left dead.

  - 1920x1080, 512m: same tournament and workload for 14.4 minutes with
    zero OutOfMemoryError, zero pressure-driven full GCs and zero
    evacuation failures.

Co-authored by Claude (Anthropic, Claude Code)
