### PR TITLE
Keep the Rank panel current, and rank players on settled chips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ Thumbs.db
 build
 release
 installer/builds
+
+# AI
+CLAUDE.md
+TODO.md

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
@@ -68,7 +68,22 @@ public class ChipLeaderPanel extends DDTabPanel
     public void createUI()
     {
         PokerPlayer p;
-        List<PokerPlayer> leaders = game_.getPlayersByRank();
+
+        // Capture each player's settled chip count once, then sort that snapshot.
+        // Settled counts are what make this panel agree with the Rank dashboard item -
+        // this dialog is opened mid-hand, when live counts have the current table's
+        // bets already pushed into the pot.  See PokerGame.getSettledChipCount().
+        // Sorting the snapshot also keeps Collections.sort() off of live mutable state,
+        // which can otherwise throw "Comparison method violates its general contract!"
+        // if the tournament director moves chips while the sort is running.
+        List<PokerPlayer> all = game_.getPokerPlayersCopy();
+        List<RankInfo> leaders = new ArrayList<RankInfo>(all.size());
+        for (PokerPlayer each : all)
+        {
+            leaders.add(new RankInfo(each, 0, game_.getSettledChipCount(each)));
+        }
+        Collections.sort(leaders, SORT_SETTLED);
+
         List<RankInfo> finished = new ArrayList<RankInfo>();
         List<RankInfo> current = new ArrayList<RankInfo>();
         int nNum = leaders.size();
@@ -76,6 +91,7 @@ public class ChipLeaderPanel extends DDTabPanel
         int min = Integer.MAX_VALUE;
         int max = 0;
         int nChips;
+        RankInfo info;
         PokerPlayer human = game_.getHumanPlayer();
         int nHumanRank = 0;
         int nRank = 0;
@@ -84,15 +100,17 @@ public class ChipLeaderPanel extends DDTabPanel
         // current players
         for (int i = 0; !bDone && i < nNum; i++)
         {
-            p = leaders.get(i);
-            nChips = p.getChipCount();
+            info = leaders.get(i);
+            p = info.player;
+            nChips = info.nChips;
             if (nChips == 0 && p.getPlace() != 0) continue;
             if (nChips != nLastChips)
             {
                 nRank = (i+1);
             }
             nLastChips = nChips;
-            current.add(new RankInfo(p, nRank));
+            info.nRank = nRank;
+            current.add(info);
             if (nChips < min) min = nChips;
             if (nChips > max) max = nChips;
             if (p == human)
@@ -104,9 +122,11 @@ public class ChipLeaderPanel extends DDTabPanel
         // finished players
         for (int i = 0; i < nNum; i++)
         {
-            p = leaders.get(i);
-            if ((p.getChipCount() != 0 && !bDone) || p.getPlace() == 0) continue;
-            finished.add(new RankInfo(p, i+1));
+            info = leaders.get(i);
+            p = info.player;
+            if ((info.nChips != 0 && !bDone) || p.getPlace() == 0) continue;
+            info.nRank = i+1;
+            finished.add(info);
             if (p == human)
             {
                 nHumanRank = i+1;
@@ -164,7 +184,7 @@ public class ChipLeaderPanel extends DDTabPanel
 
             if (human.getPlace() == 0 && !human.isObserver())
             {
-                int chip = human.getChipCount();
+                int chip = game_.getSettledChipCount(human);
                 int big = game_.getProfile().getLastBigBlind(human.getTable().getLevel());
                 double perc = ((double) chip / (double) total) * 100.0d;
                 double multavg = (double) chip / (double) avg;
@@ -226,13 +246,53 @@ public class ChipLeaderPanel extends DDTabPanel
     {
         PokerPlayer player;
         int nRank;
+        int nChips; // NO_CHIPS means none captured - display the live count instead
 
         RankInfo(PokerPlayer player, int nRank)
         {
+            this(player, nRank, NO_CHIPS);
+        }
+
+        RankInfo(PokerPlayer player, int nRank, int nChips)
+        {
             this.player = player;
             this.nRank = nRank;
+            this.nChips = nChips;
         }
     }
+
+    /**
+     * Marks a RankInfo which carries no captured chip count.  TableListPanel builds
+     * RankInfo directly to show a live view of one table, and must keep showing live
+     * chips so it agrees with the felt.
+     */
+    static final int NO_CHIPS = -1;
+
+    /**
+     * Orders players by captured chip count.  Mirrors PokerGame.SortChips, but reads
+     * the captured count rather than the live one so the ordering cannot change
+     * underneath the sort.
+     */
+    private static final Comparator<RankInfo> SORT_SETTLED = new Comparator<RankInfo>()
+    {
+        public int compare(RankInfo r1, RankInfo r2)
+        {
+            // reverse comparison so highest chips at top
+            int diff = r2.nChips - r1.nChips;
+            if (diff != 0) return diff;
+
+            // if no diff, and chip count is zero, sort by place
+            // normal comparison so best finish at top
+            if (r1.nChips == 0)
+            {
+                diff = r1.player.getPlace() - r2.player.getPlace();
+                if (diff != 0) return diff;
+            }
+
+            // if still no diff, rank by id, which puts human towards the top
+            return r1.player.getID() - r2.player.getID();
+        }
+    };
 
     public static final String COL_SEAT = "seat";
     public static final String COL_RANK = "rank";
@@ -300,6 +360,10 @@ public class ChipLeaderPanel extends DDTabPanel
             return players.get(r).nRank;
         }
 
+        public int getChips(int r) {
+            return players.get(r).nChips;
+        }
+
         public String getColumnName(int c) {
             return names[c];
         }
@@ -362,7 +426,10 @@ public class ChipLeaderPanel extends DDTabPanel
             else if (names[colIndex].equals(COL_CHIPS))
             {
                 if (p == null || getRank(rowIndex) < 0) return "";
-                sValue = getNumber(p.getChipCount());
+                // fall back to the live count for callers which build RankInfo
+                // directly (TableListPanel) - see NO_CHIPS
+                int nChips = getChips(rowIndex);
+                sValue = getNumber(nChips == NO_CHIPS ? p.getChipCount() : nChips);
             }
             else if (names[colIndex].equals(COL_BUYIN))
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -492,10 +492,18 @@ public class PokerGame extends Game implements PlayerActionListener
      * rank, so this is one more than the number of players holding strictly more -
      * the same result the previous sort-based version produced.
      *
+     * Compares settled chip counts, not live ones - see getSettledChipCount().  A rank
+     * is a comparison across the whole tournament, and tables are not in step with each
+     * other: in an online game they are independent state machines, so at any instant
+     * some are mid-hand and some are between hands.  Comparing live counts sinks
+     * whoever has chips in a pot.  This is reached at arbitrary moments - the Rank
+     * dashboard item recomputes when another table finishes a hand, which lands in the
+     * middle of ours, and PlayerInfo recomputes on every mouse-over.
+     *
      * Counted in a single pass rather than sorting a copy of the player list.  This
-     * runs every time the rank is displayed, which is now at the end of every hand,
-     * and in a large tournament the old version allocated and sorted a 5,625 element
-     * list each time.
+     * runs every time the rank is displayed, which is at the end of every hand, and in
+     * a large tournament the old version allocated and sorted a 5,625 element list
+     * each time.
      *
      * The loop bound is re-read each pass on purpose: players_ can shrink from
      * another thread (see removePlayer(), called from OnlineManager when a player
@@ -503,7 +511,7 @@ public class PokerGame extends Game implements PlayerActionListener
      */
     public int getRank(PokerPlayer player)
     {
-        int nChips = player.getChipCount();
+        int nChips = getSettledChipCount(player);
         int nRank = 1;
         boolean bFound = false;
 
@@ -515,7 +523,7 @@ public class PokerGame extends Game implements PlayerActionListener
                 bFound = true;
                 continue;
             }
-            if (p.getChipCount() > nChips) nRank++;
+            if (getSettledChipCount(p) > nChips) nRank++;
         }
 
         if (!bFound)
@@ -533,7 +541,7 @@ public class PokerGame extends Game implements PlayerActionListener
      * ante or bet is committed and is not credited back until the pot is awarded.
      * Comparing live counts across tables while a hand is in progress therefore
      * understates whoever is in the middle of a hand - which is everyone at the
-     * current table for most of its hand.  Same idiom as BUG 420 (see
+     * current table for most of its hand.  Same idea as BUG 420 (see
      * PokerTable.isRebuyAllowed()).
      *
      * Not synchronized on purpose - see PokerTable.isHandInProgress().
@@ -542,19 +550,39 @@ public class PokerGame extends Game implements PlayerActionListener
     {
         PokerTable table = player.getTable();
         if (table == null) return player.getChipCount();
-        if (table.isHandInProgress()) return player.getChipCountAtStart();
+
+        // Add back what this player has put in the pot this hand.  Deliberately not
+        // PokerPlayer.getChipCountAtStart(), which BUG 420 uses: that snapshot is taken
+        // in PokerPlayer.newHand(), during HoldemHand.deal(), which runs *after*
+        // PokerTable.startNewHand() has already fired TYPE_NEW_HAND - so anything
+        // recomputing on that event would read the previous hand's value.  Summing the
+        // committed chips is right whenever it is read; before any action it is zero.
+        if (table.isHandInProgress())
+        {
+            HoldemHand hhand = table.getHoldemHand();
+            if (hhand != null) return player.getChipCount() + hhand.getTotalBet(player);
+        }
 
         // All-computer tables play an entire hand in one shot inside
         // TournamentDirector.doBettingAllComputer(), which runs at the *first* betting
-        // round of the current table's hand.  So while the current table is mid-hand,
-        // those tables have already finished the same hand and are one hand ahead.
-        // Roll them back so every table is reported as of the same point in the
-        // tournament.  HoldemHand.simulateHand() calls PokerPlayer.newSimulatedHand()
-        // before any bets, so getChipCountAtStart() is their settled prior stack.
+        // round of the current table's hand.  So once they have played, they are a hand
+        // ahead of us for as long as our hand lasts; roll them back so every table is
+        // reported as of the same point in the tournament.  HoldemHand.simulateHand()
+        // calls PokerPlayer.newSimulatedHand() before any bets, so getChipCountAtStart()
+        // is their settled prior stack.
+        //
+        // The hand number test is what says "they have played".  Our hand number is
+        // incremented in startNewHand() before the deal, so between our new hand and our
+        // first bet the computer tables are still a hand behind us and their live count
+        // is already the settled one - rolling back there would go a hand too far.
         if (!isOnlineGame() && table.isAllComputer())
         {
             PokerTable current = getCurrentTable();
-            if (current != null && current.isHandInProgress()) return player.getChipCountAtStart();
+            if (current != null && current.isHandInProgress() &&
+                table.getHandNum() >= current.getHandNum())
+            {
+                return player.getChipCountAtStart();
+            }
         }
 
         return player.getChipCount();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -512,6 +512,41 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
+     * Get a player's chip count as of the last point at which chips were settled -
+     * that is, with nothing committed to a pot yet to be awarded.
+     *
+     * getChipCount() is the live stack, which is decremented the instant a blind,
+     * ante or bet is committed and is not credited back until the pot is awarded.
+     * Comparing live counts across tables while a hand is in progress therefore
+     * understates whoever is in the middle of a hand - which is everyone at the
+     * current table for most of its hand.  Same idiom as BUG 420 (see
+     * PokerTable.isRebuyAllowed()).
+     *
+     * Not synchronized on purpose - see PokerTable.isHandInProgress().
+     */
+    public int getSettledChipCount(PokerPlayer player)
+    {
+        PokerTable table = player.getTable();
+        if (table == null) return player.getChipCount();
+        if (table.isHandInProgress()) return player.getChipCountAtStart();
+
+        // All-computer tables play an entire hand in one shot inside
+        // TournamentDirector.doBettingAllComputer(), which runs at the *first* betting
+        // round of the current table's hand.  So while the current table is mid-hand,
+        // those tables have already finished the same hand and are one hand ahead.
+        // Roll them back so every table is reported as of the same point in the
+        // tournament.  HoldemHand.simulateHand() calls PokerPlayer.newSimulatedHand()
+        // before any bets, so getChipCountAtStart() is their settled prior stack.
+        if (!isOnlineGame() && table.isAllComputer())
+        {
+            PokerTable current = getCurrentTable();
+            if (current != null && current.isHandInProgress()) return player.getChipCountAtStart();
+        }
+
+        return player.getChipCount();
+    }
+
+    /**
      * Get sorted list of players
      */
     public List<PokerPlayer> getPlayersByRank()

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -488,27 +488,41 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
-     * Return rank of player based on chips
+     * Return rank of player based on chips.  Players holding equal chips share a
+     * rank, so this is one more than the number of players holding strictly more -
+     * the same result the previous sort-based version produced.
+     *
+     * Counted in a single pass rather than sorting a copy of the player list.  This
+     * runs every time the rank is displayed, which is now at the end of every hand,
+     * and in a large tournament the old version allocated and sorted a 5,625 element
+     * list each time.
+     *
+     * The loop bound is re-read each pass on purpose: players_ can shrink from
+     * another thread (see removePlayer(), called from OnlineManager when a player
+     * switches to observer), and a bound captured up front would index off the end.
      */
     public int getRank(PokerPlayer player)
     {
-        PokerPlayer p;
-        int nLastChips = 0;
-        int nRank = 0;
-        int nChips;
-        List<PokerPlayer> rank = getPlayersByRank();
-        for (int i = 0; i < rank.size(); i++)
+        int nChips = player.getChipCount();
+        int nRank = 1;
+        boolean bFound = false;
+
+        for (int i = 0; i < getNumPlayers(); i++)
         {
-            p = rank.get(i);
-            nChips = p.getChipCount();
-            if (nChips != nLastChips)
+            PokerPlayer p = getPokerPlayerAt(i);
+            if (p == player)
             {
-                nRank = (i + 1);
+                bFound = true;
+                continue;
             }
-            nLastChips = nChips;
-            if (p == player) return nRank;
+            if (p.getChipCount() > nChips) nRank++;
         }
-        throw new ApplicationError(ErrorCodes.ERROR_CODE_ERROR, "No rank for player", player.toString());
+
+        if (!bFound)
+        {
+            throw new ApplicationError(ErrorCodes.ERROR_CODE_ERROR, "No rank for player", player.toString());
+        }
+        return nRank;
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -1534,7 +1534,21 @@ public class PokerTable implements ObjectID
     {
         return hhand_;
     }
-    
+
+    /**
+     * Is a hand in progress at this table - that is, are there chips committed to
+     * a pot which have not yet been awarded?  When this is true, the chip counts of
+     * players at this table are mid-hand and must not be compared against players at
+     * other tables; use PokerPlayer.getChipCountAtStart() instead.  See BUG 420.
+     *
+     * Not synchronized on purpose - this is read from the swing thread while the
+     * tournament director holds this table's monitor.
+     */
+    public boolean isHandInProgress()
+    {
+        return hhand_ != null && hhand_.getRound() != HoldemHand.ROUND_SHOWDOWN;
+    }
+
     /**
      * Set holdem hand (called directly for testing/other usage, normal way is to startNewHand(),
      * which calls this)
@@ -1611,7 +1625,7 @@ public class PokerTable implements ObjectID
         // BUG 420 - use chip count at start of hand to determine if
         // player can rebuy during a hand.  This prevents someone from
         // going all-in and then rebuying
-        if (hhand_ != null && hhand_.getRound() != HoldemHand.ROUND_SHOWDOWN)
+        if (isHandInProgress())
         {
             nChipCount += player.getChipCountAtStart();
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -1539,7 +1539,10 @@ public class PokerTable implements ObjectID
      * Is a hand in progress at this table - that is, are there chips committed to
      * a pot which have not yet been awarded?  When this is true, the chip counts of
      * players at this table are mid-hand and must not be compared against players at
-     * other tables; use PokerPlayer.getChipCountAtStart() instead.  See BUG 420.
+     * other tables; use PokerGame.getSettledChipCount() instead.  Note that is
+     * deliberately not PokerPlayer.getChipCountAtStart() - that snapshot is not taken
+     * until the deal, which is too late for anything reacting to TYPE_NEW_HAND.
+     * See BUG 420 for the original use of this test, in isRebuyAllowed() below.
      *
      * Not synchronized on purpose - this is read from the swing thread while the
      * tournament director holds this table's monitor.

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
@@ -60,15 +60,33 @@ public class Rank extends DashboardItem
         super(context, "rank");
         setDynamicTitle(true);
         //setTableEventsImmediate(); // we need them immediately so rank is correct
+
+        // TYPE_END_HAND is what keeps the rank current.  It is fired at the end of
+        // HoldemHand.resolve(), once the pot has been awarded, so every chip count in
+        // the tournament is settled at that moment: the all-computer tables played
+        // their whole hand back at our first betting round (see
+        // TournamentDirector.doBettingAllComputer).  Without it the rank does not move
+        // until the *next* hand is dealt - with auto deal off, that means it sits stale
+        // for as long as the player looks at the pot they just won.
+        //
+        // TYPE_NEW_HAND is still needed: busted players are not removed and tables are
+        // not consolidated until the next hand's clean-up, so it is what corrects the
+        // "out of N players at M tables" part of the message.
+        //
+        // TYPE_PLAYER_CHIPS_CHANGED looks dead but is not - it is fired only by the
+        // cheat menu's change-chip-count option (ShowTournamentTable), which is the
+        // one way chips move outside of a hand.
         if (game_.isOnlineGame())
         {
             trackTableEvents(PokerTableEvent.TYPE_NEW_HAND |
+                             PokerTableEvent.TYPE_END_HAND |
                              PokerTableEvent.TYPE_PLAYER_CHIPS_CHANGED |
                              PokerTableEvent.TYPE_STATE_CHANGED);
         }
         else
         {
             trackTableEvents(PokerTableEvent.TYPE_NEW_HAND |
+                             PokerTableEvent.TYPE_END_HAND |
                              PokerTableEvent.TYPE_PLAYER_CHIPS_CHANGED);
         }
         game_.addPropertyChangeListener(PokerGame.PROP_GAME_LOADED, this);
@@ -91,7 +109,7 @@ public class Rank extends DashboardItem
     }
 
     /**
-     * update rank on new level change and new hand
+     * update rank on end of hand, new hand and new level change
      */
     @Override
     public void tableEventOccurred(PokerTableEvent event)

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
@@ -1,0 +1,223 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.base.ApplicationError;
+import com.donohoedigital.config.ApplicationType;
+import com.donohoedigital.config.ConfigManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Verifies PokerGame.getRank() counts in a single pass without changing the answer the
+ * previous sort-based implementation gave.  Rank is one more than the number of players
+ * holding strictly more chips, so players holding equal chips share a rank.
+ */
+public class PokerGameRankTest
+{
+    private PokerGame game_;
+
+    @Before
+    public void setUp()
+    {
+        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
+        game_ = new PokerGame(null);
+    }
+
+    private PokerPlayer add(int nId, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
+        p.setChipCount(nChips);
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * The rank the sort-based implementation produced, kept here so the single-pass
+     * version can be held to it.
+     */
+    private int legacyRank(PokerPlayer player)
+    {
+        int nLastChips = 0;
+        int nRank = 0;
+        List<PokerPlayer> rank = game_.getPlayersByRank();
+        for (int i = 0; i < rank.size(); i++)
+        {
+            PokerPlayer p = rank.get(i);
+            int nChips = p.getChipCount();
+            if (nChips != nLastChips) nRank = (i + 1);
+            nLastChips = nChips;
+            if (p == player) return nRank;
+        }
+        throw new IllegalStateException("no rank for " + player);
+    }
+
+    @Test
+    public void countsPlayersWithStrictlyMoreChips()
+    {
+        PokerPlayer a = add(1, 1000);
+        PokerPlayer b = add(2, 900);
+        PokerPlayer c = add(3, 800);
+
+        assertEquals(1, game_.getRank(a));
+        assertEquals(2, game_.getRank(b));
+        assertEquals(3, game_.getRank(c));
+    }
+
+    @Test
+    public void tiedPlayersShareARank()
+    {
+        PokerPlayer a = add(1, 1000);
+        PokerPlayer b = add(2, 900);
+        PokerPlayer c = add(3, 900);
+        PokerPlayer d = add(4, 700);
+
+        assertEquals(1, game_.getRank(a));
+        assertEquals("tied players share the better rank", 2, game_.getRank(b));
+        assertEquals("tied players share the better rank", 2, game_.getRank(c));
+        assertEquals("the rank after a tie skips the shared spot", 4, game_.getRank(d));
+    }
+
+    @Test
+    public void rankIsIndependentOfPlayerListOrder()
+    {
+        // added shortest stack first - rank must not depend on insertion order
+        PokerPlayer small = add(1, 100);
+        PokerPlayer big = add(2, 5000);
+
+        assertEquals(1, game_.getRank(big));
+        assertEquals(2, game_.getRank(small));
+    }
+
+    /**
+     * The equivalence claim, over a randomized field with plenty of ties.
+     */
+    @Test
+    public void matchesLegacySortBasedResult()
+    {
+        Random random = new Random(20260811L);
+        for (int i = 1; i <= 200; i++)
+        {
+            // small range of stack sizes so ties are common
+            add(i, random.nextInt(12) * 100);
+        }
+
+        for (int i = 0; i < game_.getNumPlayers(); i++)
+        {
+            PokerPlayer p = game_.getPokerPlayerAt(i);
+            assertEquals("rank differs for " + p.getName() + " with $" + p.getChipCount(),
+                         legacyRank(p), game_.getRank(p));
+        }
+    }
+
+    /**
+     * Deliberate difference from the sort-based version, which returned 0 here.  The
+     * state does not arise in a live tournament, and 1 is the correct answer for it -
+     * 0 also suppressed the rank entirely in the Rank dashboard item.
+     */
+    @Test
+    public void allPlayersBrokeRanksFirstRatherThanZero()
+    {
+        PokerPlayer a = add(1, 0);
+        PokerPlayer b = add(2, 0);
+
+        assertEquals(1, game_.getRank(a));
+        assertEquals(1, game_.getRank(b));
+        assertEquals("legacy version returned 0 here", 0, legacyRank(a));
+    }
+
+    /**
+     * TournamentSummaryPanel indexes getPlayersByRank() by payout spot to show "Name paid
+     * $X", so the position of an already-paid finisher in that list has to be stable while
+     * a hand is in progress.  It is, but only because SortChips breaks ties among zero-chip
+     * players by place: a live player who is all-in has zero live chips and no place yet,
+     * so place 0 keeps them ahead of every finisher.  Without that tiebreak they would
+     * slide into the finished group and shift every paid player down a row.
+     */
+    @Test
+    public void allInPlayerDoesNotDisplaceFinishersInRankOrder()
+    {
+        PokerTable table = new PokerTable(game_, 1);
+
+        PokerPlayer leader = new PokerPlayer(1, "Leader", true);
+        leader.setChipCount(1000);
+        leader.newSimulatedHand();
+        leader.setTable(table, 0);
+        game_.addPlayer(leader);
+
+        PokerPlayer allin = new PokerPlayer(2, "AllIn", true);
+        allin.setChipCount(500);
+        allin.newSimulatedHand();
+        allin.setTable(table, 1);
+        game_.addPlayer(allin);
+
+        PokerPlayer third = add(3, 0);
+        third.setPlace(3);
+        PokerPlayer fourth = add(4, 0);
+        fourth.setPlace(4);
+
+        // hand in progress, AllIn shoves their whole stack into the pot
+        table.setHoldemHand(new HoldemHand());
+        allin.setChipCount(0);
+
+        List<PokerPlayer> rank = game_.getPlayersByRank();
+        assertEquals("live players stay ahead of finishers", leader, rank.get(0));
+        assertEquals("an all-in player is still a live player", allin, rank.get(1));
+        assertEquals("paid finishers keep their index", third, rank.get(2));
+        assertEquals("paid finishers keep their index", fourth, rank.get(3));
+    }
+
+    @Test
+    public void throwsForPlayerNotInTheGame()
+    {
+        add(1, 1000);
+        PokerPlayer stranger = new PokerPlayer(99, "Stranger", true);
+        stranger.setChipCount(500);
+
+        try
+        {
+            game_.getRank(stranger);
+            fail("expected ApplicationError for a player not in the game");
+        }
+        catch (ApplicationError expected)
+        {
+            // expected
+        }
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
@@ -35,6 +35,7 @@ package com.donohoedigital.games.poker;
 import com.donohoedigital.base.ApplicationError;
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.games.poker.model.TournamentProfile;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -58,12 +60,47 @@ public class PokerGameRankTest
     {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
         game_ = new PokerGame(null);
+        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
     }
 
     private PokerPlayer add(int nId, int nChips)
     {
         PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
         p.setChipCount(nChips);
+        game_.addPlayer(p);
+        return p;
+    }
+
+    private PokerTable table(int nNum)
+    {
+        PokerTable t = new PokerTable(game_, nNum);
+        t.setMinChip(1); // HoldemHand.addToPot() divides by this
+        return t;
+    }
+
+    /**
+     * Put a hand in progress at the table, far enough along that chips can be committed.
+     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
+     * needs it before any bet is recorded.
+     */
+    private HoldemHand startHand(PokerTable table)
+    {
+        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
+        HoldemHand hhand = new HoldemHand(table);
+        table.setHoldemHand(hhand);
+        hhand.deal();
+        return hhand;
+    }
+
+    /**
+     * Seat a player, snapshotting their chips as the count at the start of the hand.
+     */
+    private PokerPlayer seat(PokerTable table, int nSeat, int nId, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
+        p.setChipCount(nChips);
+        p.newSimulatedHand();
+        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
         game_.addPlayer(p);
         return p;
     }
@@ -173,18 +210,18 @@ public class PokerGameRankTest
     @Test
     public void allInPlayerDoesNotDisplaceFinishersInRankOrder()
     {
-        PokerTable table = new PokerTable(game_, 1);
+        PokerTable table = table(1);
 
         PokerPlayer leader = new PokerPlayer(1, "Leader", true);
         leader.setChipCount(1000);
         leader.newSimulatedHand();
-        leader.setTable(table, 0);
+        table.setPlayer(leader, 0);
         game_.addPlayer(leader);
 
         PokerPlayer allin = new PokerPlayer(2, "AllIn", true);
         allin.setChipCount(500);
         allin.newSimulatedHand();
-        allin.setTable(table, 1);
+        table.setPlayer(allin, 1);
         game_.addPlayer(allin);
 
         PokerPlayer third = add(3, 0);
@@ -192,8 +229,8 @@ public class PokerGameRankTest
         PokerPlayer fourth = add(4, 0);
         fourth.setPlace(4);
 
-        // hand in progress, AllIn shoves their whole stack into the pot
-        table.setHoldemHand(new HoldemHand());
+        // hand in progress and AllIn has no chips left in front of them
+        startHand(table);
         allin.setChipCount(0);
 
         List<PokerPlayer> rank = game_.getPlayersByRank();
@@ -201,6 +238,58 @@ public class PokerGameRankTest
         assertEquals("an all-in player is still a live player", allin, rank.get(1));
         assertEquals("paid finishers keep their index", third, rank.get(2));
         assertEquals("paid finishers keep their index", fourth, rank.get(3));
+    }
+
+    /**
+     * Tables are not in step with each other - online they are independent state
+     * machines - so a rank computed while one table is mid-hand must not sink the
+     * players sitting at it.  This is the shape of the online bug: the Rank dashboard
+     * item recomputes when another table finishes a hand, which lands in the middle of
+     * ours, and PlayerInfo recomputes on every mouse-over.
+     */
+    @Test
+    public void comparesSettledChipsAcrossTablesMidHand()
+    {
+        PokerTable mine = table(1);
+        PokerTable theirs = table(2);
+
+        PokerPlayer doug = seat(mine, 0, 1, 1000);
+        seat(mine, 1, 98, 1); // a hand needs two players
+        PokerPlayer rival = seat(theirs, 0, 2, 0);
+
+        // my table is mid-hand - dealing put my blind in the pot - and theirs is between
+        // hands.  Park the rival between my live count and my settled one.
+        HoldemHand hhand = startHand(mine);
+        int nCommitted = hhand.getTotalBet(doug);
+        assertTrue("expected the deal to commit chips", nCommitted > 1);
+        rival.setChipCount(1000 - nCommitted + 1);
+
+        assertTrue("live counts would invert these two",
+                   doug.getChipCount() < rival.getChipCount());
+
+        assertEquals("chips in the pot must not cost me a place", 1, game_.getRank(doug));
+        assertEquals(2, game_.getRank(rival));
+    }
+
+    /**
+     * The mid-hand player must not gain a place either - only the chips actually
+     * committed are restored, not the pot they might win.
+     */
+    @Test
+    public void settledChipsDoNotOverstateTheMidHandPlayer()
+    {
+        PokerTable mine = table(1);
+        PokerTable theirs = table(2);
+
+        PokerPlayer doug = seat(mine, 0, 1, 900);
+        seat(mine, 1, 98, 1); // a hand needs two players
+        PokerPlayer rival = seat(theirs, 0, 2, 950);
+
+        HoldemHand hhand = startHand(mine);
+        assertTrue("expected the deal to commit chips", hhand.getTotalBet(doug) > 0);
+
+        assertEquals("still behind on settled chips", 2, game_.getRank(doug));
+        assertEquals(1, game_.getRank(rival));
     }
 
     @Test

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
@@ -1,0 +1,148 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.config.ApplicationType;
+import com.donohoedigital.config.ConfigManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies PokerGame.getSettledChipCount() reports a player's chips as of the last
+ * point they were settled.  getChipCount() is decremented the moment a bet is
+ * committed and not credited back until the pot is awarded, so standings computed
+ * while a hand is in progress used to sink whoever had chips in the pot - which is
+ * everyone at the current table for most of its hand.
+ */
+public class PokerGameSettledChipsTest
+{
+    private PokerGame game_;
+
+    @Before
+    public void setUp()
+    {
+        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
+        game_ = new PokerGame(null);
+    }
+
+    /**
+     * Seat a player holding the given chips, with that count snapshotted as their
+     * chip count at the start of the hand.
+     */
+    private PokerPlayer seat(PokerTable table, int nSeat, int nId, String sName, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, sName, true);
+        p.setChipCount(nChips);
+        p.newSimulatedHand(); // snapshots nChipsAtStart_
+        p.setTable(table, nSeat);
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * Commit chips to the pot the way a bet does - straight off the live stack,
+     * leaving the start-of-hand snapshot alone.
+     */
+    private void commitToPot(PokerPlayer p, int nAmount)
+    {
+        p.setChipCount(p.getChipCount() - nAmount);
+    }
+
+    @Test
+    public void reportsStartOfHandChipsWhileHandInProgress()
+    {
+        PokerTable table = new PokerTable(game_, 1);
+        PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
+        table.setHoldemHand(new HoldemHand());
+        assertTrue("expected a hand in progress", table.isHandInProgress());
+
+        commitToPot(doug, 100);
+
+        assertEquals("live count reflects the bet", 900, doug.getChipCount());
+        assertEquals("settled count ignores the bet", 1000, game_.getSettledChipCount(doug));
+    }
+
+    @Test
+    public void reportsLiveChipsBetweenHands()
+    {
+        PokerTable table = new PokerTable(game_, 1);
+        PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
+        assertFalse("expected no hand in progress", table.isHandInProgress());
+
+        // pot awarded - the live count is the settled count once the hand is over
+        doug.setChipCount(1400);
+
+        assertEquals(1400, game_.getSettledChipCount(doug));
+    }
+
+    @Test
+    public void reportsLiveChipsWhenPlayerHasNoTable()
+    {
+        PokerPlayer doug = new PokerPlayer(1, "Doug", true);
+        doug.setChipCount(1000);
+        game_.addPlayer(doug);
+
+        assertEquals(1000, game_.getSettledChipCount(doug));
+    }
+
+    /**
+     * The regression this all exists for: mid-hand, a player with chips committed
+     * must not be ranked below a rival at a settled table whom they are actually
+     * still ahead of.
+     */
+    @Test
+    public void midHandPlayerIsNotSunkBelowSettledRivals()
+    {
+        PokerTable mine = new PokerTable(game_, 1);
+        PokerTable theirs = new PokerTable(game_, 2);
+
+        PokerPlayer doug = seat(mine, 0, 1, "Doug", 1000);
+        PokerPlayer rival = seat(theirs, 0, 2, "Rival", 950);
+
+        // my table is mid-hand, theirs has finished
+        mine.setHoldemHand(new HoldemHand());
+        commitToPot(doug, 100);
+
+        // live counts have me behind, which is the bug
+        assertTrue("live comparison sinks the mid-hand player",
+                   doug.getChipCount() < rival.getChipCount());
+
+        // settled counts have me ahead, which is the truth
+        assertTrue("settled comparison keeps the mid-hand player ahead",
+                   game_.getSettledChipCount(doug) > game_.getSettledChipCount(rival));
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
@@ -34,6 +34,7 @@ package com.donohoedigital.games.poker;
 
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.games.poker.model.TournamentProfile;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +58,14 @@ public class PokerGameSettledChipsTest
     {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
         game_ = new PokerGame(null);
+        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
+    }
+
+    private PokerTable table(int nNum)
+    {
+        PokerTable t = new PokerTable(game_, nNum);
+        t.setMinChip(1); // HoldemHand.addToPot() divides by this
+        return t;
     }
 
     /**
@@ -68,38 +77,74 @@ public class PokerGameSettledChipsTest
         PokerPlayer p = new PokerPlayer(nId, sName, true);
         p.setChipCount(nChips);
         p.newSimulatedHand(); // snapshots nChipsAtStart_
-        p.setTable(table, nSeat);
+        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
         game_.addPlayer(p);
         return p;
     }
 
     /**
-     * Commit chips to the pot the way a bet does - straight off the live stack,
-     * leaving the start-of-hand snapshot alone.
+     * Put a hand in progress at the table, far enough along that chips can be committed.
+     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
+     * needs it before any bet is recorded.
      */
-    private void commitToPot(PokerPlayer p, int nAmount)
+    private HoldemHand startHand(PokerTable table)
     {
-        p.setChipCount(p.getChipCount() - nAmount);
+        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
+        HoldemHand hhand = new HoldemHand(table);
+        table.setHoldemHand(hhand);
+        hhand.deal();
+        return hhand;
     }
 
     @Test
     public void reportsStartOfHandChipsWhileHandInProgress()
     {
-        PokerTable table = new PokerTable(game_, 1);
+        PokerTable table = table(1);
         PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
-        table.setHoldemHand(new HoldemHand());
+        seat(table, 1, 99, "Opponent", 1000); // a hand needs two players
+        HoldemHand hhand = startHand(table);
         assertTrue("expected a hand in progress", table.isHandInProgress());
 
-        commitToPot(doug, 100);
+        // dealing posts the blinds, which is chips out of the stack and into the pot
+        int nCommitted = hhand.getTotalBet(doug);
+        assertTrue("expected the deal to commit chips", nCommitted > 0);
 
-        assertEquals("live count reflects the bet", 900, doug.getChipCount());
-        assertEquals("settled count ignores the bet", 1000, game_.getSettledChipCount(doug));
+        assertEquals("live count is down by what is in the pot",
+                     1000 - nCommitted, doug.getChipCount());
+        assertEquals("settled count is the stack before it went in",
+                     1000, game_.getSettledChipCount(doug));
+    }
+
+    /**
+     * PokerTable.startNewHand() fires TYPE_NEW_HAND from setHoldemHand() and only then
+     * calls deal(), which is what snapshots PokerPlayer.getChipCountAtStart().  Anything
+     * recomputing on that event sees a hand in progress with nothing committed yet, and
+     * must report the live count - the start-of-hand snapshot is still the *previous*
+     * hand's at that instant.
+     */
+    @Test
+    public void reportsLiveChipsAfterNewHandFiresButBeforeTheDeal()
+    {
+        PokerTable table = table(1);
+        PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
+
+        // won the last hand - live count is now settled at 1400, but the snapshot still
+        // holds 1000 until the next deal calls PokerPlayer.newHand()
+        doug.setChipCount(1400);
+        assertEquals("snapshot is deliberately stale here", 1000, doug.getChipCountAtStart());
+
+        // new hand created and TYPE_NEW_HAND fired; deal() has not run
+        table.setHoldemHand(new HoldemHand(table));
+        assertTrue(table.isHandInProgress());
+
+        assertEquals("must not report the previous hand's snapshot",
+                     1400, game_.getSettledChipCount(doug));
     }
 
     @Test
     public void reportsLiveChipsBetweenHands()
     {
-        PokerTable table = new PokerTable(game_, 1);
+        PokerTable table = table(1);
         PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
         assertFalse("expected no hand in progress", table.isHandInProgress());
 
@@ -127,15 +172,20 @@ public class PokerGameSettledChipsTest
     @Test
     public void midHandPlayerIsNotSunkBelowSettledRivals()
     {
-        PokerTable mine = new PokerTable(game_, 1);
-        PokerTable theirs = new PokerTable(game_, 2);
+        PokerTable mine = table(1);
+        PokerTable theirs = table(2);
 
         PokerPlayer doug = seat(mine, 0, 1, "Doug", 1000);
-        PokerPlayer rival = seat(theirs, 0, 2, "Rival", 950);
+        seat(mine, 1, 99, "Opponent", 1000); // a hand needs two players
+        PokerPlayer rival = seat(theirs, 0, 2, "Rival", 0);
 
-        // my table is mid-hand, theirs has finished
-        mine.setHoldemHand(new HoldemHand());
-        commitToPot(doug, 100);
+        // my table is mid-hand, theirs is between hands
+        HoldemHand hhand = startHand(mine);
+        int nCommitted = hhand.getTotalBet(doug);
+        assertTrue("expected the deal to commit chips", nCommitted > 1);
+
+        // park the rival between my live count and my settled one
+        rival.setChipCount(1000 - nCommitted + 1);
 
         // live counts have me behind, which is the bug
         assertTrue("live comparison sinks the mid-hand player",


### PR DESCRIPTION
Alternate fix for the stale Rank panel reported in #214. Thanks to @Snotface for the
report and the detailed trace — the panel really was stale, it had been for a long time,
and digging into why turned up more than the original bug.

## Two separate problems

**1. The Rank panel did not refresh when a hand ended.** It subscribed to `TYPE_NEW_HAND`
and `TYPE_PLAYER_CHIPS_CHANGED`, but `TYPE_PLAYER_CHIPS_CHANGED` is fired from exactly one
place in the codebase — the cheat menu's change-chip-count option — so in normal play
`TYPE_NEW_HAND` was the only recurring trigger. That fires from `setHoldemHand()`, i.e. when
the *next* hand is dealt. With auto deal off, the tournament director parks in
`STATE_BEGIN_WAIT` until the Deal button is pressed, so you could win a pot, watch your stack
grow, and have the panel keep showing your pre-hand standing for as long as you sat there.

**2. The rank itself was computed from live chip counts.** `getChipCount()` is decremented
the instant a blind, ante or bet is committed, and is not credited back until the pot is
awarded. A rank is a comparison across the whole tournament and tables are not in step with
each other, so comparing live counts sinks whoever happens to have chips in a pot.

Problem 2 is why #214's trace showed 1st → 5623rd within a single hand. That figure is
dominated by the human's own blind sitting in the pot while every all-computer table is
settled — at hand 1 in a 5,625 player field, ~5,600 players are at or above the starting
stack while yours is starting-stack-minus-the-blind. The staleness was real; the magnitude
was an artifact of the same live-chip accounting this PR fixes.

## The fix

**`Rank` now also listens to `TYPE_END_HAND`.** That event already existed — it is fired at
the end of `HoldemHand.resolve()`, once the pot has been awarded — and `MyHand` and `Odds`
already used it. No new event type, so no change to what `PokerAI` sees.

In a practice game this lands at a moment when the whole tournament is settled: all-computer
tables play their entire hand inside `doBettingAllComputer()`, which runs at the *first*
betting round of the current table's hand, so by the time our hand resolves they have already
finished the same hand. `TYPE_NEW_HAND` is still subscribed — busted players are not removed
and tables are not consolidated until the next hand's clean-up, so it is what corrects the
"out of N players at M tables" half of the message.

**`PokerGame.getRank()` now compares settled chips** via a new `getSettledChipCount()`, which
adds back whatever a player has committed to the current pot. This matters most online, where
tables containing a human run as independent state machines:

- On any client, `notifyPlayers()` broadcasts every table's hand-end to *every* player in the
  game, so another table finishing a hand lands at an arbitrary point in yours and recomputed
  your rank with your own chips in the pot.
- On the host, which holds live state for every table, other tables can genuinely be mid-hand
  at our `TYPE_END_HAND`, understating them and overstating our own rank.

Neither is new — `Rank` already recomputed on `PROP_GAME_LOADED` and `STATE_NEW_LEVEL_CHECK`
at arbitrary mid-hand moments — but both are now correct. This also fixes `PlayerInfo`, which
recomputes a hovered player's rank on every mouse-over and is registered for online games only.

Settled chips are computed as `getChipCount() + HoldemHand.getTotalBet(player)` rather than
`PokerPlayer.getChipCountAtStart()` (the BUG 420 idiom in `PokerTable.isRebuyAllowed()`).
The snapshot that idiom reads is taken in `PokerPlayer.newHand()` during `HoldemHand.deal()`,
which runs *after* `startNewHand()` has already fired `TYPE_NEW_HAND` — so reading it on that
event returns the previous hand's value. Summing committed chips is correct whenever it is
read; before any action it is simply zero.

One place still uses the snapshot: all-computer tables, which are a hand ahead of us for the
duration of our hand, get rolled back so every table is reported as of the same point. That
is gated on hand number, because our hand number is incremented before the deal — between our
new hand and our first bet those tables have not played yet and their live count is already
the settled one.

## Also in here

**`getRank()` counts in a single pass** instead of sorting a copy of the player list. Rank is
one more than the number of players holding strictly more chips, which is exactly what the
sort produced. The old version allocated and sorted a 5,625 element list on every call, which
now happens at the end of every hand. The loop bound is re-read each pass rather than captured
up front, because `players_` can shrink from a network thread when a player switches to
observer. Only behavioural difference: a field where every player holds zero now ranks 1
rather than 0 — that state does not arise in a live tournament, and 1 is the correct answer
for it (0 also suppressed the rank entirely in the panel).

**The Leader Board (`ChipLeaderPanel`) now uses settled chips too.** It is a one-shot snapshot
built when the dialog opens, which is always mid-hand, so it disagreed with the Rank panel —
observed showing the human 12th at $1,005 while the panel correctly said 8th. It now captures
each count once and sorts that capture, which also keeps `Collections.sort()` off live mutable
state. The Table List tab shares `PlayerModel` and `RankInfo` and deliberately still shows
live chips so it agrees with the felt; a sentinel keeps the two apart.

## Tests

`PokerGameRankTest` and `PokerGameSettledChipsTest`, neither needing MySQL. Between them they
pin the equivalence of the single-pass count against the old sort-based algorithm over a
200-player randomized field, the tie and all-zero edge cases, the settled-chips comparison
across a mid-hand and a between-hands table, and the `TYPE_NEW_HAND`-before-`deal()` ordering
described above.

They also pin one invariant that was load-bearing and undocumented: live players sort ahead of
finished players even when a live player is all-in with zero chips, because `SortChips` breaks
ties among zero-chip players by place. `TournamentSummaryPanel` indexes `getPlayersByRank()`
by payout spot and silently depends on that.

## Deliberately not done

- No polling. Every refresh is event-driven.
- No new `PokerTableEvent` type, and no event raised after `doBettingAllComputer()` — `PokerAI`
  reacts to `TYPE_PLAYER_CHIPS_CHANGED`, and firing anything for activity elsewhere risks
  changing AI behaviour.
- `getPlayersByRank()` is left on live chips. Its three remaining callers are a cheat, an
  end-of-game history dump, and one panel that only reads the finished players, so none of them
  is affected.

One known issue left alone here: `players_` is mutated from network threads without
synchronization while every ranking path iterates it. This PR narrows the exposure in
`getRank()` by re-reading the loop bound each pass rather than capturing it, but does not
close it.
