### PR TITLE
Add the Player Info dashboard panel to practice games

### DIFF
--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -595,6 +595,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         }
         manager.addItem(new MyTable(context_), false);
         manager.addItem(new Rank(context_), false);
+        manager.addItem(new PlayerInfo(context_), false);
         if (!game_.isOnlineGame() || bDashAdvisor)
         {
             manager.addItem(new DashboardAdvisor(context_), false);
@@ -605,7 +606,6 @@ public class ShowTournamentTable extends ShowPokerTable implements
         if (game_.isOnlineGame())
         {
             manager.addItem(new ObserversDash(context_), false);
-            manager.addItem(new PlayerInfo(context_), false);
         }
 
         manager.addItem(new DebugDash(context_), false);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -135,20 +135,33 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             int numLeft = game_.getNumPlayers() - game_.getNumPlayersOut();
             // if end of tournament, list number of players in tournament
             if (numLeft == 0) numLeft = game_.getNumPlayers();
+
+            // Disconnects and sit-outs can only happen in an online game - nothing in
+            // a practice game sets either flag, so both counters would read zero for
+            // the whole tournament.  Leave the rows out rather than show dead text.
+            String sOnline = !game_.isOnlineGame() ? "" :
+                             PropertyConfig.getMessage("msg.dash.playerinfo.online",
+                                      last_.getHandsPlayedDisconnected(),
+                                      last_.getHandsPlayedSitout());
+
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo",
                                       Utils.encodeHTML(last_.getName()),
-                                      last_.getHandsPlayedDisconnected(),
-                                      last_.getHandsPlayedSitout(),
-                                      sRebuy,
                                       PropertyConfig.getPlace(game_.getRank(last_)),
-                                      numLeft
+                                      numLeft,
+                                      sOnline,
+                                      sRebuy
             ));
         }
         else
         {
+            // keep the same height as when filled in, so the panel does not jump
+            // about as the mouse moves on and off the players
+            String sOnlineSpace = !game_.isOnlineGame() ? "" :
+                                  PropertyConfig.getMessage("msg.dash.playerinfo.online.space");
             String sRebuySpace = "";
             if (game_.getProfile().isRebuys()) sRebuySpace = PropertyConfig.getMessage("msg.dash.rebuy.space");
-            labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.none", sRebuySpace));
+            labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.none",
+                                      sOnlineSpace, sRebuySpace));
         }
 
     }

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1875,17 +1875,18 @@ label.levelx.label=		Level
 label.tname.label=
 
 msg.dash.playerinfo.none= <HTML><font color="white">Player:</font> <font color="yellow">(mouse over a player)</font><BR>\
-							&nbsp;<BR>\
-							&nbsp;<BR>\
 							&nbsp;\
-							{0}
+							{0}{1}
 msg.dash.rebuy.space=		<BR>&nbsp;
 
+# rows built up by PlayerInfo: {3} is the pair of online-only rows, blank in a
+# practice game; {4} is rebuys, blank when the tournament does not allow them
 msg.dash.playerinfo= <HTML><font color="white">Player:</font> <font color="yellow">{0}</font><BR>\
-						Rank:</font> <font color="yellow">{4} of {5}</font><BR>\
-						Disconnected Hands:</font> <font color="yellow">{1}</font><BR>\
-						<font color="white">Sitting-out Hands:</font> <font color="yellow">{2}</font>\
-						{3}
+						<font color="white">Rank:</font> <font color="yellow">{1} of {2}</font>\
+						{3}{4}
+msg.dash.playerinfo.online=	<BR><font color="white">Disconnected Hands:</font> <font color="yellow">{0}</font><BR>\
+							<font color="white">Sitting-out Hands:</font> <font color="yellow">{1}</font>
+msg.dash.playerinfo.online.space= <BR>&nbsp;<BR>&nbsp;
 
 msg.dash.rebuy=		<BR><font color="white">Rebuys Left:</font> <font color="yellow">{0}</font>
 msg.dash.rebuy.none= None


### PR DESCRIPTION
The Player Info panel is added to the dashboard for online games only.  Two of
its four rows are the reason: disconnected hands and sitting-out hands.  Both
counters are incremented in PokerPlayer.endHand(), guarded by isDisconnected()
and isSittingOut(), and every caller that sets either flag is an online one -
OnlineManager, the online TournamentDirector, OnlineDash, the sit-out button,
and PokerGame's own call, which is gated on the game being online.  In a
practice game both would read zero for the entire tournament.

The rest of the panel is just as true in practice.  The rank and the number of
players left are tournament-wide, rebuys apply in any tournament that allows
them - computer players do rebuy, with a propensity rolled per player when they
are created - and the mouse-over mechanism is the one the Player Style panel
already uses in practice games.

So the two rows are emitted only for an online game, rather than the panel
being held back from practice.  The message is now assembled from optional
fragments, the way the rebuy row already was, and the placeholder text pads to
match so the panel does not change height as the mouse moves on and off the
players.

The panel is registered once, unconditionally, next to the other tournament
panels rather than at the end of the online-only block.  Online players will
find it slightly higher in the dashboard list than before; it can be moved with
the dashboard editor as usual.

Co-authored by Claude (Anthropic, Claude Code)
