### PR TITLE
Installer upgrades adopted from DD Photos and Version 3.1.7 prep

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -289,7 +289,10 @@ find the constants and then find usages of those constants.
 
 ### Installers
 
-An alternative to using the installers found in [Releases](https://github.com/dougdonohoe/ddpoker/releases)
+The installers in [Releases](https://github.com/dougdonohoe/ddpoker/releases) are built with
+`install4j` — see [Appendix H](#appendix-h-releasing-a-new-version) for the release process.
+
+An alternative to using those installers
 is to distribute an all-in-one `.jar` file by doing this:
 
 ```shell
@@ -654,3 +657,72 @@ current working directory.  To preview the site run:
 python3 -m http.server 8000
 ```
 
+
+## Appendix H: Releasing a New Version
+
+### Prep
+
+* Add the new version to the top of the `VERSION` history in
+  `code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java`
+  (most recent first - nothing needs commenting out).
+* Add a matching entry at the top of
+  `code/poker/src/main/resources/config/poker/help/whatsnew.html`.  The release notes
+  are generated from this entry, so the version in its header must match the new version
+  exactly.
+* Commit everything, since the GitHub release tags the code.
+* Plug in the code signing USB token.
+* Have KeePassXC ready for the signing passwords.
+
+### Build and release
+
+```shell
+# Build everything to ~/builds/poker3.x/full/ddpoker/installer/builds
+buildall -full -clean
+
+# Inspect / validate the installers if desired
+
+# Rehearse the release: drafts the notes, echoes the gh command, changes nothing
+buildall -full -github-dryrun
+
+# Release to GitHub
+buildall -full -github
+```
+
+`-full` builds in a **separate clone** at `~/builds/poker3.x/full/ddpoker`, not this
+working tree.  `-github` skips the git, mvn, unpack, buildrelease and installer steps,
+assuming a `-full` run already produced and validated the installers.
+
+### What `-github` does
+
+1. Checks the build clone isn't behind `origin/main` and that all three installers exist,
+   failing before anything is published.  Since `-github` skips the git step, a stale clone
+   means both a bad README push and installers built from old code - re-run `-full` if it
+   complains.
+2. Generates release notes from the `whatsnew.html` entry for this version into
+   `installer/builds/release_notes_<version>.md`, converting each `<li>` to a Markdown
+   bullet (`<tt>` becomes code, `<b>` becomes bold), then appending a **Full Changelog**
+   compare link against the previous release and the `md5sums.txt` block.
+3. Prints the drafted notes and waits for approval before running `gh release create`.
+4. Rewrites the installer links in `README.md` between the
+   `<!-- installers:begin ... -->` / `<!-- installers:end -->` markers, shows the diff,
+   and asks before committing and pushing.
+5. Runs `git pull --tags` in the directory you launched `buildall` from, so this working
+   tree picks up the new tag and the README commit that were made in the build clone.
+   That last step is skipped, with a note saying why, if you didn't run from a git repo,
+   if that repo isn't on `main`, or if you ran from the build clone itself (`-dev`).  A
+   failure there is only a warning - the release is already published at that point, so a
+   dirty working tree won't be reported as a broken build.
+
+**Do not hand-edit the marked block in `README.md`** - anything inside those markers is
+regenerated.  Put wording you want kept outside them.
+
+### Developing the installer locally
+
+* `install4j` has a UI for editing `installer/install4j/poker.install4j`; under _Build_
+  you can selectively choose which media files to build.
+* Use `buildall -dev` to build into this working tree instead of the build clone.
+* The `-nogit`, `-nomvn`, `-nounpack`, `-nobuildrelease`, `-noinstaller` and `-nonotarize`
+  options skip individual steps, which saves a lot of time when iterating.  Run `buildall`
+  with no arguments to list them all.
+* Installer file names come from the `mediaFileName` attribute on each media set in
+  `poker.install4j` and must stay in step with the `@PLATFORMS` table in `buildall.pl`.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ no longer run a server, but you can run your own using the code in this repo.
 
 ## Installers
 
-See [Releases](https://github.com/dougdonohoe/ddpoker/releases) for the latest Mac, Linux and Windows installers.
+<!-- installers:begin (updated by tools/bin/buildall.pl -github) -->
+Download the latest release, **3.1.6**:
+
+- **Mac**: [ddpoker3_1_6.dmg](https://github.com/dougdonohoe/ddpoker/releases/download/3.1.6/ddpoker3_1_6.dmg)
+- **Windows**: [ddpoker3_1_6.exe](https://github.com/dougdonohoe/ddpoker/releases/download/3.1.6/ddpoker3_1_6.exe)
+- **Linux**: [ddpoker3_1_6.sh](https://github.com/dougdonohoe/ddpoker/releases/download/3.1.6/ddpoker3_1_6.sh)
+<!-- installers:end -->
+
+See [Releases](https://github.com/dougdonohoe/ddpoker/releases) for release notes and older versions.
 
 [<img src="images/install4j_small.png">](https://www.ej-technologies.com/install4j)
 Installers are built by [Donohoe Digital LLC](https://www.donohoedigital.com/) 
@@ -64,7 +72,7 @@ the [Developer Notes](README-DEV.md) explains.
 
 ## TL;DR Running DD Poker From Source
 
-If you are impatient and just want to run the DD Poker game without
+If you are an impatient developer and just want to run the DD Poker game without
 reading all the [developer documentation](README-DEV.md) or worrying
 about servers and databases, follow these steps:
 

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -46,17 +46,39 @@
 </table>
 <br>
 
+<!-- 3.1.7 -->
+
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.7 - TBD</span></strong>
+</div>
+<ul>
+    <li>
+        Fixed out-of-memory errors in large-field tournaments, which could crash the game while
+        dealing or cause <b>Save</b> to silently do nothing.  The game had been limited to 68 MB of
+        memory since 2004; it now gets 512 MB.  Thanks to <b>Snotface</b> for the report and the fix.
+    </li>
+    <li>
+        The <b>Rank</b> dashboard panel now updates at the end of every hand instead of waiting for the
+        next hand to be dealt, and ranks players on their settled chip counts, so chips committed to
+        the current pot no longer make your standing look worse than it is.
+    </li>
+    <li>
+        The <b>Player Info</b> dashboard panel is now available in practice games, not just online
+        games.  Thanks to <b>Snotface</b> for the contribution.
+    </li>
+    <li>
+        The deck chooser no longer offers to create folders or rename files.
+    </li>
+    <li>
+        Incorporating updates to various software dependencies.
+    </li>
+</ul>
+
 <!-- 3.1.6 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.6 - January 8, 2026
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.6 - January 8, 2026</span></strong>
+</div>
 <ul>
     <li>
         Upgrade to Java 25.
@@ -68,15 +90,9 @@
 
 <!-- 3.1.5 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.5 - May 18, 2025
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.5 - May 18, 2025</span></strong>
+</div>
 <ul>
     <li>
         Upgrade to Java 21.
@@ -88,15 +104,9 @@
 
 <!-- 3.1.4 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.4 - November 10, 2024
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.4 - November 10, 2024</span></strong>
+</div>
 <ul>
     <li>
         Upgrade to Java 17.
@@ -108,15 +118,9 @@
 
 <!-- 3.1.3 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.3 - November 9, 2024
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.3 - November 9, 2024</span></strong>
+</div>
 <ul>
     <li>
         Upgrade to Java 11.
@@ -128,15 +132,9 @@
 
 <!-- 3.1.2 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.2 - October 20, 2024
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.2 - October 20, 2024</span></strong>
+</div>
 <ul>
     <li>
         Restore handling of <tt>.ddpokerjoin</tt> files to Mac (installer fix).
@@ -148,15 +146,9 @@
 
 <!-- 3.1.1 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1.1 - September 8, 2024
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.1 - September 8, 2024</span></strong>
+</div>
 <ul>
     <li>
         Windows installer!
@@ -165,15 +157,9 @@
 
 <!-- 3.1 open source -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.1 - August 30, 2024
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1 - August 30, 2024</span></strong>
+</div>
 <ul>
     <li>
         DD Poker lives to see another day, now as open source software.
@@ -185,15 +171,9 @@
 
 <!-- 3.0p6 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p6 - June 20, 2020
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p6 - June 20, 2020</span></strong>
+</div>
 <ul>
     <li>
         Prolonged life support.  Update to Java 8, testing all-in-one.jar.
@@ -202,15 +182,9 @@
 
 <!-- The End -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                DD Poker Farewell - July 31, 2017
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">DD Poker Farewell - July 31, 2017</span></strong>
+</div>
 <ul>
     <li>
         DD Poker shutdown (although the game will still work offline and for private games).
@@ -219,15 +193,9 @@
 
 <!-- 3.0p5 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p5 - April 19, 2014 (Mac Only)
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p5 - April 19, 2014 (Mac Only)</span></strong>
+</div>
 <ul>
     <li>
         Update to workaround bug introduced by Apple's Java update to 1.6.0_65 (from 1.6.0_31).
@@ -236,15 +204,9 @@
 
 <!-- 3.0p4 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p4 - July 23, 2011
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p4 - July 23, 2011</span></strong>
+</div>
 <ul>
     <li>
         Verify Online Activated player profiles before joining any game to prevent profile hijacking.
@@ -253,15 +215,9 @@
 
 <!-- 3.0p3 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p3 - July 1, 2011
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p3 - July 1, 2011</span></strong>
+</div>
 <ul>
     <li>
         Added "Online Activated Players Only" tournament option to prevent impostors from joining games.
@@ -270,15 +226,9 @@
 
 <!-- 3.0p2 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p2 - August 2, 2009 (Mac Only)
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p2 - August 2, 2009 (Mac Only)</span></strong>
+</div>
 <ul>
     <li>
         Fixed font bug introduced by Apple's Java for Mac OS X 10.5 Update 4.
@@ -287,15 +237,9 @@
 
 <!-- 3.0p1 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">
-                Version 3.0p1 - February 15th, 2009
-            </font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.0p1 - February 15th, 2009</span></strong>
+</div>
 <ul>
     <li>
         Fixed bug where multiple side pots were incorrectly calculated.
@@ -329,14 +273,9 @@
 
 <!-- 3.0 -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">DD Poker 3.0
-                - Totally Free! - January 2009</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">DD Poker 3.0 - Totally Free! - January 2009</span></strong>
+</div>
 <ul>
     <li>Most changes were related to making DD Poker a free product (including updates
         to the server and website).
@@ -358,14 +297,9 @@
 
 <!-- 2.x -->
 
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 15 (Version 2.5p3) - February 18th,
-                2007</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 15 (Version 2.5p3) - February 18th, 2007</span></strong>
+</div>
 <ul>
     <li>Fixed an &quot;unexpected error&quot; bug that occurred during a table merge and
         color up.
@@ -373,26 +307,15 @@
     <li>Returned the card shuffle back to the redundant 3X shuffle removed in the 2.5 update.</li>
     <li>Fixed a very minor customer requested shuffle bug.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center">
-                <strong><font color="#FFFF00" size="+1">Free Update 13 &amp; 14 (Version 2.5p2) - July 11th, 2006</font></strong>
-            </div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 13 &amp; 14 (Version 2.5p2) - July 11th, 2006</span></strong>
+</div>
 <ul>
     <li>This release fixes some bugs introduced in version 2.5.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 12 (Version 2.5) - July 5th,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 12 (Version 2.5) - July 5th, 2006</span></strong>
+</div>
 <p><font color="#1D4A07"><strong>Mac system requirements:</strong> Mac users are
     required to update to MacOS 10.4.5 (Tiger) or higher and Java 5 in order to
     install free update 12 or later.</font></p>
@@ -485,26 +408,16 @@
         (CTRL/Apple-U)
     </li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 11 (Version 2.1p1) - April 7th,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 11 (Version 2.1p1) - April 7th, 2006</span></strong>
+</div>
 <ul>
     <li>Fixed an online bug introduced in free update 10 that worsened the effects of brief disconnects.</li>
     <li>Added Mac Intel Core compatibility.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 10 (Version 2.1) - April 5th,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 10 (Version 2.1) - April 5th, 2006</span></strong>
+</div>
 <ul>
     <li>Major computer AI improvements.</li>
     <li>New AI player personalities.</li>
@@ -520,14 +433,9 @@
     </li>
     <li>Improved the online player transition from the poker lobby to the poker table.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 9 (Version 2.0p9) - March 5th,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 9 (Version 2.0p9) - March 5th, 2006</span></strong>
+</div>
 <ul>
     <li>Improvements to the pre-flop intelligence of the computer AI making better decisions based on position and first
         player in the pot.
@@ -538,14 +446,9 @@
         profiles.
     </li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 8 (Version 2.0p8) - February 5th,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 8 (Version 2.0p8) - February 5th, 2006</span></strong>
+</div>
 <ul>
     <li>Added the &quot;Player Info&quot; DD Dash item for online games showing player's ranks, hands disconnected and
         sitting-out.
@@ -558,25 +461,15 @@
     <li>Added a statement to the host quit confirmation dialog concerning the etiquette of quitting a hosted game.</li>
     <li>Added more Leaderboard functionality with a server side code update.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 7 (Version 2.0p7) - January 5,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 7 (Version 2.0p7) - January 5, 2006</span></strong>
+</div>
 <ul>
     <li>Fixed a minor bug introduced in free update 6 where the showdown placards displayed the wrong cards.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 6 (Version 2.0p6) - January 5,
-                2006</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 6 (Version 2.0p6) - January 5, 2006</span></strong>
+</div>
 <ul>
     <li>Increased the maximum buy-in chip amount to accommodate for tournament structures with larger starting chips.
     </li>
@@ -587,14 +480,9 @@
     </li>
     <li>Fixed auto update problems for some individuals with a server side code fix.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 5 (Version 2.0p5) - December 5,
-                2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 5 (Version 2.0p5) - December 5, 2005</span></strong>
+</div>
 <ul>
     <li>Added a mute feature to allow users to mute all chat from an individual player if they find their chat is
         annoying or offensive. When a player is muted they are automatically added to a muted player list and are muted
@@ -603,39 +491,24 @@
     <li>Added a banned players list. Prohibits any players you add to the list to join your hosted online games.</li>
     <li>Option to disable the keyboard shortcuts to avoid accidental player actions when chatting online.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 4 (Version 2.0p4) - October 15,
-                2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 4 (Version 2.0p4) - October 15, 2005</span></strong>
+</div>
 <ul>
     <li>Big improvement with online disconnect issues.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 3 (Version 2.0p3) - October 10,
-                2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 3 (Version 2.0p3) - October 10, 2005</span></strong>
+</div>
 <ul>
     <li>Improved online stability reducing disconnect issues.</li>
     <li>Faster indication of online disconnects.</li>
     <li>Fixed an export formatting issue that caused Poker Tracker to crash when replaying hands won before flop.</li>
     <li>Pause online tournament at start option now actually works.</li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 2 (Version
-                2.0p2) - October 5, 2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 2 (Version 2.0p2) - October 5, 2005</span></strong>
+</div>
 <ul>
     <li>Online host feature that sends an automatic personal greeting to each player that joins their game.</li>
     <li>Set the maximum number of players per table (2-10).</li>
@@ -653,14 +526,9 @@
         blind. <br>
     </li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td>
-            <div align="center"><strong><font color="#FFFF00" size="+1">Free Update 1 (Version
-                2.0p1) - September 5, 2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Free Update 1 (Version 2.0p1) - September 5, 2005</span></strong>
+</div>
 <ul>
     <li>Online host option to enable the use of the dashboard <a href="advisor.html">Advisor</a>,
         odds and the <a href="calculator.html">Calculator Tool</a> during online play.
@@ -680,14 +548,9 @@
     <li>A few small bug fixes dealing with an action button freeze and alt-tab fixes. <br>
     </li>
 </ul>
-<table width="100%" border="1">
-    <tr bgcolor="#1D4A07">
-        <td colspan="2">
-            <div align="center"><strong><font color="#FFFF00" size="+1">Version
-                2.0 - August 5, 2005</font></strong></div>
-        </td>
-    </tr>
-</table>
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 2.0 - August 5, 2005</span></strong>
+</div>
 <p align="center" size="+1"><strong><font size="+1">Computer AI &quot;Artificial Intelligence&quot;</font></strong><font
         size="+1"></font></font> </p>
 

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -48,26 +48,37 @@ import com.donohoedigital.p2p.P2PURL;
  */
 public class PokerConstants
 {
-    // version of Poker
-    //public static Version VERSION = new Version(1, 0, true, 8, false, 0, false); // beta
-    //public static Version VERSION = new Version(1, 0, false, 0, true, 1, false); // demo 1
-    //public static Version VERSION = new Version(1, 0, false); // release 1.0 CD
-    //public static Version VERSION = new Version(1, 0, true); // release 1.0 download
-    //public static Version VERSION = new Version(1, 1, false); // release 1.1 CD
-    //public static Version VERSION = new Version(1, 1, true); // release 1.1 download
-    //public static Version VERSION = new Version(1, 2, false, 0, true, 1, false); // release 1.2 demo 1
-    //public static Version VERSION = new Version(1, 2, true); // release 1.2 - Patch 2
-    //public static Version VERSION = new Version(Version.TYPE_BETA, 2, 0, 6, 4, true); // release 2.0 - Beta 6, Patch 4
-    //public static final Version VERSION = new Version(2, 5, 3, true); // release 2.5 - Patch 3
-    //public static final Version VERSION = new Version(3, 0, 5, true); // release 3.0, Patch 5
-    //public static final Version VERSION = new Version(3, 0, 6, true); // release 3.0, Patch 6
-    //public static final Version VERSION = new Version(3, 1, 0, true); // release 3.1 (open sourced!)
-    //public static final Version VERSION = new Version(3, 1, 1, true); // release 3.1.1 (add Windows installer)
-    //public static final Version VERSION = new Version(3, 1, 2, true); // release 3.1.2 (dependency updates)
-    //public static final Version VERSION = new Version(3, 1, 3, true); // release 3.1.3 (Java 11, dependency updates)
-    //public static final Version VERSION = new Version(3, 1, 4, true); // release 3.1.4 (Java 17, dependency updates)
-    //public static final Version VERSION = new Version(3, 1, 5, true); // release 3.1.5 (Java 21, dependency updates)
-    public static final Version VERSION = new Version(3, 1, 6, true); // release 3.1.6 (Java 25, dependency updates)
+    /**
+     * Version history of Poker, most recent first.  The current version is always the first
+     * entry - to ship a new release, just add a line at the top (no commenting/uncommenting
+     * needed).
+     */
+    public static final Version VERSION = latest(
+            new Version(3, 1, 7, true), // release 3.1.7 (memory fix, dashboard improvements)
+            new Version(3, 1, 6, true), // release 3.1.6 (Java 25, dependency updates)
+            new Version(3, 1, 5, true), // release 3.1.5 (Java 21, dependency updates)
+            new Version(3, 1, 4, true), // release 3.1.4 (Java 17, dependency updates)
+            new Version(3, 1, 3, true), // release 3.1.3 (Java 11, dependency updates)
+            new Version(3, 1, 2, true), // release 3.1.2 (dependency updates)
+            new Version(3, 1, 1, true), // release 3.1.1 (add Windows installer)
+            new Version(3, 1, 0, true), // release 3.1 (open sourced!)
+            new Version(3, 0, 6, true), // release 3.0, Patch 6
+            new Version(3, 0, 5, true), // release 3.0, Patch 5
+            new Version(2, 5, 3, true), // release 2.5, Patch 3
+            new Version(Version.TYPE_BETA, 2, 0, 6, 4, true) // release 2.0 - Beta 6, Patch 4
+    );
+
+    // Pre-2.0 history, kept for the record.  These used Version constructors that no longer
+    // exist: 1.2 - Patch 2, 1.2 demo 1, 1.1 (CD and download), 1.0 (CD and download),
+    // 1.0 demo 1, 1.0 beta 8.
+
+    /**
+     * Returns the current (most recent) version, i.e. the first in the history.
+     */
+    private static Version latest(Version... history)
+    {
+        return history[0];
+    }
 
     // OS versions (can be different if specific patches released)
     public static final Version LATEST_MAC = VERSION;

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/download/DownloadHome.html
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/download/DownloadHome.html
@@ -49,7 +49,7 @@
     </div>
 
     <div class="download">
-        Go to <a href="https://github.com/dougdonohoe/ddpoker/releases">GitHub</a> to get the latest installers.
+        Go to <a href="https://github.com/dougdonohoe/ddpoker#installers">GitHub</a> to get the latest installers.
         You can still find the historical pre-open source installers
         <a href="https://static.ddpoker.com/download">here</a>.
     </div>

--- a/installer/install4j/poker.install4j
+++ b/installer/install4j/poker.install4j
@@ -8,7 +8,7 @@
     <codeSigning macEnabled="true" macPkcs12File="../../target/developerID_application.p12" windowsEnabled="true" windowsKeySource="pkcs11" windowsPkcs11Library="/usr/local/lib/libeTPkcs11.dylib">
       <windowsPkcs11Identifier issuer="Sectigo Public Code Signing CA R36" serial="b188553e484920219014bcbae1b277c5" subject="Donohoe Digital LLC" />
     </codeSigning>
-    <jreBundles jdkProviderId="Corretto" release="25/25.0.1.8.1" />
+    <jreBundles jdkProviderId="Corretto" release="25/25.0.4.7.1" />
   </application>
   <files>
     <mountPoints>
@@ -1005,14 +1005,13 @@ return true;
     </widgetStyles>
   </installerGui>
   <mediaSets>
-    <windows name="Windows" id="4" installDir="ddpoker3" failOnPostProcessorError="true" architecture="64" />
-    <unixInstaller name="Unix Installer" id="15" installDir="ddpoker3" customInstallBaseDir="/usr/local/games">
+    <windows name="Windows" id="4" mediaFileName="ddpoker_windows_${compiler:sys.version}" installDir="ddpoker3" failOnPostProcessorError="true" architecture="64" />
+    <unixInstaller name="Unix Installer" id="15" mediaFileName="ddpoker_linux_${compiler:sys.version}" installDir="ddpoker3" customInstallBaseDir="/usr/local/games">
       <excludedBeans>
-        <bean refId="13" />
         <bean refId="50" />
       </excludedBeans>
     </unixInstaller>
-    <macosArchive name="macOS Single Bundle Archive" id="201" volumeName="${compiler:sys.fullName}" architecture="universal" dmgStylingMode="none" launcherId="2">
+    <macosArchive name="macOS Single Bundle Archive" id="201" mediaFileName="ddpoker_mac_${compiler:sys.version}" volumeName="${compiler:sys.fullName}" architecture="universal" dmgStylingMode="none" launcherId="2">
       <topLevelFiles>
         <symlink name="&quot; &quot;" target="/Applications" />
         <file name=".DS_Store" file="./custom/DS_Store" />

--- a/tools/bin/buildall.pl
+++ b/tools/bin/buildall.pl
@@ -40,6 +40,12 @@
 # options: see below
 #
 
+use Cwd;
+
+# where the script was invoked from, captured before anything cd()s away - see
+# pullOriginalDir()
+$ORIGDIR = getcwd();
+
 $OSTYPE=$^O;
 # mac?
 if ($OSTYPE =~ "darwin.*")
@@ -70,6 +76,11 @@ $MAIN_MVN_MODULE="poker";
 $MVN_VERSION="3.0"; # current version (should match poker maven module version)
 $BUILDDIR="poker3.x";
 $BASEDIR="builds/$BUILDDIR";
+$GITREPO="ddpoker";
+
+# platform token -> installer extension, README label
+# (tokens must match mediaFileName in poker.install4j)
+@PLATFORMS = ( ["mac", "dmg", "Mac"], ["windows", "exe", "Windows"], ["linux", "sh", "Linux"] );
 
 # base dir
 if ($MAC)
@@ -89,6 +100,13 @@ if ($dev)
 }
 
 # place to copy installers
+
+#
+# -github-dryrun is a rehearsal of -github.  'perl -s' can't put a hyphenated switch
+# in a normal variable, so pick it up via a symbolic ref.
+#
+$githubdryrun = ${'github-dryrun'};
+$github = 1 if ($githubdryrun);
 
 #
 # if github, skip git, mvn, unpack, buildrelease, installer (assumes done previously).
@@ -128,6 +146,7 @@ if (!$builtsomething)
 	print ("   -noinstaller     skip install4j build step\n");
 	print ("   -nonotarize      skip notarize step\n");
 	print ("   -github          create a release at github with all installers\n");
+	print ("   -github-dryrun   rehearse -github: draft notes, echo the gh command, change nothing\n");
 	print ("   -exitearly       just print env vars\n");
 	print ("\n");
 	exit(1);
@@ -198,7 +217,7 @@ sub build
 		cd($DEVPARENT);
 
 		if ( ! -d $DEVDIR ) {
-            runIndented("git clone --progress --no-checkout git\@github.com:dougdonohoe/ddpoker.git", $indent);
+            runIndented("git clone --progress --no-checkout git\@github.com:dougdonohoe/$GITREPO.git", $indent);
             cd($DEVDIR);
             runIndented("git checkout --progress", $indent); # TODO git checkout <tag>
 		} else {
@@ -314,7 +333,7 @@ sub build
         chop $win_pw;
 
         # clean old builds
-        runIndented("rm -vf $INSTALLERDIR/${PRODUCT}${VERSION_FILE}.*");
+        runIndented("rm -vf $INSTALLERDIR/${INSTALLER_START}_*_${VERSION_FILE}.*");
 
 		# run install4j
         $cmd = "/Applications/install4j.app/Contents/Resources/app/bin/install4jc --release=$VERSION " .
@@ -323,14 +342,14 @@ sub build
 
         # Set icons in Mac installer and notarize
         if (!$nonotarize) {
-            runIndented("${DEVDIR}/tools/bin/mac-set-icons-notarize.sh $VERSION_FILE");
+            runIndented("${DEVDIR}/tools/bin/mac-set-icons-notarize.sh " . installerName("mac", "dmg"));
         } else {
             print($indent . "Notarization skipped.\n");
         }
 
         # Create md5sums.txt
         cd($INSTALLERDIR);
-        runIndented("md5 ddpoker$VERSION_FILE.* > md5sums.txt");
+        runIndented("md5 " . installerNames() . " > md5sums.txt");
 
         print("Installers are in $INSTALLERDIR\n");
 	}
@@ -338,16 +357,74 @@ sub build
 	# push installers to GitHub
 	if ($github)
 	{
-	    cd($INSTALLERDIR);
-        my $files = join " ", map { "ddpoker$VERSION_FILE$_" } (".dmg", ".sh", ".exe");
-	    runIndented("gh release create $VERSION --title 'DD Poker $VERSION' --notes-file md5sums.txt $files");
+		# -github skips the git step, so make sure we can still push the README
+		# update before we publish anything
+		checkNotBehind();
+		checkInstallers();
+
+		# draft release notes from whatsnew.html so they can be checked over.  These
+		# are kept alongside the installers, one file per version.
+		$notes = releaseNotes($VERSION);
+		$notesfile = releaseNotesName();
+		writeFile("$INSTALLERDIR/$notesfile", $notes);
+
+		print("\nDraft release notes for $VERSION ($INSTALLERDIR/$notesfile):\n\n");
+		print(("-" x 78) . "\n");
+		print($notes);
+		print(("-" x 78) . "\n");
+
+		# check the notes over before going any further.  The dry run asks too, so
+		# the whole flow gets rehearsed.
+		confirm($githubdryrun
+		        ? "Continue the dry run with these notes?"
+		        : "Create the GitHub release for $VERSION with these notes?");
+
+		cd($INSTALLERDIR);
+		$cmd = "gh release create $VERSION --title 'DD Poker $VERSION' " .
+		       "--notes-file $notesfile " . installerNames();
+
+		if ($githubdryrun)
+		{
+			# check the README markers now, since we stop before rewriting them
+			updateReadme($VERSION, 1);
+
+			# report the same pull decision the real run would make, skip reason and all
+			my($pullok, $pulldetail) = pullPlan();
+
+			print("\nDRY RUN - would run:\n\n    $cmd\n");
+			print("\nDRY RUN - would then point the README.md installer links at $VERSION,\n");
+			print("show the diff, and commit/push it.  It would then " .
+			      ($pullok ? "run 'git pull --tags' in $pulldetail"
+			               : "skip the git pull ($pulldetail)") . ".\n");
+			print("No release was created and README.md was not touched\n");
+			print("(only $INSTALLERDIR/$notesfile was written).\n\n");
+			exit(0);
+		}
+
+		runIndented($cmd, $indent);
+
+		# post-release: point the README at the installers we just published
+		updateReadme($VERSION, 0);
+
+		cd($DEVDIR);
+		runIndented("git diff README.md", $indent);
+		confirm("Commit and push this README.md change?");
+		runIndented("git add README.md", $indent);
+		runIndented("git commit -m 'Update README installer links for $VERSION'", $indent);
+		runIndented("git push", $indent);
+
+		# everything above happened in the build clone, so bring the tag and the README
+		# commit back to wherever this was run from
+		pullOriginalDir();
 	}
 }
 
-# run given command and indent output, and optionally filter lines
+# run given command and indent output, and optionally filter lines.  A non-zero exit
+# normally aborts the build; $warnonly downgrades that to a warning, for steps that run
+# after the release has already been published.
 sub runIndented
 {
-	my($command, $indent, $filter) = @_;
+	my($command, $indent, $filter, $warnonly) = @_;
     print("\n" . $indent . "Running '$command'...\n");
 	open (OUTPUT, "$command 2>&1 |") || die "can't open $!";
 	while (<OUTPUT>)
@@ -358,9 +435,14 @@ sub runIndented
 	close OUTPUT;
     my $exit_code = $? >> 8;
     if ($exit_code != 0) {
-        print("\n*** Error (exit code $exit_code) running '$command'\n\n");
-        exit($exit_code);
+        if ($warnonly) {
+            print("\n*** Warning (exit code $exit_code) running '$command'\n\n");
+        } else {
+            print("\n*** Error (exit code $exit_code) running '$command'\n\n");
+            exit($exit_code);
+        }
     }
+    return $exit_code;
 }
 
 # set VERSION and VERSION_FILE (assumes mvn has been run)
@@ -372,6 +454,234 @@ sub getVersion
 	chop $VERSION;
 	$VERSION_FILE = $VERSION =~ s/\./_/gr;
 	print("\nVERSION is '$VERSION', file extension is '$VERSION_FILE'\n");
+}
+
+# installer file name for a platform, e.g. ddpoker_mac_3_1_6.dmg
+sub installerName
+{
+	my($platform, $ext) = @_;
+
+	return "${INSTALLER_START}_${platform}_${VERSION_FILE}.$ext";
+}
+
+# all installer file names, space separated
+sub installerNames
+{
+	return join " ", map { installerName($$_[0], $$_[1]) } @PLATFORMS;
+}
+
+# release notes file name, e.g. release_notes_3_1_6.md
+sub releaseNotesName
+{
+	return "release_notes_${VERSION_FILE}.md";
+}
+
+# read and return the entire contents of a file
+sub slurp
+{
+	my($file) = @_;
+
+	open (IN, "$file") || die "Couldn't open $file";
+	local $/;
+	my $contents = <IN>;
+	close(IN);
+
+	return $contents;
+}
+
+# write contents to a file
+sub writeFile
+{
+	my($file, $contents) = @_;
+
+	open (OUT, ">$file") || die "Couldn't write $file";
+	print OUT $contents;
+	close(OUT);
+}
+
+# ask a yes/no question, exiting unless the answer is yes
+sub confirm
+{
+	my($prompt) = @_;
+
+	print("\n$prompt [y/N] ");
+	my $answer = <STDIN>;
+	if ($answer !~ /^\s*y(es)?\s*$/i)
+	{
+		print("\nAborted.\n\n");
+		exit(1);
+	}
+}
+
+# -github skips the git step, so make sure the build clone is current.  Otherwise we
+# could publish a release and then be unable to push the README update, and the
+# installers we are about to publish would have been built from stale code.
+sub checkNotBehind
+{
+	cd($DEVDIR);
+	runIndented("git fetch origin", $indent);
+
+	my $behind = `git rev-list --count HEAD..origin/main`;
+	chop $behind;
+	if ($behind > 0)
+	{
+		print("\n*** $DEVDIR is $behind commit(s) behind origin/main.\n");
+		print("*** Re-run 'buildall.pl -full' so the installers match origin/main.\n\n");
+		exit(1);
+	}
+}
+
+# top of the git work tree containing $dir, or empty when $dir isn't in one
+sub gitTopLevel
+{
+	my($dir) = @_;
+
+	my $top = `git -C '$dir' rev-parse --show-toplevel 2>/dev/null`;
+	chop $top;
+
+	return $top;
+}
+
+# current branch name of the repo containing $dir ("HEAD" when detached)
+sub gitBranch
+{
+	my($dir) = @_;
+
+	my $branch = `git -C '$dir' rev-parse --abbrev-ref HEAD 2>/dev/null`;
+	chop $branch;
+
+	return $branch;
+}
+
+# Whether pullOriginalDir() should pull, as ($ok, $detail): the work tree to pull when
+# $ok, otherwise the reason it is being skipped.  Split out from the pull itself so
+# -github-dryrun can rehearse the same decision without touching anything.
+sub pullPlan
+{
+	my $top = gitTopLevel($ORIGDIR);
+
+	return (0, "$ORIGDIR is not a git repository") if (!$top);
+
+	# with -dev (or if run from the build clone itself) the release was made right here,
+	# so there is nothing to pull back
+	return (0, "it ran from the build clone $top") if ($top eq gitTopLevel($DEVDIR));
+
+	my $branch = gitBranch($ORIGDIR);
+	return (0, "$top is on '$branch', not main") if ($branch ne "main");
+
+	return (1, $top);
+}
+
+# -github does its git work in the build clone, so the dev tree this was launched from
+# never sees the new tag or the README commit.  Pull them over, when that is safe to do.
+sub pullOriginalDir
+{
+	my($ok, $detail) = pullPlan();
+
+	if (!$ok)
+	{
+		print("\n" . $indent . "Skipping git pull: $detail.\n");
+		return;
+	}
+
+	cd($ORIGDIR);
+
+	# only a warning if this fails: the release is published and the README is pushed, so
+	# a dirty or diverged dev tree shouldn't make a good release look like a broken build
+	runIndented("git pull --tags --progress", $indent, undef, 1);
+}
+
+# build markdown release notes for $version from the whatsnew.html entry of the same
+# version
+sub releaseNotes
+{
+	my($version) = @_;
+
+	my $whatsnew = "$DEVDIR/code/$MAIN_MVN_MODULE/src/main/resources/config/$PRODUCT/help/whatsnew.html";
+	my $html = slurp($whatsnew);
+
+	# the version header, then the <ul> of items that follows it
+	$html =~ m{Version\s+\Q$version\E\s+-\s+([^<]+?)\s*</span>.*?<ul>(.*?)</ul>}s
+		|| die "No 'Version $version' entry found in $whatsnew";
+	my($date, $items) = ($1, $2);
+
+	my $notes = "## Version $version - $date\n\n";
+	while ($items =~ m{<li>(.*?)</li>}gs)
+	{
+		my $item = $1;
+		$item =~ s{<tt>(.*?)</tt>}{`$1`}gs;    # fixed width -> code
+		$item =~ s{<b>(.*?)</b>}{**$1**}gs;    # bold -> bold
+		$item =~ s/&lt;/</g;
+		$item =~ s/&gt;/>/g;
+		$item =~ s/&amp;/&/g;
+		$item =~ s/\s+/ /g;                    # undo the source line wrapping
+		$item =~ s/^\s+|\s+$//g;
+		$notes .= "- $item\n";
+	}
+
+	# changelog against the most recent release that isn't this one (so re-running
+	# -github after the release exists still produces the same notes)
+	my $prevcmd = "gh release list --limit 5 --json tagName " .
+	              "--jq '[.[].tagName] | map(select(. != \"$version\")) | .[0] // \"\"'";
+	my $prev = `$prevcmd`;
+	chop $prev;
+	if ($prev && $prev ne $version)
+	{
+		$notes .= "\n**Full Changelog**: " .
+		          "https://github.com/dougdonohoe/$GITREPO/compare/$prev...$version\n";
+	}
+
+	# md5sums.txt is written by the installer step of the preceding -full run, so make
+	# sure it is for this version and not left over from an earlier one
+	my $verfile = $version =~ s/\./_/gr;
+	my $md5file = "$INSTALLERDIR/md5sums.txt";
+	die "$md5file not found - run 'buildall.pl -full' first" if (! -f $md5file);
+
+	# match the "_<version>." out of the installer names rather than the bare version:
+	# a plain "3_1" is also a substring of a left-over "3_1_6" build
+	my $md5 = slurp($md5file);
+	die "$md5file has no $verfile entries (stale?) - re-run 'buildall.pl -full'"
+		if ($md5 !~ /_\Q$verfile\E\./);
+	$notes .= "\n" . $md5;
+
+	return $notes;
+}
+
+# make sure every installer we are about to upload actually exists
+sub checkInstallers
+{
+	for my $platform (@PLATFORMS)
+	{
+		my $file = "$INSTALLERDIR/" . installerName($$platform[0], $$platform[1]);
+		die "$file not found - run 'buildall.pl -full' first" if (! -f $file);
+	}
+}
+
+# rewrite the installer links between the markers in README.md.  If $dryrun, only
+# check that the markers are still there.
+sub updateReadme
+{
+	my($version, $dryrun) = @_;
+
+	my $readme = "$DEVDIR/README.md";
+	my $begin = "<!-- installers:begin (updated by tools/bin/buildall.pl -github) -->";
+	my $end = "<!-- installers:end -->";
+
+	my $block = "$begin\nDownload the latest release, **$version**:\n\n";
+	for my $platform (@PLATFORMS)
+	{
+		my($plat, $ext, $label) = @$platform;
+		my $file = installerName($plat, $ext);
+		$block .= "- **$label**: [$file]" .
+		          "(https://github.com/dougdonohoe/$GITREPO/releases/download/$version/$file)\n";
+	}
+	$block .= $end;
+
+	my $text = slurp($readme);
+	($text =~ s/\Q$begin\E.*?\Q$end\E/$block/s)
+		|| die "Could not find the installers:begin/end markers in $readme";
+
+	writeFile($readme, $text) if (!$dryrun);
 }
 
 # chdir with error checking

--- a/tools/bin/mac-set-icons-notarize.sh
+++ b/tools/bin/mac-set-icons-notarize.sh
@@ -36,21 +36,22 @@
 
 set -e
 
-# Verify we have a version
-VERSION=$1
-if [[ -z "$VERSION" ]]; then
-  echo "mac-set-icons-notarize.sh [version]"
+# Verify we have a dmg to work on
+DMG=$1
+if [[ -z "$DMG" ]]; then
+  echo "mac-set-icons-notarize.sh [dmg-file-name]"
   exit 1
 fi
+BASE="${DMG%.dmg}"
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPTDIR"
 DDHOME="$(git rev-parse --show-toplevel)"
 
-SRC="$DDHOME/installer/builds/ddpoker${VERSION}.dmg"
-BAK="/tmp/ddpoker${VERSION}.bak.dmg"
-DST_RW="$DDHOME/installer/builds/ddpoker${VERSION}_rw.dmg"
-DST_ALT="$DDHOME/installer/builds/ddpoker${VERSION}_alt.dmg"
+SRC="$DDHOME/installer/builds/$DMG"
+BAK="/tmp/${BASE}.bak.dmg"
+DST_RW="$DDHOME/installer/builds/${BASE}_rw.dmg"
+DST_ALT="$DDHOME/installer/builds/${BASE}_alt.dmg"
 DST_MNT="/Volumes/dd_poker_dst"
 
 if [[ ! -f "$SRC" ]]; then


### PR DESCRIPTION
Brings the release tooling back from [ddphotos-app](https://github.com/dougdonohoe/ddphotos-app),
where it was reworked after that repo was forked from this one, and does the version prep for 3.1.7.

Until now the release was a one-liner — `gh release create … --notes-file md5sums.txt` — so the
published notes were just checksums, and the installers were named `ddpoker3_1_6.dmg` with no
platform in the name.

## Installer names now carry the platform

`ddpoker_mac_3_1_7.dmg`, `ddpoker_windows_3_1_7.exe`, `ddpoker_linux_3_1_7.sh`.

Each media set in `poker.install4j` gets its own `mediaFileName`; `buildall.pl` grows a
`@PLATFORMS` table with `installerName()` / `installerNames()` so the clean, `md5`, notarize and
upload steps all agree on one place. `mac-set-icons-notarize.sh` now takes the dmg filename
instead of a version.

Two incidental fixes came along:

* The `rm -vf` that cleans old builds used `$PRODUCT` (`poker3_1_6.*`) and so had never matched
  anything — it now uses the `ddpoker` prefix the files actually have.
* Dropped the leftover `<bean refId="13" />` from the Unix installer's `excludedBeans`, which had
  been suppressing `CreateDefaultStartMenuEntriesAction` on Linux. This is the icons bug DD Photos
  fixed; we were the original source of it.

## Release notes are drafted from `whatsnew.html`

`buildall.pl -github` now:

1. Checks the build clone isn't behind `origin/main` and that all three installers exist, before
   anything is published.
2. Generates `installer/builds/release_notes_<version>.md` from the `whatsnew.html` entry for this
   version — each `<li>` becomes a Markdown bullet (`<tt>` → code, `<b>` → bold) — then appends a
   **Full Changelog** compare link and the `md5sums.txt` block.
3. Prints the draft and waits for approval before running `gh release create`.
4. Rewrites the installer links in `README.md` between the `<!-- installers:begin … -->` /
   `<!-- installers:end -->` markers, shows the diff, and asks before committing and pushing.
5. Runs `git pull --tags` in the directory `buildall` was launched from, so the working tree picks
   up the tag and README commit made in the build clone. Skipped, with a reason, when that isn't
   safe; a failure there is only a warning, since the release is already out by then.

New `-github-dryrun` rehearses all of it — drafts the notes, verifies the README markers, echoes the
`gh` command — and changes nothing.

For the parser to find an entry, `whatsnew.html` needed the DD Photos header markup, so all 30
version banners moved from `<table bgcolor>` + `<font>` to `<div style=…><strong><span style=…>`.
`font-size: 120%` rather than DD Photos' `1.1em`, because the in-game help is Swing's
`HTMLEditorKit` (via `DDHtmlArea`), whose `CSS.FontSize` handles `pt`/`px`/`%` but not `em`;
browsers render the two identically for the static.ddpoker.com copy.

## Version history is a list again

`PokerConstants.VERSION` was a stack of commented-out lines where shipping a release meant
commenting one out and uncommenting the next. It's now an array, most recent first, and the current
version is just the first entry:

```java
public static final Version VERSION = latest(
        new Version(3, 1, 7, true), // release 3.1.7 (memory fix, dashboard improvements)
        new Version(3, 1, 6, true), // release 3.1.6 (Java 25, dependency updates)
        …
);
```

The pre-2.0 entries are a comment rather than array elements — they used `Version` constructors that
no longer exist.

## 3.1.7 prep

New `whatsnew.html` entry, dated **TBD** until the release goes out:

* Fixed out-of-memory errors in large-field tournaments (#215).
* Rank panel updates at end of hand and ranks on settled chips (#216).
* Player Info dashboard panel now in practice games (#217).
* Deck chooser no longer offers to create folders or rename files.
* Dependency updates.

## Docs

* New **Appendix H: Releasing a New Version** in `README-DEV.md` covering prep, the
  `-full` → `-github-dryrun` → `-github` sequence, what `-github` does, and local installer
  iteration; cross-referenced from the existing *Installers* section.
* `README.md` gets the marked installer block (seeded with the current 3.1.6 asset names, which
  `-github` regenerates on the next release).
* The website download page now points at the README's Installers section rather than the bare
  Releases page.

`test-buildall.pl` from DD Photos is deliberately not ported.

## Testing

* Full `mvn package` clean; `PrintVersion` prints `3.1.7`.
* `perl -c buildall.pl` and `xmllint` on `poker.install4j` both pass.
* `buildall -dev -github-dryrun`, with stub installers staged, produced the right notes and the
  right `gh` command, checked the README markers, and correctly reported it would skip the git pull.
* Rendered `whatsnew.html` through a `JEditorPane`/`HTMLEditorKit` the way `Help.java` does — the
  green bars, centred yellow text and larger size all come out right.

