### PR TITLE
Show table position and a rank graphic in Player Info

### DIFF
--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -514,6 +514,9 @@ public class PokerGame extends Game implements PlayerActionListener
      *
      * Every player in the tournament is in this list, so not finding one is an error -
      * unlike the table-scoped version, where it just means "seated elsewhere".
+     *
+     * See RankUtils for why settled chip counts are compared rather than live ones,
+     * and for what re-reading the list size on every pass does and does not buy.
      */
     public int getRank(PokerPlayer player)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -487,46 +487,39 @@ public class PokerGame extends Game implements PlayerActionListener
         return getPokerPlayerFromID(GamePlayer.HOST_ID);
     }
 
+    // this game's players, as the players a rank is counted over.  Held as a field so
+    // that counting a rank allocates nothing.
+    private final RankUtils.Players rankPlayers_ = new RankUtils.Players()
+    {
+        public int size()
+        {
+            return getNumPlayers();
+        }
+
+        public PokerPlayer getPlayerAt(int n)
+        {
+            return getPokerPlayerAt(n);
+        }
+    };
+
     /**
-     * Return rank of player based on chips.  Players holding equal chips share a
-     * rank, so this is one more than the number of players holding strictly more -
-     * the same result the previous sort-based version produced.
+     * Return rank of player based on chips, across the whole tournament.  Players
+     * holding equal chips share a rank, so this is one more than the number of players
+     * holding strictly more - the same result the previous sort-based version produced.
      *
-     * Compares settled chip counts, not live ones - see getSettledChipCount().  A rank
-     * is a comparison across the whole tournament, and tables are not in step with each
-     * other: in an online game they are independent state machines, so at any instant
-     * some are mid-hand and some are between hands.  Comparing live counts sinks
-     * whoever has chips in a pot.  This is reached at arbitrary moments - the Rank
-     * dashboard item recomputes when another table finishes a hand, which lands in the
-     * middle of ours, and PlayerInfo recomputes on every mouse-over.
+     * Counted in a single pass by RankUtils rather than by sorting a copy of the player
+     * list.  This runs every time the rank is displayed, which is at the end of every
+     * hand, and in a large tournament the old version allocated and sorted a 5,625
+     * element list each time.  PokerTable.getRank() counts the same way over one table.
      *
-     * Counted in a single pass rather than sorting a copy of the player list.  This
-     * runs every time the rank is displayed, which is at the end of every hand, and in
-     * a large tournament the old version allocated and sorted a 5,625 element list
-     * each time.
-     *
-     * The loop bound is re-read each pass on purpose: players_ can shrink from
-     * another thread (see removePlayer(), called from OnlineManager when a player
-     * switches to observer), and a bound captured up front would index off the end.
+     * Every player in the tournament is in this list, so not finding one is an error -
+     * unlike the table-scoped version, where it just means "seated elsewhere".
      */
     public int getRank(PokerPlayer player)
     {
-        int nChips = getSettledChipCount(player);
-        int nRank = 1;
-        boolean bFound = false;
+        int nRank = RankUtils.getRank(this, rankPlayers_, player);
 
-        for (int i = 0; i < getNumPlayers(); i++)
-        {
-            PokerPlayer p = getPokerPlayerAt(i);
-            if (p == player)
-            {
-                bFound = true;
-                continue;
-            }
-            if (getSettledChipCount(p) > nChips) nRank++;
-        }
-
-        if (!bFound)
+        if (nRank == 0)
         {
             throw new ApplicationError(ErrorCodes.ERROR_CODE_ERROR, "No rank for player", player.toString());
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -415,40 +415,40 @@ public class PokerTable implements ObjectID
         return players_[nSeat];
     }
 
+    // this table's seats, as the players a rank is counted over.  The whole array is
+    // walked, not getSeats(): addPlayer() seats at a random index in 0..SEATS-1
+    // whatever the table's size, so a shorter bound would miss players in high seats.
+    private final RankUtils.Players rankPlayers_ = new RankUtils.Players()
+    {
+        public int size()
+        {
+            return PokerConstants.SEATS;
+        }
+
+        public PokerPlayer getPlayerAt(int n)
+        {
+            return players_[n];
+        }
+    };
+
     /**
      * Return rank of a player among those seated at this table, based on chips.
-     * Players holding equal chips share a rank, so this is one more than the
-     * number seated here holding strictly more - the same definition
-     * PokerGame.getRank() uses, scoped to one table.
+     * Counted by RankUtils, the same way PokerGame.getRank() counts it, scoped to
+     * one table - so a player's table rank and tournament rank can never disagree
+     * about ties or about which chip count they compare.
      *
      * Returns 0 when the player is not seated here.  Unlike the tournament-wide
      * version that is not an error: this is read for whichever player is moused
-     * over, who may be seated anywhere.
-     *
-     * Compares settled chip counts for the same reason PokerGame.getRank() does -
-     * this is reached on every mouse-over, which lands mid-hand, where live counts
-     * sink whoever has chips in a pot.  See PokerGame.getSettledChipCount().
+     * over, who may be seated anywhere - or, once they are out, nowhere.
      */
     public int getRank(PokerPlayer player)
     {
+        // no game while a table is being demarshalled, and SimulatorDialog builds one
+        // with none at all
         PokerGame game = getGame();
-        int nChips = game.getSettledChipCount(player);
-        int nRank = 1;
-        boolean bFound = false;
+        if (game == null) return 0;
 
-        for (int i = 0; i < PokerConstants.SEATS; i++)
-        {
-            PokerPlayer p = players_[i];
-            if (p == null) continue;
-            if (p == player)
-            {
-                bFound = true;
-                continue;
-            }
-            if (game.getSettledChipCount(p) > nChips) nRank++;
-        }
-
-        return bFound ? nRank : 0;
+        return RankUtils.getRank(game, rankPlayers_, player);
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -416,6 +416,42 @@ public class PokerTable implements ObjectID
     }
 
     /**
+     * Return rank of a player among those seated at this table, based on chips.
+     * Players holding equal chips share a rank, so this is one more than the
+     * number seated here holding strictly more - the same definition
+     * PokerGame.getRank() uses, scoped to one table.
+     *
+     * Returns 0 when the player is not seated here.  Unlike the tournament-wide
+     * version that is not an error: this is read for whichever player is moused
+     * over, who may be seated anywhere.
+     *
+     * Compares settled chip counts for the same reason PokerGame.getRank() does -
+     * this is reached on every mouse-over, which lands mid-hand, where live counts
+     * sink whoever has chips in a pot.  See PokerGame.getSettledChipCount().
+     */
+    public int getRank(PokerPlayer player)
+    {
+        PokerGame game = getGame();
+        int nChips = game.getSettledChipCount(player);
+        int nRank = 1;
+        boolean bFound = false;
+
+        for (int i = 0; i < PokerConstants.SEATS; i++)
+        {
+            PokerPlayer p = players_[i];
+            if (p == null) continue;
+            if (p == player)
+            {
+                bFound = true;
+                continue;
+            }
+            if (game.getSettledChipCount(p) > nChips) nRank++;
+        }
+
+        return bFound ? nRank : 0;
+    }
+
+    /**
      * Return array of players sorted by last time moved, with least recently
      * moved at the top of the array
      */

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
@@ -1,0 +1,104 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+/**
+ * Rank of a player among a group of players, by chips.
+ *
+ * PokerGame and PokerTable both need this - the same count over a different set of
+ * players - so the count lives here and each supplies the players to walk.
+ */
+public class RankUtils
+{
+    /**
+     * The players a rank is counted over.
+     *
+     * Deliberately an indexed list rather than a java.util.List: neither caller has
+     * one to hand, and copying into one on every call is exactly what counting in a
+     * single pass exists to avoid.
+     *
+     * size() is re-read on every pass of the loop on purpose.  PokerGame's list can
+     * shrink from another thread (see PokerGame.removePlayer(), called from
+     * OnlineManager when a player switches to observer), and a bound captured up
+     * front would index off the end.
+     */
+    public interface Players
+    {
+        /**
+         * Number of slots to walk.
+         */
+        int size();
+
+        /**
+         * Player in slot n, or null if the slot is empty - a table's seats are a
+         * fixed-size array with gaps in it.
+         */
+        PokerPlayer getPlayerAt(int n);
+    }
+
+    /**
+     * Return rank of a player among the given players, based on chips.  Players
+     * holding equal chips share a rank, so this is one more than the number holding
+     * strictly more - the same result the previous sort-based version produced.
+     *
+     * Returns 0 when the player is not among them.  Whether that is an error is the
+     * caller's to decide: it is for a tournament-wide rank, where every player is in
+     * the list by definition, and is not for a table-scoped one, which is asked about
+     * whoever is under the mouse and who may be seated anywhere.
+     *
+     * Compares settled chip counts, not live ones - see PokerGame.getSettledChipCount().
+     * A rank is read at arbitrary moments: the Rank dashboard item recomputes when
+     * another table finishes a hand, which lands in the middle of ours, and PlayerInfo
+     * recomputes on every mouse-over.  Live counts sink whoever has chips in a pot.
+     */
+    public static int getRank(PokerGame game, Players players, PokerPlayer player)
+    {
+        int nChips = game.getSettledChipCount(player);
+        int nRank = 1;
+        boolean bFound = false;
+
+        for (int i = 0; i < players.size(); i++)
+        {
+            PokerPlayer p = players.getPlayerAt(i);
+            if (p == null) continue;
+            if (p == player)
+            {
+                bFound = true;
+                continue;
+            }
+            if (game.getSettledChipCount(p) > nChips) nRank++;
+        }
+
+        return bFound ? nRank : 0;
+    }
+}

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
@@ -46,11 +46,6 @@ public class RankUtils
      * Deliberately an indexed list rather than a java.util.List: neither caller has
      * one to hand, and copying into one on every call is exactly what counting in a
      * single pass exists to avoid.
-     *
-     * size() is re-read on every pass of the loop on purpose.  PokerGame's list can
-     * shrink from another thread (see PokerGame.removePlayer(), called from
-     * OnlineManager when a player switches to observer), and a bound captured up
-     * front would index off the end.
      */
     public interface Players
     {
@@ -87,6 +82,11 @@ public class RankUtils
         int nRank = 1;
         boolean bFound = false;
 
+        // size() is re-read on every pass on purpose.  PokerGame's list can shrink
+        // from another thread (see PokerGame.removePlayer(), called from OnlineManager
+        // when a player switches to observer), and a bound captured up front would
+        // index off the end.  It does not close the window between reading size() and
+        // reading the slot - that race is older than this method and unchanged by it.
         for (int i = 0; i < players.size(); i++)
         {
             PokerPlayer p = players.getPlayerAt(i);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -44,9 +44,11 @@ import com.donohoedigital.games.poker.PokerUtils;
 import com.donohoedigital.games.poker.event.PokerTableEvent;
 import com.donohoedigital.games.poker.model.TournamentProfile;
 import com.donohoedigital.gui.DDLabel;
+import com.donohoedigital.gui.DDPanel;
 import com.donohoedigital.gui.GuiManager;
 
 import javax.swing.*;
+import java.awt.BorderLayout;
 import java.awt.event.MouseEvent;
 
 /**
@@ -60,18 +62,51 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
 {
     DDLabel labelInfo_;
     PokerPlayer last_;
+    private DDLabel labelName_;
+    private RankBandsPanel bands_;
 
     public PlayerInfo(GameContext context)
     {
         super(context, "playerinfo");
-        trackTableEvents(PokerTableEvent.TYPE_PLAYER_REBUY);
+
+        // TYPE_PLAYER_REBUY keeps the rebuy count honest.  The two hand events keep
+        // the ranks honest: the hovered player's position moves as the rest of the
+        // tournament plays, and the mouse can sit still across many hands, so
+        // without them the figures freeze at whatever they were when hovered.
+        // TYPE_END_HAND is the settled moment - see the note in Rank.
+        trackTableEvents(PokerTableEvent.TYPE_PLAYER_REBUY |
+                         PokerTableEvent.TYPE_END_HAND |
+                         PokerTableEvent.TYPE_NEW_HAND);
         PokerUtils.getGameboard().addTerritorySelectionListener(this);
     }
 
     protected JComponent createBody()
     {
+        DDPanel base = new DDPanel();
+        ((BorderLayout) base.getLayout()).setVgap(0);
+
+        // the player's name spans the full width, above everything else
+        labelName_ = new DDLabel(GuiManager.DEFAULT, STYLE);
+        base.add(labelName_, BorderLayout.NORTH);
+
+        // The graphic sits beside the rank rows rather than beside the panel as a
+        // whole, and is pinned to the top of them, so it stays level with the
+        // Tournament row however many rows are added underneath - rebuys, and the
+        // online-only rows, both come and go.
+        DDPanel rows = new DDPanel(GuiManager.DEFAULT, STYLE);
+        ((BorderLayout) rows.getLayout()).setHgap(4);
+
+        bands_ = new RankBandsPanel();
+        DDPanel bandsTop = new DDPanel();
+        ((BorderLayout) bandsTop.getLayout()).setVgap(0);
+        bandsTop.add(bands_, BorderLayout.NORTH);
+
         labelInfo_ = new DDLabel(GuiManager.DEFAULT, STYLE);
-        return labelInfo_;
+        rows.add(bandsTop, BorderLayout.WEST);
+        rows.add(labelInfo_, BorderLayout.CENTER);
+        base.add(rows, BorderLayout.CENTER);
+
+        return base;
     }
 
     /**
@@ -86,6 +121,10 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         if (t == null) p = null;
         else p = PokerUtils.getPokerPlayer(context_, t);
 
+        // fall back to ourselves, as the Player Style panel does, so the panel
+        // says something useful before the mouse has been anywhere
+        if (p == null) p = game_.getHumanPlayer();
+
         if (p != last_)
         {
             last_ = p;
@@ -98,6 +137,8 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
      */
     protected void updateInfo()
     {
+        if (!isOpen() || !isDisplayed()) return;
+
         if (last_ != null && !last_.isObserver())
         {
             String sRebuy = "";
@@ -119,7 +160,7 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
                         what = PropertyConfig.getMessage("msg.dash.rebuy.unlimited");
                     }
                     else if (nLeft > 0)
-                    {                        
+                    {
                         what = nLeft;
                     }
                 }
@@ -135,6 +176,20 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             int numLeft = game_.getNumPlayers() - game_.getNumPlayersOut();
             // if end of tournament, list number of players in tournament
             if (numLeft == 0) numLeft = game_.getNumPlayers();
+            int nTourneyRank = game_.getRank(last_);
+
+            // position at the hovered player's own table.  Rank of 0 means they are
+            // not seated - an observer, or a player already out - and at a single
+            // table the two scales would say the same thing, so the row is dropped.
+            PokerTable table = last_.getTable();
+            int nTableRank = table == null ? 0 : table.getRank(last_);
+            int nTableCount = table == null ? 0 : table.getNumOccupiedSeats();
+            boolean bSingleBar = game_.getNumTables() == 1 || nTableRank == 0 || nTableCount == 0;
+
+            String sTable = bSingleBar ? "" :
+                            PropertyConfig.getMessage("msg.dash.playerinfo.table",
+                                      PropertyConfig.getPlace(nTableRank),
+                                      nTableCount);
 
             // Disconnects and sit-outs can only happen in an online game - nothing in
             // a practice game sets either flag, so both counters would read zero for
@@ -144,24 +199,34 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
                                       last_.getHandsPlayedDisconnected(),
                                       last_.getHandsPlayedSitout());
 
+            labelName_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.name",
+                                      Utils.encodeHTML(last_.getName())));
+
+            // the table row follows the tournament row directly, so the two positions
+            // always read together and stay beside the graphic
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo",
-                                      Utils.encodeHTML(last_.getName()),
-                                      PropertyConfig.getPlace(game_.getRank(last_)),
+                                      PropertyConfig.getPlace(nTourneyRank),
                                       numLeft,
+                                      sTable,
                                       sOnline,
                                       sRebuy
             ));
+            bands_.setValues(nTourneyRank, numLeft, nTableRank, nTableCount, bSingleBar);
         }
         else
         {
             // keep the same height as when filled in, so the panel does not jump
             // about as the mouse moves on and off the players
+            String sTableSpace = game_.getNumTables() == 1 ? "" :
+                                 PropertyConfig.getMessage("msg.dash.playerinfo.table.space");
             String sOnlineSpace = !game_.isOnlineGame() ? "" :
                                   PropertyConfig.getMessage("msg.dash.playerinfo.online.space");
             String sRebuySpace = "";
             if (game_.getProfile().isRebuys()) sRebuySpace = PropertyConfig.getMessage("msg.dash.rebuy.space");
+            labelName_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.name.none"));
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.none",
-                                      sOnlineSpace, sRebuySpace));
+                                      sTableSpace, sOnlineSpace, sRebuySpace));
+            bands_.setValues(0, 0, 0, 0, true);
         }
 
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -34,15 +34,19 @@ package com.donohoedigital.games.poker.dashboard;
 
 import com.donohoedigital.base.Utils;
 import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.config.GameState;
 import com.donohoedigital.games.config.Territory;
 import com.donohoedigital.games.engine.GameContext;
 import com.donohoedigital.games.engine.Gameboard;
 import com.donohoedigital.games.engine.TerritorySelectionListener;
+import com.donohoedigital.games.poker.PokerGame;
 import com.donohoedigital.games.poker.PokerPlayer;
 import com.donohoedigital.games.poker.PokerTable;
 import com.donohoedigital.games.poker.PokerUtils;
+import com.donohoedigital.games.poker.engine.PokerSaveDetails;
 import com.donohoedigital.games.poker.event.PokerTableEvent;
 import com.donohoedigital.games.poker.model.TournamentProfile;
+import com.donohoedigital.games.poker.online.TournamentDirector;
 import com.donohoedigital.gui.DDLabel;
 import com.donohoedigital.gui.DDPanel;
 import com.donohoedigital.gui.GuiManager;
@@ -51,6 +55,7 @@ import com.donohoedigital.gui.GuiUtils;
 import javax.swing.*;
 import java.awt.BorderLayout;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
 
 /**
  * Created by IntelliJ IDEA.
@@ -61,8 +66,8 @@ import java.awt.event.MouseEvent;
  */
 public class PlayerInfo extends DashboardItem implements TerritorySelectionListener
 {
-    /** pixels between the name above and the top of the position graphic */
-    private static final int BANDS_TOP_GAP = 3;
+    /** pixels between the name and the rows below it */
+    private static final int NAME_GAP = 4;
 
     DDLabel labelInfo_;
     PokerPlayer last_;
@@ -78,15 +83,98 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         // tournament plays, and the mouse can sit still across many hands, so
         // without them the figures freeze at whatever they were when hovered.
         // TYPE_END_HAND is the settled moment - see the note in Rank.
-        trackTableEvents(PokerTableEvent.TYPE_PLAYER_REBUY |
-                         PokerTableEvent.TYPE_END_HAND |
-                         PokerTableEvent.TYPE_NEW_HAND);
+        //
+        // TYPE_PLAYER_CHIPS_CHANGED covers the one way chips move outside of a hand -
+        // the cheat menu's change-chip-count option - which is a shipped user option,
+        // not a debug build flag.  Rank tracks it for the same reason.
+        //
+        // Those are enough in a practice game, where the other tables are played out
+        // inside our own hand, but not online, where they are independent: we only
+        // ever listen to our own table, so nothing above fires when another table
+        // finishes a hand or a player.  The rest of this mirrors Rank, which reports
+        // the same two figures and needs them current for the same reasons -
+        // STATE_NEW_LEVEL_CHECK included, since clients do not receive
+        // PROP_PLAYER_FINISHED.
+        int nEvents = PokerTableEvent.TYPE_PLAYER_REBUY |
+                      PokerTableEvent.TYPE_END_HAND |
+                      PokerTableEvent.TYPE_NEW_HAND |
+                      PokerTableEvent.TYPE_PLAYER_CHIPS_CHANGED;
+        if (game_.isOnlineGame()) nEvents |= PokerTableEvent.TYPE_STATE_CHANGED;
+        trackTableEvents(nEvents);
+
+        game_.addPropertyChangeListener(PokerGame.PROP_GAME_LOADED, this);
+        game_.addPropertyChangeListener(PokerGame.PROP_GAME_OVER, this);
+        game_.addPropertyChangeListener(PokerGame.PROP_PLAYER_FINISHED, this);
+
         PokerUtils.getGameboard().addTerritorySelectionListener(this);
+    }
+
+    /**
+     * Only the level check is of interest among the state changes - it runs after
+     * clean-up, so the number of players left is settled by then.  Everything else
+     * we track updates unconditionally, as the superclass does.
+     */
+    @Override
+    public void tableEventOccurred(PokerTableEvent event)
+    {
+        if (event.getType() == PokerTableEvent.TYPE_STATE_CHANGED &&
+            event.getNew() != PokerTable.STATE_NEW_LEVEL_CHECK) return;
+
+        super.tableEventOccurred(event);
+    }
+
+    // these arrive on the game's thread, not the swing one - unlike the table events,
+    // which the superclass already delivers in swing.  We set label text directly.
+    private final Runnable updateInfoRunner_ = new Runnable()
+    {
+        public void run()
+        {
+            // invoke() is invokeLater from the game's thread, so the game can be torn
+            // down before we run: finish() clears players_ and the rank lookup then
+            // throws.  isDisplayed() is no help - bUiCreated_ is never reset - so this
+            // is the same guard updateAll() uses, for the same reason.
+            if (!game_.isFinished()) updateInfo();
+        }
+    };
+
+    /**
+     * Track the tournament-wide changes our own table does not tell us about - see
+     * the note in the constructor, and the same three in Rank.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt)
+    {
+        String name = evt.getPropertyName();
+
+        if (name.equals(PokerGame.PROP_GAME_LOADED))
+        {
+            // a load of another table's state can move everyone's position
+            GameState state = (GameState) evt.getOldValue();
+            PokerSaveDetails pdetails = (PokerSaveDetails) state.getSaveDetails().getCustomInfo();
+            if (pdetails.isOtherTableUpdate())
+            {
+                if (TournamentDirector.DEBUG_CLEANUP_TABLE) logger.debug("Update player info on other table update");
+                GuiUtils.invoke(updateInfoRunner_);
+            }
+        }
+        else if (name.equals(PokerGame.PROP_GAME_OVER) ||
+                 name.equals(PokerGame.PROP_PLAYER_FINISHED))
+        {
+            GuiUtils.invoke(updateInfoRunner_);
+        }
+        super.propertyChange(evt);
     }
 
     protected JComponent createBody()
     {
         DDPanel base = new DDPanel();
+
+        // Dropped clear of the name rather than pinned flush to it: a line of text
+        // carries its own leading and the graphic carries none, so flush against the
+        // name the graphic reads as squashed against it.  On base's gap so that the
+        // rows and the graphic drop together - the same 4 the Player Style panel puts
+        // between its own two halves.
+        ((BorderLayout) base.getLayout()).setVgap(NAME_GAP);
 
         // the player's name spans the full width, above everything else
         labelName_ = new DDLabel(GuiManager.DEFAULT, STYLE);
@@ -99,12 +187,7 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         DDPanel rows = new DDPanel(GuiManager.DEFAULT, STYLE);
         ((BorderLayout) rows.getLayout()).setHgap(4);
 
-        // Dropped clear of the name above rather than pinned flush to it.  A line of
-        // text carries its own leading and the graphic carries none, so flush against
-        // the name the graphic reads as squashed against it.
         bands_ = new RankBandsPanel();
-        JComponent bandsTop = GuiUtils.NORTH(bands_);
-        bandsTop.setBorder(BorderFactory.createEmptyBorder(BANDS_TOP_GAP, 0, 0, 0));
 
         // Top aligned so the first row stays level with the graphic.  A DDLabel
         // centres vertically by default, which would leave the two out of step
@@ -113,7 +196,7 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         labelInfo_ = new DDLabel(GuiManager.DEFAULT, STYLE);
         labelInfo_.setVerticalAlignment(SwingConstants.TOP);
 
-        rows.add(bandsTop, BorderLayout.WEST);
+        rows.add(GuiUtils.NORTH(bands_), BorderLayout.WEST);
         rows.add(labelInfo_, BorderLayout.CENTER);
         base.add(rows, BorderLayout.CENTER);
 
@@ -150,16 +233,26 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         // something useful before the mouse has been anywhere.  Done here rather than
         // where the mouse is read: that only runs once the mouse has crossed the
         // gameboard, and the panel is drawn - and starts tracking hands - well before.
-        if (last_ == null) last_ = game_.getHumanPlayer();
+        // Into a local, so last_ goes on meaning "what the mouse is on".
+        PokerPlayer player = last_ != null ? last_ : game_.getHumanPlayer();
 
-        // A player who is out has no table.  PokerGame.playerOut() marks them
-        // eliminated but only an online game converts them to an observer, so in a
-        // practice game someone watching the AI after busting is still a plain player
-        // whose seat OtherTables.cleanTable() has already taken away.  There is no
-        // position to report for them, and the rebuy row below needs a table, so they
-        // get the same empty state as no player at all.
-        PokerTable table = last_ == null || last_.isObserver() ? null : last_.getTable();
-        int nTableRank = table == null ? 0 : table.getRank(last_);
+        // Someone who is out is placed by where they finished, never by the chips in
+        // front of them - they have none, so counting chips would tie every loser for
+        // second.  PokerGame.playerOut() records the place, for the winner too.  Same
+        // rule as Rank, which prefers getPlace() over getRank() for exactly this.
+        int nPlace = player == null ? 0 : player.getPlace();
+        boolean bOut = nPlace > 0;
+
+        // No table means no seat to report and no rebuys to count.  A busted player
+        // keeps their PokerPlayer but loses their seat: processRemovedPlayers() makes
+        // them an observer, and that runs on the host - which in a practice game is
+        // the human, so this is not an online-only path.  It does not happen at once,
+        // though.  Both TournamentDirector.cleanTables() at the end of a tournament
+        // and CheckEndHand when a practice player busts deliberately leave them
+        // seated so the display still shows them, which is why having a seat cannot
+        // stand in for still being in.
+        PokerTable table = player == null || player.isObserver() ? null : player.getTable();
+        int nTableRank = table == null ? 0 : table.getRank(player);
         boolean bSeated = nTableRank > 0;
 
         // One scale or two, and with it the presence of the Table row.  Decided by the
@@ -168,7 +261,7 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         // panel changes size as the mouse moves on and off the players.
         boolean bSingleBar = game_.getNumTables() == 1;
 
-        if (bSeated)
+        if (bSeated || bOut)
         {
             String sRebuy = "";
             TournamentProfile profile = game_.getProfile();
@@ -176,11 +269,16 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             {
                 Object what = null;
 
+                // an out player has nothing left to rebuy into, and without a table
+                // there is no level to read anyway - both fall through to "none" below.
+                // Out has to be tested in its own right: cleanTable() eliminates a
+                // busted player but deliberately leaves them seated, so inside the
+                // rebuy levels they still have a table to read a level from.
                 int nLast = profile.getLastRebuyLevel();
-                if (table.getLevel() <= nLast)
+                if (!bOut && table != null && table.getLevel() <= nLast)
                 {
                     int nMax = profile.getMaxRebuys();
-                    int nRebuys = last_.getNumRebuys() + last_.getNumRebuysPending();
+                    int nRebuys = player.getNumRebuys() + player.getNumRebuysPending();
                     int nLeft = nMax - nRebuys;
 
                     if (nMax == 0)
@@ -201,41 +299,59 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
                 sRebuy = PropertyConfig.getMessage("msg.dash.rebuy", what);
             }
 
-            int numLeft = game_.getNumPlayers() - game_.getNumPlayersOut();
-            // if end of tournament, list number of players in tournament
-            if (numLeft == 0) numLeft = game_.getNumPlayers();
-            int nTourneyRank = game_.getRank(last_);
+            // The field the position is read against.  Someone who is out finished
+            // among everyone who entered - "25th of 24" otherwise, and at the end of
+            // the tournament nobody is left at all, which is the case the old count
+            // had to special-case.  A player still in it is placed among those still
+            // in it.
+            int nTourneyRank;
+            int nTourneyCount;
+            if (bOut)
+            {
+                nTourneyRank = nPlace;
+                nTourneyCount = game_.getNumPlayers();
+            }
+            else
+            {
+                nTourneyRank = game_.getRank(player);
+                nTourneyCount = game_.getNumPlayers() - game_.getNumPlayersOut();
+            }
 
-            // position at the hovered player's own table.  Dropped at a single table,
-            // where the two scales would say the same thing.
-            int nTableCount = table.getNumOccupiedSeats();
+            // Position at the hovered player's own table.  Dropped at a single table,
+            // where the two scales would say the same thing, and left blank - but
+            // still padded for - when the player is out and has no seat to report.
+            int nTableCount = bSeated ? table.getNumOccupiedSeats() : 0;
 
-            String sTable = bSingleBar ? "" :
-                            PropertyConfig.getMessage("msg.dash.playerinfo.table",
-                                      PropertyConfig.getPlace(nTableRank),
-                                      nTableCount);
+            String sTable = "";
+            if (!bSingleBar)
+            {
+                sTable = bSeated ? PropertyConfig.getMessage("msg.dash.playerinfo.table",
+                                             PropertyConfig.getPlace(nTableRank),
+                                             nTableCount)
+                                 : PropertyConfig.getMessage("msg.dash.playerinfo.table.space");
+            }
 
             // Disconnects and sit-outs can only happen in an online game - nothing in
             // a practice game sets either flag, so both counters would read zero for
             // the whole tournament.  Leave the rows out rather than show dead text.
             String sOnline = !game_.isOnlineGame() ? "" :
                              PropertyConfig.getMessage("msg.dash.playerinfo.online",
-                                      last_.getHandsPlayedDisconnected(),
-                                      last_.getHandsPlayedSitout());
+                                      player.getHandsPlayedDisconnected(),
+                                      player.getHandsPlayedSitout());
 
             labelName_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.name",
-                                      Utils.encodeHTML(last_.getName())));
+                                      Utils.encodeHTML(player.getName())));
 
             // the table row follows the tournament row directly, so the two positions
             // always read together and stay beside the graphic
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo",
                                       PropertyConfig.getPlace(nTourneyRank),
-                                      numLeft,
+                                      nTourneyCount,
                                       sTable,
                                       sOnline,
                                       sRebuy
             ));
-            bands_.setValues(nTourneyRank, numLeft, nTableRank, nTableCount, bSingleBar);
+            bands_.setValues(nTourneyRank, nTourneyCount, nTableRank, nTableCount, bSingleBar);
         }
         else
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -46,6 +46,7 @@ import com.donohoedigital.games.poker.model.TournamentProfile;
 import com.donohoedigital.gui.DDLabel;
 import com.donohoedigital.gui.DDPanel;
 import com.donohoedigital.gui.GuiManager;
+import com.donohoedigital.gui.GuiUtils;
 
 import javax.swing.*;
 import java.awt.BorderLayout;
@@ -60,6 +61,9 @@ import java.awt.event.MouseEvent;
  */
 public class PlayerInfo extends DashboardItem implements TerritorySelectionListener
 {
+    /** pixels between the name above and the top of the position graphic */
+    private static final int BANDS_TOP_GAP = 3;
+
     DDLabel labelInfo_;
     PokerPlayer last_;
     private DDLabel labelName_;
@@ -83,7 +87,6 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
     protected JComponent createBody()
     {
         DDPanel base = new DDPanel();
-        ((BorderLayout) base.getLayout()).setVgap(0);
 
         // the player's name spans the full width, above everything else
         labelName_ = new DDLabel(GuiManager.DEFAULT, STYLE);
@@ -96,12 +99,20 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         DDPanel rows = new DDPanel(GuiManager.DEFAULT, STYLE);
         ((BorderLayout) rows.getLayout()).setHgap(4);
 
+        // Dropped clear of the name above rather than pinned flush to it.  A line of
+        // text carries its own leading and the graphic carries none, so flush against
+        // the name the graphic reads as squashed against it.
         bands_ = new RankBandsPanel();
-        DDPanel bandsTop = new DDPanel();
-        ((BorderLayout) bandsTop.getLayout()).setVgap(0);
-        bandsTop.add(bands_, BorderLayout.NORTH);
+        JComponent bandsTop = GuiUtils.NORTH(bands_);
+        bandsTop.setBorder(BorderFactory.createEmptyBorder(BANDS_TOP_GAP, 0, 0, 0));
 
+        // Top aligned so the first row stays level with the graphic.  A DDLabel
+        // centres vertically by default, which would leave the two out of step
+        // whenever the rows are shorter than the graphic - a single-table practice
+        // game with no rebuys is one row against 25 pixels.
         labelInfo_ = new DDLabel(GuiManager.DEFAULT, STYLE);
+        labelInfo_.setVerticalAlignment(SwingConstants.TOP);
+
         rows.add(bandsTop, BorderLayout.WEST);
         rows.add(labelInfo_, BorderLayout.CENTER);
         base.add(rows, BorderLayout.CENTER);
@@ -121,10 +132,6 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         if (t == null) p = null;
         else p = PokerUtils.getPokerPlayer(context_, t);
 
-        // fall back to ourselves, as the Player Style panel does, so the panel
-        // says something useful before the mouse has been anywhere
-        if (p == null) p = game_.getHumanPlayer();
-
         if (p != last_)
         {
             last_ = p;
@@ -139,7 +146,29 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
     {
         if (!isOpen() || !isDisplayed()) return;
 
-        if (last_ != null && !last_.isObserver())
+        // Fall back to ourselves, as the Player Style panel does, so the panel says
+        // something useful before the mouse has been anywhere.  Done here rather than
+        // where the mouse is read: that only runs once the mouse has crossed the
+        // gameboard, and the panel is drawn - and starts tracking hands - well before.
+        if (last_ == null) last_ = game_.getHumanPlayer();
+
+        // A player who is out has no table.  PokerGame.playerOut() marks them
+        // eliminated but only an online game converts them to an observer, so in a
+        // practice game someone watching the AI after busting is still a plain player
+        // whose seat OtherTables.cleanTable() has already taken away.  There is no
+        // position to report for them, and the rebuy row below needs a table, so they
+        // get the same empty state as no player at all.
+        PokerTable table = last_ == null || last_.isObserver() ? null : last_.getTable();
+        int nTableRank = table == null ? 0 : table.getRank(last_);
+        boolean bSeated = nTableRank > 0;
+
+        // One scale or two, and with it the presence of the Table row.  Decided by the
+        // tournament alone so that both branches below agree: anything else and the
+        // empty state pads to a different height than the filled-in state, and the
+        // panel changes size as the mouse moves on and off the players.
+        boolean bSingleBar = game_.getNumTables() == 1;
+
+        if (bSeated)
         {
             String sRebuy = "";
             TournamentProfile profile = game_.getProfile();
@@ -147,7 +176,6 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             {
                 Object what = null;
 
-                PokerTable table = last_.getTable();
                 int nLast = profile.getLastRebuyLevel();
                 if (table.getLevel() <= nLast)
                 {
@@ -178,13 +206,9 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             if (numLeft == 0) numLeft = game_.getNumPlayers();
             int nTourneyRank = game_.getRank(last_);
 
-            // position at the hovered player's own table.  Rank of 0 means they are
-            // not seated - an observer, or a player already out - and at a single
-            // table the two scales would say the same thing, so the row is dropped.
-            PokerTable table = last_.getTable();
-            int nTableRank = table == null ? 0 : table.getRank(last_);
-            int nTableCount = table == null ? 0 : table.getNumOccupiedSeats();
-            boolean bSingleBar = game_.getNumTables() == 1 || nTableRank == 0 || nTableCount == 0;
+            // position at the hovered player's own table.  Dropped at a single table,
+            // where the two scales would say the same thing.
+            int nTableCount = table.getNumOccupiedSeats();
 
             String sTable = bSingleBar ? "" :
                             PropertyConfig.getMessage("msg.dash.playerinfo.table",
@@ -216,8 +240,9 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
         else
         {
             // keep the same height as when filled in, so the panel does not jump
-            // about as the mouse moves on and off the players
-            String sTableSpace = game_.getNumTables() == 1 ? "" :
+            // about as the mouse moves on and off the players.  Each row that the
+            // filled-in state can show is padded for on the same condition it appears.
+            String sTableSpace = bSingleBar ? "" :
                                  PropertyConfig.getMessage("msg.dash.playerinfo.table.space");
             String sOnlineSpace = !game_.isOnlineGame() ? "" :
                                   PropertyConfig.getMessage("msg.dash.playerinfo.online.space");
@@ -226,7 +251,10 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
             labelName_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.name.none"));
             labelInfo_.setText(PropertyConfig.getMessage("msg.dash.playerinfo.none",
                                       sTableSpace, sOnlineSpace, sRebuySpace));
-            bands_.setValues(0, 0, 0, 0, true);
+
+            // empty, but the same number of scales as when filled in - otherwise the
+            // graphic changes shape as the mouse moves on and off the players
+            bands_.setValues(0, 0, 0, 0, bSingleBar);
         }
 
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
@@ -1,0 +1,243 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker.dashboard;
+
+import com.donohoedigital.gui.*;
+
+import java.awt.*;
+
+/**
+ * Rank position graphic for the Player Info dashboard item.  Draws one or two vertical
+ * scales, each divided into bands, with a marker line showing where a player
+ * sits.  Deliberately the same 25x25 footprint as StyleQuadrantsGridPanel so the
+ * two read as siblings in the dashboard.
+ *
+ * The bar is a fixed scale and the marker travels along it - the marker is drawn
+ * over the scale and does not repaint the rest of it.  Position 1 is at the top.
+ *
+ * The bands are an approximation; exact figures are shown as text below the
+ * graphic by the Player Info item.
+ */
+public class RankBandsPanel extends DDPanel
+{
+    // panel geometry - matches StyleQuadrantsGridPanel's 25x25
+    private static final int SIZE = 25;
+    private static final int BAR_WIDTH = 9;
+    private static final int BAR_HEIGHT = 20;
+    private static final int BAR_TOP = 2;
+    private static final int LEFT_BAR_X = 2;
+    private static final int RIGHT_BAR_X = 14;
+    private static final int SINGLE_BAR_X = (SIZE - BAR_WIDTH) / 2;
+
+    /** never divide a scale into more bands than this */
+    private static final int MAX_BANDS = 10;
+
+    // default palette, taken from StyleQuadrantsGridPanel so this looks native
+    static final Color DEFAULT_BACKGROUND = Color.BLACK;
+    static final Color DEFAULT_BORDER = Color.DARK_GRAY;
+    static final Color DEFAULT_MARKER = new Color(64, 128, 255);
+
+    // palette - settable so the user can pick an alternative (e.g. green->red)
+    private Color colBackground_ = DEFAULT_BACKGROUND;
+    private Color colBorder_ = DEFAULT_BORDER;
+    private Color colMarker_ = DEFAULT_MARKER;
+
+    // when both are non-null the scale is painted as a banded gradient between
+    // them (top colour -> bottom colour) instead of a flat background
+    private Color colScaleTop_ = null;
+    private Color colScaleBottom_ = null;
+
+    // current values; rank of 0 means "nothing to show"
+    private int nTourneyRank_ = 0;
+    private int nTourneyCount_ = 0;
+    private int nTableRank_ = 0;
+    private int nTableCount_ = 0;
+
+    // when the tournament field IS the table (final table, or a single-table
+    // game) both scales would show the same thing, so we draw only one
+    private boolean bSingleBar_ = false;
+
+    public RankBandsPanel()
+    {
+        setDoubleBuffered(true);
+        setPreferredSize(new Dimension(SIZE, SIZE));
+    }
+
+    /**
+     * Set the palette.  Pass null for scaleTop/scaleBottom to paint a flat
+     * background instead of a gradient.
+     */
+    public void setPalette(Color background, Color border, Color marker,
+                           Color scaleTop, Color scaleBottom)
+    {
+        colBackground_ = background;
+        colBorder_ = border;
+        colMarker_ = marker;
+        colScaleTop_ = scaleTop;
+        colScaleBottom_ = scaleBottom;
+        repaint();
+    }
+
+    /**
+     * Show a player's position.  bSingleBar collapses to one scale for the final
+     * table and single-table games, where the two would be identical.
+     */
+    public void setValues(int nTourneyRank, int nTourneyCount,
+                          int nTableRank, int nTableCount, boolean bSingleBar)
+    {
+        nTourneyRank_ = nTourneyRank;
+        nTourneyCount_ = nTourneyCount;
+        nTableRank_ = nTableRank;
+        nTableCount_ = nTableCount;
+        bSingleBar_ = bSingleBar;
+        repaint();
+    }
+
+    /**
+     * Nothing hovered / nothing to show - scales are drawn empty.
+     */
+    public void clear()
+    {
+        nTourneyRank_ = 0;
+        nTourneyCount_ = 0;
+        nTableRank_ = 0;
+        nTableCount_ = 0;
+        repaint();
+    }
+
+    /**
+     * Number of bands for a field of the given size.  "Match the count where
+     * it's small": one band per player when the field is small enough, deciles
+     * otherwise.  A table never has more than 10 seats, so a table scale is
+     * always exact.
+     */
+    private int getNumBands(int nCount)
+    {
+        if (nCount <= 0) return 0;
+        return Math.min(nCount, MAX_BANDS);
+    }
+
+    /**
+     * Which band (0-based, 0 at the top) a rank falls into.
+     */
+    private int getBandIndex(int nRank, int nCount, int nBands)
+    {
+        if (nBands <= 0 || nCount <= 0) return -1;
+        int nIndex = (int) (((long) (nRank - 1) * nBands) / nCount);
+        if (nIndex < 0) nIndex = 0;
+        if (nIndex >= nBands) nIndex = nBands - 1;
+        return nIndex;
+    }
+
+    /**
+     * Top edge of band i, relative to the top of the bar.  Computed as
+     * round(i * H / N) so the remainder is spread across the bands - they differ
+     * by at most a pixel and none can collapse to zero height.
+     */
+    private int getBandOffset(int nIndex, int nBands)
+    {
+        return Math.round((nIndex * (float) BAR_HEIGHT) / nBands);
+    }
+
+    @Override
+    public void paintComponent(Graphics g1)
+    {
+        super.paintComponent(g1);
+
+        Graphics2D g = (Graphics2D) g1;
+
+        if (bSingleBar_)
+        {
+            paintScale(g, SINGLE_BAR_X, nTourneyRank_, nTourneyCount_);
+        }
+        else
+        {
+            paintScale(g, LEFT_BAR_X, nTourneyRank_, nTourneyCount_);
+            paintScale(g, RIGHT_BAR_X, nTableRank_, nTableCount_);
+        }
+    }
+
+    /**
+     * Paint one scale plus its marker.  The scale is painted first and the
+     * marker drawn over it, so the rest of the scale shows through either side.
+     */
+    private void paintScale(Graphics2D g, int nX, int nRank, int nCount)
+    {
+        int nBands = getNumBands(nCount);
+
+        // background / scale.  No per-band divider lines: at ~2px a band there
+        // is no room for them.  With a gradient the bands read as colour steps.
+        if (nBands > 0 && colScaleTop_ != null && colScaleBottom_ != null)
+        {
+            for (int i = 0; i < nBands; i++)
+            {
+                int nTop = getBandOffset(i, nBands);
+                int nBottom = getBandOffset(i + 1, nBands);
+                g.setColor(blend(colScaleTop_, colScaleBottom_, i, nBands));
+                g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
+            }
+        }
+        else
+        {
+            g.setColor(colBackground_);
+            g.fillRect(nX, BAR_TOP, BAR_WIDTH, BAR_HEIGHT);
+        }
+
+        // marker - only when we actually have a player
+        int nIndex = getBandIndex(nRank, nCount, nBands);
+        if (nRank > 0 && nIndex >= 0)
+        {
+            int nTop = getBandOffset(nIndex, nBands);
+            int nBottom = getBandOffset(nIndex + 1, nBands);
+            g.setColor(colMarker_);
+            g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
+        }
+
+        // border last so it is never painted over
+        g.setColor(colBorder_);
+        g.drawRect(nX - 1, BAR_TOP - 1, BAR_WIDTH + 1, BAR_HEIGHT + 1);
+    }
+
+    /**
+     * Colour for band i of n, interpolated between the two scale endpoints.
+     * Banded rather than smooth so the band structure stays visible.
+     */
+    private Color blend(Color top, Color bottom, int nIndex, int nBands)
+    {
+        float f = (nBands <= 1) ? 0f : (nIndex / (float) (nBands - 1));
+        int r = Math.round(top.getRed() + f * (bottom.getRed() - top.getRed()));
+        int g = Math.round(top.getGreen() + f * (bottom.getGreen() - top.getGreen()));
+        int b = Math.round(top.getBlue() + f * (bottom.getBlue() - top.getBlue()));
+        return new Color(r, g, b);
+    }
+}

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
@@ -54,13 +54,17 @@ import java.awt.*;
  */
 public class RankBandsPanel extends DDPanel
 {
-    // panel geometry - matches StyleQuadrantsGridPanel's 25x25
+    // Panel geometry - matches StyleQuadrantsGridPanel's 25x25.  A scale is BAR_WIDTH
+    // wide with its border drawn a pixel outside that, so the two of them span x=0..10
+    // and x=14..24, leaving three clear columns down the middle.  Worth the space: the
+    // panel is not opaque, so a one-pixel gap between two dark grey borders reads as a
+    // seam rather than as two scales.
     private static final int SIZE = 25;
     private static final int BAR_WIDTH = 9;
     private static final int BAR_HEIGHT = 20;
     private static final int BAR_TOP = 2;
-    private static final int LEFT_BAR_X = 2;
-    private static final int RIGHT_BAR_X = 14;
+    private static final int LEFT_BAR_X = 1;
+    private static final int RIGHT_BAR_X = 15;
     private static final int SINGLE_BAR_X = (SIZE - BAR_WIDTH) / 2;
 
     /** never divide a scale into more bands than this */
@@ -85,7 +89,6 @@ public class RankBandsPanel extends DDPanel
 
     public RankBandsPanel()
     {
-        setDoubleBuffered(true);
         setPreferredSize(new Dimension(SIZE, SIZE));
     }
 
@@ -141,11 +144,9 @@ public class RankBandsPanel extends DDPanel
     }
 
     @Override
-    public void paintComponent(Graphics g1)
+    public void paintComponent(Graphics g)
     {
-        super.paintComponent(g1);
-
-        Graphics2D g = (Graphics2D) g1;
+        super.paintComponent(g);
 
         if (bSingleBar_)
         {
@@ -163,7 +164,7 @@ public class RankBandsPanel extends DDPanel
      * filled over the band the player falls in, so the scale shows above and below it.
      * No per-band divider lines: at two pixels a band there is no room for them.
      */
-    private void paintScale(Graphics2D g, int nX, int nRank, int nCount)
+    private void paintScale(Graphics g, int nX, int nRank, int nCount)
     {
         int nBands = getNumBands(nCount);
 
@@ -171,13 +172,16 @@ public class RankBandsPanel extends DDPanel
         g.fillRect(nX, BAR_TOP, BAR_WIDTH, BAR_HEIGHT);
 
         // marker - only when we actually have a player
-        int nIndex = getBandIndex(nRank, nCount, nBands);
-        if (nRank > 0 && nIndex >= 0)
+        if (nRank > 0)
         {
-            int nTop = getBandOffset(nIndex, nBands);
-            int nBottom = getBandOffset(nIndex + 1, nBands);
-            g.setColor(MARKER);
-            g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
+            int nIndex = getBandIndex(nRank, nCount, nBands);
+            if (nIndex >= 0)
+            {
+                int nTop = getBandOffset(nIndex, nBands);
+                int nBottom = getBandOffset(nIndex + 1, nBands);
+                g.setColor(MARKER);
+                g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
+            }
         }
 
         // border last so it is never painted over

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/RankBandsPanel.java
@@ -2,31 +2,31 @@
  * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  * DD Poker - Source Code
  * Copyright (c) 2003-2026 Doug Donohoe
- *
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * For the full License text, please see the LICENSE.txt file
  * in the root directory of this project.
- *
- * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
  * graphics, text, and documentation found in this repository (including but not
- * limited to written documentation, website content, and marketing materials)
- * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
- * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
  * without explicit written permission for any uses not covered by this License.
  * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
  * in the root directory of this project.
- *
- * For inquiries regarding commercial licensing of this source code or
- * the use of names, logos, images, text, or other assets, please contact
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
  * doug [at] donohoe [dot] info.
  * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
  */
@@ -38,15 +38,19 @@ import java.awt.*;
 
 /**
  * Rank position graphic for the Player Info dashboard item.  Draws one or two vertical
- * scales, each divided into bands, with a marker line showing where a player
- * sits.  Deliberately the same 25x25 footprint as StyleQuadrantsGridPanel so the
- * two read as siblings in the dashboard.
+ * scales, each with a marker showing the band a player's position falls in - the
+ * tournament on the left, their own table on the right, or a single scale where the
+ * two would say the same thing.  Position 1 is at the top.
  *
- * The bar is a fixed scale and the marker travels along it - the marker is drawn
- * over the scale and does not repaint the rest of it.  Position 1 is at the top.
+ * The same 25x25 footprint as StyleQuadrantsGridPanel, so the two sit alongside each
+ * other in the dashboard.  Unlike that one this does not fill its square: DDPanel is
+ * not opaque, and only the scales are painted, so the dashboard shows through around
+ * them.
  *
- * The bands are an approximation; exact figures are shown as text below the
- * graphic by the Player Info item.
+ * A scale is divided into one band per player where the field is small enough, and
+ * deciles beyond that, so the marker is a band rather than a line - at ten bands in
+ * twenty pixels a line would be finer than the thing it points at.  The bands are
+ * therefore an approximation; the exact figures are the text beside the graphic.
  */
 public class RankBandsPanel extends DDPanel
 {
@@ -62,20 +66,12 @@ public class RankBandsPanel extends DDPanel
     /** never divide a scale into more bands than this */
     private static final int MAX_BANDS = 10;
 
-    // default palette, taken from StyleQuadrantsGridPanel so this looks native
-    static final Color DEFAULT_BACKGROUND = Color.BLACK;
-    static final Color DEFAULT_BORDER = Color.DARK_GRAY;
-    static final Color DEFAULT_MARKER = new Color(64, 128, 255);
-
-    // palette - settable so the user can pick an alternative (e.g. green->red)
-    private Color colBackground_ = DEFAULT_BACKGROUND;
-    private Color colBorder_ = DEFAULT_BORDER;
-    private Color colMarker_ = DEFAULT_MARKER;
-
-    // when both are non-null the scale is painted as a banded gradient between
-    // them (top colour -> bottom colour) instead of a flat background
-    private Color colScaleTop_ = null;
-    private Color colScaleBottom_ = null;
+    // palette, taken from StyleQuadrantsGridPanel so this looks native.  Hardcoded as
+    // that one and every other painter in the dashboard hardcodes: there is a single
+    // shipped styles.xml and no user-selectable colour profile to read.
+    private static final Color BACKGROUND = Color.BLACK;
+    private static final Color BORDER = Color.DARK_GRAY;
+    private static final Color MARKER = new Color(64, 128, 255);
 
     // current values; rank of 0 means "nothing to show"
     private int nTourneyRank_ = 0;
@@ -94,23 +90,10 @@ public class RankBandsPanel extends DDPanel
     }
 
     /**
-     * Set the palette.  Pass null for scaleTop/scaleBottom to paint a flat
-     * background instead of a gradient.
-     */
-    public void setPalette(Color background, Color border, Color marker,
-                           Color scaleTop, Color scaleBottom)
-    {
-        colBackground_ = background;
-        colBorder_ = border;
-        colMarker_ = marker;
-        colScaleTop_ = scaleTop;
-        colScaleBottom_ = scaleBottom;
-        repaint();
-    }
-
-    /**
-     * Show a player's position.  bSingleBar collapses to one scale for the final
-     * table and single-table games, where the two would be identical.
+     * Show a player's position.  A rank of 0 draws that scale empty, which is how the
+     * Player Info item shows "nothing to report" without the graphic changing shape.
+     * bSingleBar collapses to one scale for single-table games, where the two would be
+     * identical.
      */
     public void setValues(int nTourneyRank, int nTourneyCount,
                           int nTableRank, int nTableCount, boolean bSingleBar)
@@ -120,18 +103,6 @@ public class RankBandsPanel extends DDPanel
         nTableRank_ = nTableRank;
         nTableCount_ = nTableCount;
         bSingleBar_ = bSingleBar;
-        repaint();
-    }
-
-    /**
-     * Nothing hovered / nothing to show - scales are drawn empty.
-     */
-    public void clear()
-    {
-        nTourneyRank_ = 0;
-        nTourneyCount_ = 0;
-        nTableRank_ = 0;
-        nTableCount_ = 0;
         repaint();
     }
 
@@ -188,30 +159,16 @@ public class RankBandsPanel extends DDPanel
     }
 
     /**
-     * Paint one scale plus its marker.  The scale is painted first and the
-     * marker drawn over it, so the rest of the scale shows through either side.
+     * Paint one scale plus its marker.  The scale is painted first and the marker
+     * filled over the band the player falls in, so the scale shows above and below it.
+     * No per-band divider lines: at two pixels a band there is no room for them.
      */
     private void paintScale(Graphics2D g, int nX, int nRank, int nCount)
     {
         int nBands = getNumBands(nCount);
 
-        // background / scale.  No per-band divider lines: at ~2px a band there
-        // is no room for them.  With a gradient the bands read as colour steps.
-        if (nBands > 0 && colScaleTop_ != null && colScaleBottom_ != null)
-        {
-            for (int i = 0; i < nBands; i++)
-            {
-                int nTop = getBandOffset(i, nBands);
-                int nBottom = getBandOffset(i + 1, nBands);
-                g.setColor(blend(colScaleTop_, colScaleBottom_, i, nBands));
-                g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
-            }
-        }
-        else
-        {
-            g.setColor(colBackground_);
-            g.fillRect(nX, BAR_TOP, BAR_WIDTH, BAR_HEIGHT);
-        }
+        g.setColor(BACKGROUND);
+        g.fillRect(nX, BAR_TOP, BAR_WIDTH, BAR_HEIGHT);
 
         // marker - only when we actually have a player
         int nIndex = getBandIndex(nRank, nCount, nBands);
@@ -219,25 +176,12 @@ public class RankBandsPanel extends DDPanel
         {
             int nTop = getBandOffset(nIndex, nBands);
             int nBottom = getBandOffset(nIndex + 1, nBands);
-            g.setColor(colMarker_);
+            g.setColor(MARKER);
             g.fillRect(nX, BAR_TOP + nTop, BAR_WIDTH, nBottom - nTop);
         }
 
         // border last so it is never painted over
-        g.setColor(colBorder_);
+        g.setColor(BORDER);
         g.drawRect(nX - 1, BAR_TOP - 1, BAR_WIDTH + 1, BAR_HEIGHT + 1);
-    }
-
-    /**
-     * Colour for band i of n, interpolated between the two scale endpoints.
-     * Banded rather than smooth so the band structure stays visible.
-     */
-    private Color blend(Color top, Color bottom, int nIndex, int nBands)
-    {
-        float f = (nBands <= 1) ? 0f : (nIndex / (float) (nBands - 1));
-        int r = Math.round(top.getRed() + f * (bottom.getRed() - top.getRed()));
-        int g = Math.round(top.getGreen() + f * (bottom.getGreen() - top.getGreen()));
-        int b = Math.round(top.getBlue() + f * (bottom.getBlue() - top.getBlue()));
-        return new Color(r, g, b);
     }
 }

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1885,8 +1885,9 @@ msg.dash.rebuy.space=		<BR>&nbsp;
 # {0} is the tournament place and {1} the number of players left; {2} is the table
 # row, blank at a single table; {3} is the pair of online-only rows, blank in a
 # practice game; {4} is rebuys, blank when the tournament does not allow them.
-# Each of the last three has a matching blank-line key below, emitted on exactly the
-# same condition, so the empty state is the same height as the filled-in one.
+# Each of the last three has a matching blank-line key - .table.space, .online.space
+# and msg.dash.rebuy.space - emitted on exactly the same condition, so the panel is
+# the same height whichever state it is in.
 msg.dash.playerinfo= <HTML><font color="white">Tournament:</font> <font color="yellow">{0} of {1}</font>\
 						{2}{3}{4}
 msg.dash.playerinfo.table=	<BR><font color="white">Table:</font> <font color="yellow">{0} of {1}</font>

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1881,10 +1881,12 @@ msg.dash.playerinfo.name.none= <HTML><font color="white">Player:</font> <font co
 msg.dash.playerinfo.none= <HTML>&nbsp;{0}{1}{2}
 msg.dash.rebuy.space=		<BR>&nbsp;
 
-# rows built up by PlayerInfo, in this order so the two positions read together:
-# {2} is the table row, blank at a single table; {3} is the pair of online-only
-# rows, blank in a practice game; {4} is rebuys, blank when the tournament does
-# not allow them
+# rows built up by PlayerInfo, in this order so the two positions read together.
+# {0} is the tournament place and {1} the number of players left; {2} is the table
+# row, blank at a single table; {3} is the pair of online-only rows, blank in a
+# practice game; {4} is rebuys, blank when the tournament does not allow them.
+# Each of the last three has a matching blank-line key below, emitted on exactly the
+# same condition, so the empty state is the same height as the filled-in one.
 msg.dash.playerinfo= <HTML><font color="white">Tournament:</font> <font color="yellow">{0} of {1}</font>\
 						{2}{3}{4}
 msg.dash.playerinfo.table=	<BR><font color="white">Table:</font> <font color="yellow">{0} of {1}</font>

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1874,16 +1874,21 @@ label.ante.label=		Ante
 label.levelx.label=		Level
 label.tname.label=
 
-msg.dash.playerinfo.none= <HTML><font color="white">Player:</font> <font color="yellow">(mouse over a player)</font><BR>\
-							&nbsp;\
-							{0}{1}
+# the name is its own label, above the rows the position graphic sits beside
+msg.dash.playerinfo.name= <HTML><font color="white">Player:</font> <font color="yellow">{0}</font>
+msg.dash.playerinfo.name.none= <HTML><font color="white">Player:</font> <font color="yellow">(mouse over a player)</font>
+
+msg.dash.playerinfo.none= <HTML>&nbsp;{0}{1}{2}
 msg.dash.rebuy.space=		<BR>&nbsp;
 
-# rows built up by PlayerInfo: {3} is the pair of online-only rows, blank in a
-# practice game; {4} is rebuys, blank when the tournament does not allow them
-msg.dash.playerinfo= <HTML><font color="white">Player:</font> <font color="yellow">{0}</font><BR>\
-						<font color="white">Rank:</font> <font color="yellow">{1} of {2}</font>\
-						{3}{4}
+# rows built up by PlayerInfo, in this order so the two positions read together:
+# {2} is the table row, blank at a single table; {3} is the pair of online-only
+# rows, blank in a practice game; {4} is rebuys, blank when the tournament does
+# not allow them
+msg.dash.playerinfo= <HTML><font color="white">Tournament:</font> <font color="yellow">{0} of {1}</font>\
+						{2}{3}{4}
+msg.dash.playerinfo.table=	<BR><font color="white">Table:</font> <font color="yellow">{0} of {1}</font>
+msg.dash.playerinfo.table.space= <BR>&nbsp;
 msg.dash.playerinfo.online=	<BR><font color="white">Disconnected Hands:</font> <font color="yellow">{0}</font><BR>\
 							<font color="white">Sitting-out Hands:</font> <font color="yellow">{1}</font>
 msg.dash.playerinfo.online.space= <BR>&nbsp;<BR>&nbsp;

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
@@ -103,7 +103,9 @@ public class PokerTableRankTest
      */
     private HoldemHand startHand(PokerTable table)
     {
-        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
+        // the button, and with it the blinds, has to land somewhere - which seat ends
+        // up posting depends on how many are seated, so each caller says for itself
+        table.setButton(1);
         HoldemHand hhand = new HoldemHand(table);
         table.setHoldemHand(hhand);
         hhand.deal();
@@ -142,16 +144,24 @@ public class PokerTableRankTest
      * The seat array is walked in full rather than up to getSeats(): addPlayer() seats
      * at a random index in 0..SEATS-1 whatever the table's size, so a player can sit in
      * a high seat at a short table.  Ranking to a shorter bound would not see them.
+     *
+     * The table has to be genuinely short for this to test anything - at the default
+     * ten seats the two bounds are the same number and the test passes either way.
+     * The profile must be set before the table is built, since getSeats() caches.
      */
     @Test
     public void countsPlayersInEverySeat()
     {
+        game_.getProfile().getMap().setInteger(TournamentProfile.PARAM_TABLE_SEATS, 6);
         PokerTable table = table(1);
+        assertTrue("expected a short table", table.getSeats() < PokerConstants.SEATS);
+
         PokerPlayer low = seat(table, 0, 1, 500);
         PokerPlayer high = seat(table, PokerConstants.SEATS - 1, 2, 1500);
 
         assertEquals(1, table.getRank(high));
-        assertEquals("the player in the last seat has to be counted", 2, table.getRank(low));
+        assertEquals("the player past the last seat of a short table has to be counted",
+                     2, table.getRank(low));
     }
 
     /**
@@ -200,7 +210,9 @@ public class PokerTableRankTest
     }
 
     /**
-     * SimulatorDialog builds a table with no game behind it.
+     * SimulatorDialog builds a table with no game behind it.  The player is seated, so
+     * this fails if the null-game guard goes: without it the answer would come from
+     * counting, and a seated player counts as first rather than as not found.
      */
     @Test
     public void returnsZeroWhenTableHasNoGame()
@@ -208,8 +220,41 @@ public class PokerTableRankTest
         PokerTable orphan = new PokerTable(null, 0);
         PokerPlayer p = new PokerPlayer(1, "P1", true);
         p.setChipCount(1000);
+        orphan.setPlayer(p, 0);
 
-        assertEquals(0, orphan.getRank(p));
+        assertEquals("no game to read chip counts through, seated or not",
+                     0, orphan.getRank(p));
+    }
+
+    /**
+     * A player with nothing left is still seated, so they rank last rather than 0 -
+     * the same 0 an unseated player gets, which is the confusion worth pinning down.
+     */
+    @Test
+    public void brokePlayerWhoIsStillSeatedRanksLastNotZero()
+    {
+        PokerTable table = table(1);
+        seat(table, 0, 1, 1000);
+        seat(table, 1, 2, 900);
+        PokerPlayer broke = seat(table, 2, 3, 0);
+
+        assertEquals(3, table.getRank(broke));
+    }
+
+    /**
+     * Table-scoped twin of PokerGameRankTest.allPlayersBrokeRanksFirstRatherThanZero.
+     * Both count through RankUtils, so a table where nobody has chips has to answer the
+     * same way the tournament-wide version does - first, not the not-seated-here 0.
+     */
+    @Test
+    public void allPlayersAtThisTableBrokeRankFirstRatherThanZero()
+    {
+        PokerTable table = table(1);
+        PokerPlayer a = seat(table, 0, 1, 0);
+        PokerPlayer b = seat(table, 1, 2, 0);
+
+        assertEquals(1, table.getRank(a));
+        assertEquals(1, table.getRank(b));
     }
 
     /**
@@ -223,15 +268,23 @@ public class PokerTableRankTest
         // seats 1 and 2 take the button and the small blind, which puts the big blind
         // on the leader in seat 3 and leaves the rival in seat 0 posting nothing
         PokerTable table = table(1);
-        PokerPlayer rival = seat(table, 0, 2, 999);
+        PokerPlayer rival = seat(table, 0, 2, 500);
         seat(table, 1, 3, 500);
         seat(table, 2, 4, 500);
         PokerPlayer leader = seat(table, 3, 1, 1000);
         HoldemHand hhand = startHand(table);
 
         assertTrue("expected a hand in progress", table.isHandInProgress());
-        assertTrue("expected the leader to post a blind", hhand.getTotalBet(leader) > 0);
-        assertEquals("the rival must not have posted", 0, hhand.getTotalBet(rival));
+        int nCommitted = hhand.getTotalBet(leader);
+        int nRivalCommitted = hhand.getTotalBet(rival);
+        assertTrue("expected the blind to cost the leader more than the rival paid",
+                   nCommitted - nRivalCommitted > 1);
+
+        // Leave the rival one chip behind on settled counts, which puts them ahead on
+        // live ones - the leader has more in the pot.  Derived from what the deal
+        // actually charged rather than assuming it: the stakes belong to the profile,
+        // and a failure here should be about ranking, not about level one being 1/2.
+        rival.setChipCount(leader.getChipCount() + nCommitted - nRivalCommitted - 1);
         assertTrue("the leader's live count must have dropped below the rival's",
                    leader.getChipCount() < rival.getChipCount());
 
@@ -241,23 +294,27 @@ public class PokerTableRankTest
 
     /**
      * Heads-up, where both players post every hand: the button takes the small blind
-     * and the other the big.  The blinds differ by one chip, so two stacks a chip apart
-     * come out of the deal holding exactly the same live count - a live comparison
-     * would tie them and rank both first.  Settled counts still tell them apart.
+     * and the other the big.  Two stacks close enough together can come out of the deal
+     * holding the same live count - a live comparison would tie them and rank both
+     * first.  Settled counts still tell them apart, by the difference between the posts.
      */
     @Test
     public void usesSettledChipsHeadsUp()
     {
         PokerTable table = table(1);
         PokerPlayer leader = seat(table, 0, 1, 1000);
-        PokerPlayer rival = seat(table, 1, 2, 999);
+        PokerPlayer rival = seat(table, 1, 2, 1000);
         HoldemHand hhand = startHand(table);
 
         assertTrue("expected a hand in progress", table.isHandInProgress());
         assertTrue("expected both players to post", hhand.getTotalBet(leader) > 0 &&
                                                     hhand.getTotalBet(rival) > 0);
-        assertEquals("the blinds must leave the live counts level",
-                     leader.getChipCount(), rival.getChipCount());
+        assertTrue("the button takes the small blind, so seat 0 must have posted more",
+                   hhand.getTotalBet(leader) > hhand.getTotalBet(rival));
+
+        // level the live counts, whatever the blinds cost: settled is live plus what is
+        // in the pot, so the big blind stays ahead by the difference between the posts
+        rival.setChipCount(leader.getChipCount());
 
         assertEquals("settled counts still put the leader first", 1, table.getRank(leader));
         assertEquals("and the rival second, where a live count would tie them",

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
@@ -1,0 +1,288 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.config.ApplicationType;
+import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies PokerTable.getRank() ranks a player among those seated at one table, using
+ * the same count as PokerGame.getRank() - both go through RankUtils, so the two can
+ * never disagree about ties or about which chip count they compare.
+ *
+ * The differences from the tournament-wide version are what is worth pinning down: it
+ * walks a fixed seat array with gaps in it, it ignores players at other tables, and it
+ * returns 0 rather than throwing when the player is not seated here, since it is asked
+ * about whoever is under the mouse.
+ */
+public class PokerTableRankTest
+{
+    private PokerGame game_;
+
+    @Before
+    public void setUp()
+    {
+        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
+        game_ = new PokerGame(null);
+        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
+    }
+
+    private PokerTable table(int nNum)
+    {
+        PokerTable t = new PokerTable(game_, nNum);
+        t.setMinChip(1); // HoldemHand.addToPot() divides by this
+        return t;
+    }
+
+    /**
+     * Seat a player, snapshotting their chips as the count at the start of the hand.
+     */
+    private PokerPlayer seat(PokerTable table, int nSeat, int nId, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
+        p.setChipCount(nChips);
+        p.newSimulatedHand();
+        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * A player in the tournament but not seated anywhere - which is what a busted
+     * player is, once OtherTables.cleanTable() has removed them.
+     */
+    private PokerPlayer unseated(int nId, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
+        p.setChipCount(nChips);
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * Put a hand in progress at the table, far enough along that chips can be committed.
+     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
+     * needs it before any bet is recorded.
+     */
+    private HoldemHand startHand(PokerTable table)
+    {
+        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
+        HoldemHand hhand = new HoldemHand(table);
+        table.setHoldemHand(hhand);
+        hhand.deal();
+        return hhand;
+    }
+
+    @Test
+    public void countsPlayersAtThisTableWithStrictlyMoreChips()
+    {
+        PokerTable table = table(1);
+        PokerPlayer a = seat(table, 0, 1, 1000);
+        PokerPlayer b = seat(table, 1, 2, 900);
+        PokerPlayer c = seat(table, 2, 3, 800);
+
+        assertEquals(1, table.getRank(a));
+        assertEquals(2, table.getRank(b));
+        assertEquals(3, table.getRank(c));
+    }
+
+    @Test
+    public void tiedPlayersShareARank()
+    {
+        PokerTable table = table(1);
+        PokerPlayer a = seat(table, 0, 1, 1000);
+        PokerPlayer b = seat(table, 1, 2, 900);
+        PokerPlayer c = seat(table, 2, 3, 900);
+        PokerPlayer d = seat(table, 3, 4, 700);
+
+        assertEquals(1, table.getRank(a));
+        assertEquals("tied players share the better rank", 2, table.getRank(b));
+        assertEquals("tied players share the better rank", 2, table.getRank(c));
+        assertEquals("the rank after a tie skips the shared spot", 4, table.getRank(d));
+    }
+
+    /**
+     * The seat array is walked in full rather than up to getSeats(): addPlayer() seats
+     * at a random index in 0..SEATS-1 whatever the table's size, so a player can sit in
+     * a high seat at a short table.  Ranking to a shorter bound would not see them.
+     */
+    @Test
+    public void countsPlayersInEverySeat()
+    {
+        PokerTable table = table(1);
+        PokerPlayer low = seat(table, 0, 1, 500);
+        PokerPlayer high = seat(table, PokerConstants.SEATS - 1, 2, 1500);
+
+        assertEquals(1, table.getRank(high));
+        assertEquals("the player in the last seat has to be counted", 2, table.getRank(low));
+    }
+
+    /**
+     * The whole point of the table-scoped rank: a short stack here is still first at
+     * this table however the rest of the tournament is doing.
+     */
+    @Test
+    public void ignoresPlayersAtOtherTables()
+    {
+        PokerTable ours = table(1);
+        PokerTable theirs = table(2);
+
+        PokerPlayer shortStack = seat(ours, 0, 1, 300);
+        seat(ours, 1, 2, 200);
+        seat(theirs, 0, 3, 9000);
+        seat(theirs, 1, 4, 8000);
+
+        assertEquals("first of two here", 1, ours.getRank(shortStack));
+        assertEquals("but third of four overall", 3, game_.getRank(shortStack));
+    }
+
+    @Test
+    public void returnsZeroForPlayerSeatedAtAnotherTable()
+    {
+        PokerTable ours = table(1);
+        PokerTable theirs = table(2);
+        seat(ours, 0, 1, 1000);
+        PokerPlayer elsewhere = seat(theirs, 0, 2, 1000);
+
+        assertEquals(0, ours.getRank(elsewhere));
+    }
+
+    /**
+     * A busted player has no table at all.  The tournament-wide version throws when it
+     * cannot find a player; this one has to answer, because it is asked about whoever
+     * the mouse is over.
+     */
+    @Test
+    public void returnsZeroForPlayerWithNoTable()
+    {
+        PokerTable table = table(1);
+        seat(table, 0, 1, 1000);
+        PokerPlayer busted = unseated(2, 0);
+
+        assertEquals(0, table.getRank(busted));
+    }
+
+    /**
+     * SimulatorDialog builds a table with no game behind it.
+     */
+    @Test
+    public void returnsZeroWhenTableHasNoGame()
+    {
+        PokerTable orphan = new PokerTable(null, 0);
+        PokerPlayer p = new PokerPlayer(1, "P1", true);
+        p.setChipCount(1000);
+
+        assertEquals(0, orphan.getRank(p));
+    }
+
+    /**
+     * Ranks are read at arbitrary moments - PlayerInfo recomputes on every mouse-over,
+     * which lands mid-hand.  Comparing live counts would sink whoever has chips in the
+     * pot, so the leader would drop a place the instant they posted a blind.
+     */
+    @Test
+    public void usesSettledChipsWhileAHandIsInProgress()
+    {
+        // seats 1 and 2 take the button and the small blind, which puts the big blind
+        // on the leader in seat 3 and leaves the rival in seat 0 posting nothing
+        PokerTable table = table(1);
+        PokerPlayer rival = seat(table, 0, 2, 999);
+        seat(table, 1, 3, 500);
+        seat(table, 2, 4, 500);
+        PokerPlayer leader = seat(table, 3, 1, 1000);
+        HoldemHand hhand = startHand(table);
+
+        assertTrue("expected a hand in progress", table.isHandInProgress());
+        assertTrue("expected the leader to post a blind", hhand.getTotalBet(leader) > 0);
+        assertEquals("the rival must not have posted", 0, hhand.getTotalBet(rival));
+        assertTrue("the leader's live count must have dropped below the rival's",
+                   leader.getChipCount() < rival.getChipCount());
+
+        assertEquals("settled counts still put the leader first", 1, table.getRank(leader));
+        assertEquals(2, table.getRank(rival));
+    }
+
+    /**
+     * Heads-up, where both players post every hand: the button takes the small blind
+     * and the other the big.  The blinds differ by one chip, so two stacks a chip apart
+     * come out of the deal holding exactly the same live count - a live comparison
+     * would tie them and rank both first.  Settled counts still tell them apart.
+     */
+    @Test
+    public void usesSettledChipsHeadsUp()
+    {
+        PokerTable table = table(1);
+        PokerPlayer leader = seat(table, 0, 1, 1000);
+        PokerPlayer rival = seat(table, 1, 2, 999);
+        HoldemHand hhand = startHand(table);
+
+        assertTrue("expected a hand in progress", table.isHandInProgress());
+        assertTrue("expected both players to post", hhand.getTotalBet(leader) > 0 &&
+                                                    hhand.getTotalBet(rival) > 0);
+        assertEquals("the blinds must leave the live counts level",
+                     leader.getChipCount(), rival.getChipCount());
+
+        assertEquals("settled counts still put the leader first", 1, table.getRank(leader));
+        assertEquals("and the rival second, where a live count would tie them",
+                     2, table.getRank(rival));
+    }
+
+    /**
+     * At a single table the two scales are the same field, so they must give the same
+     * answer for every player - which is what sharing RankUtils buys.
+     */
+    @Test
+    public void agreesWithTournamentRankWhenEveryoneIsAtOneTable()
+    {
+        PokerTable table = table(1);
+        seat(table, 0, 1, 1000);
+        seat(table, 1, 2, 900);
+        seat(table, 2, 3, 900);
+        seat(table, 3, 4, 700);
+        seat(table, 4, 5, 0);
+
+        for (int i = 0; i < game_.getNumPlayers(); i++)
+        {
+            PokerPlayer p = game_.getPokerPlayerAt(i);
+            assertEquals("table and tournament rank differ for " + p.getName(),
+                         game_.getRank(p), table.getRank(p));
+        }
+    }
+}


### PR DESCRIPTION
Kept separate from the change that brings the panel to practice games, so that
change can be taken on its own.  This one is a matter of taste: it alters what
an online player already sees, and adds a piece of custom painting.  Nothing
below is needed for the panel to work in a practice game.

What it adds:

- The player's name moves to its own label above the rest, so the rows the
  graphic sits beside are just the positions and what follows them.

- The rank row becomes two.  "Tournament: Nth of M" is the existing row renamed
  for symmetry, joined by "Table: Nth of M" showing where the player sits among
  those at their own table.  The table row is dropped at a single table, and for
  anyone not seated - an observer, or a player already out - where the two would
  say the same thing or nothing at all.

- RankBandsPanel draws the position as one or two vertical scales with a marker.
  It sits beside the rank rows rather than the panel as a whole, pinned to the
  top of them so it stays level with the Tournament row as rows come and go, and
  is the same 25x25 footprint as the Player Style panel's quadrant graphic.  The
  bands are an approximation; the exact figures are the text beside them.

- PokerTable.getRank() is new: one more than the number of players seated at the
  table holding strictly more settled chips, counted in a single pass.  It uses
  settled counts, and returns 0 rather than throwing when the player is not
  seated there, since this is asked about whoever is under the mouse.

- The panel now tracks the end and start of a hand as well as rebuys.  The mouse
  can rest on one player for many hands while the rest of the tournament plays
  out; without this the figures freeze at whatever they were when the mouse
  arrived.  The end of a hand is the point at which every chip count in the
  tournament is settled.

- With nothing under the mouse the panel falls back to the local player, as the
  Player Style panel does, rather than showing placeholder text.  This is what
  makes the graphic worth having: it means something at a glance without having
  to point at anything first.

The empty state pads to match the filled-in height in all combinations, so the
panel does not change size as the mouse moves on and off the players.

Co-authored by Claude (Anthropic, Claude Code)
