### PR TITLE
Fix pixelated graphics

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
@@ -275,7 +275,7 @@ public class StylesConfig extends XMLConfigFileLoader
             boolean bBold = BBold == null ? false : BBold;
 
             int nStyle = Font.PLAIN;
-            if (bItalic && bBold) nStyle = Font.BOLD & Font.ITALIC;
+            if (bItalic && bBold) nStyle = Font.BOLD | Font.ITALIC;
             else if (bItalic) nStyle = Font.ITALIC;
             else if (bBold) nStyle = Font.BOLD;
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DialogPhase.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DialogPhase.java
@@ -375,7 +375,7 @@ public abstract class DialogPhase extends BasePhase implements InternalDialog.Di
         ApplicationError.assertNotNull(frame, "BaseFrame is null");
         dialog_.setBaseFrame(frame);
 
-        ImageIcon winicon = ImageConfig.getImageIcon(gamephase_.getString("dialog-windowtitle-image", "dialog-windowtitle-image"));
+        Icon winicon = DDMultiResIcon.load(gamephase_.getString("dialog-windowtitle-image", "dialog-windowtitle-image"));
         dialog_.setFrameIcon(winicon);
         dialog_.setIconifiable(gamephase_.getBoolean("dialog-iconifiable", false));
         back_ = new DialogBackground(context_, gamephase_, this, bNoShowOption_, sNoShowCheckboxName_);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineDialog.java
@@ -78,7 +78,7 @@ public class EngineDialog extends InternalDialog
      */
     public void init(GamePhase gamephase, String sTitle, boolean bResizable)
     {
-        ImageIcon winicon = ImageConfig.getImageIcon(gamephase.getString("dialog-windowtitle-image", "dialog-windowtitle-image"));
+        Icon winicon = DDMultiResIcon.load(gamephase.getString("dialog-windowtitle-image", "dialog-windowtitle-image"));
         setFrameIcon(winicon);
         setIconifiable(true);
         setResizable(bResizable);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/MenuBackground.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/MenuBackground.java
@@ -93,10 +93,10 @@ public class MenuBackground extends DDScrollPane
         GuiManager.setLabelAsMessage(version, GameEngine.getGameEngine().getVersion().toString());
 
         Dimension size = version.getPreferredSize();
-        int nShift = Utils.ISMAC ? 15 : 3; // 15 to move over for mac grow box
+        int nShift = 22;
         XYConstraints xy = new XYConstraints(pref.width - size.width - nShift - nBorderAdjust,
-                                             pref.height - size.height - 3 - nBorderAdjust,
-                                             size.width, size.height);
+                                             pref.height - size.height - 4 - nBorderAdjust,
+                                             size.width + 5, size.height);
         base.add(version, xy);
 
         // first place image

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SplashScreen.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SplashScreen.java
@@ -61,8 +61,8 @@ public class SplashScreen extends JFrame implements ActionListener, MouseListene
     private DDButton del_;
     private GameEngine engine_;
     private JLabel bpfull_, bpwin_;
-    private ImageComponent ic_;
-    private URL bgFile_;
+    private final ImageComponent ic_;
+    private final URL bgFile_;
 
     /**
      * initial splash - shown as soon as possible
@@ -79,6 +79,10 @@ public class SplashScreen extends JFrame implements ActionListener, MouseListene
         bgFile_ = bg;
         BufferedImage img = ImageDef.getBufferedImage(bg);
         ic_ = new ImageComponent(img, 1.0d);
+        // Splash is a fixed-size 1x bitmap of hard-edged artwork, painted essentially once.
+        // On a scaled display (Windows at 125%/150%, HiDPI) the default nearest-neighbor
+        // interpolation stair-steps the logo badly, so pay for bicubic here.
+        ic_.setInterpolation(RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         ic_.setLayout(new XYLayout());
         setContentPane(ic_);
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDImageButton.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDImageButton.java
@@ -122,11 +122,32 @@ public class DDImageButton extends DDButton
     }
 
     /**
-     * Override to make public
+     * Override to make public, and to smooth the icon on scaled displays.
+     *
+     * <p>The icons here are plain {@link ImageIcon}s, which draw at their natural size with no
+     * interpolation hint, so Java 2D's nearest-neighbor default stair-steps them wherever the
+     * device transform scales (e.g. Windows at 125%).  Setting the hint here rather than on the
+     * icon works because {@link JComponent#paintComponent} hands the UI a {@code g.create()}
+     * copy, which inherits rendering hints.  Bilinear rather than bicubic: these are small
+     * icons that repaint on rollover, and bicubic can ring around the edges at this size.
      */
     @Override
     public void paintComponent(Graphics g1)
     {
-        super.paintComponent(g1);
+        if (!(g1 instanceof Graphics2D g2))
+        {
+            super.paintComponent(g1);
+            return;
+        }
+
+        Object old = RenderUtils.applyInterpolation(g2, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        try
+        {
+            super.paintComponent(g1);
+        }
+        finally
+        {
+            RenderUtils.restoreInterpolation(g2, old);
+        }
     }
 }

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDImageView.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDImageView.java
@@ -81,7 +81,7 @@ public class DDImageView extends DDView
 
 		if (image_ == null)
 		{
-            logger.warn( "No image for src " + src);
+            logger.warn("No image for src {}", src);
 			return;
 		}
         
@@ -92,14 +92,14 @@ public class DDImageView extends DDView
         boolean nHeightChanged = false;
         
         String sValue = (String) getElement().getAttributes().getAttribute(HTML.Attribute.WIDTH);
-        if (sValue != null && sValue.length() > 0)
+        if (sValue != null && !sValue.isEmpty())
         {
             nWidth_ = Integer.parseInt(sValue);
             nWidthChanged = true;
         }
         
         sValue = (String) getElement().getAttributes().getAttribute(HTML.Attribute.HEIGHT);
-        if (sValue != null && sValue.length() > 0)
+        if (sValue != null && !sValue.isEmpty())
         {
             nHeight_ = Integer.parseInt(sValue);
             nHeightChanged = true;
@@ -118,7 +118,7 @@ public class DDImageView extends DDView
         }
 
         sValue = (String) getElement().getAttributes().getAttribute(YADJ);
-        if (sValue != null && sValue.length() > 0)
+        if (sValue != null && !sValue.isEmpty())
         {
             nYadj_ = Integer.parseInt(sValue);
         }
@@ -134,8 +134,22 @@ public class DDImageView extends DDView
         Rectangle rect = (a instanceof Rectangle) ? (Rectangle)a :
                          a.getBounds();
 
-        g.drawImage(image_, rect.x, rect.y+nYadj_, rect.x+nWidth_, rect.y+nHeight_+nYadj_,
-                                0, 0, image_.getWidth(), image_.getHeight(), null);
+        // Help/HTML content paints rarely, so pay for bicubic.  Without an interpolation hint
+        // Java 2D uses nearest-neighbor, which stair-steps these images on a scaled display
+        // (e.g. Windows at 125%) even when they are drawn at their natural size, since the
+        // device transform still scales them up.
+        Object old = null;
+        Graphics2D g2 = (g instanceof Graphics2D) ? (Graphics2D) g : null;
+        if (g2 != null) old = RenderUtils.applyInterpolation(g2, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        try
+        {
+            g.drawImage(image_, rect.x, rect.y+nYadj_, rect.x+nWidth_, rect.y+nHeight_+nYadj_,
+                                    0, 0, image_.getWidth(), image_.getHeight(), null);
+        }
+        finally
+        {
+            if (g2 != null) RenderUtils.restoreInterpolation(g2, old);
+        }
     }
     
     /** Determines the preferred span for this view along an
@@ -144,7 +158,7 @@ public class DDImageView extends DDView
      * @param axis may be either <code>View.X_AXIS</code> or
      * 		<code>View.Y_AXIS</code>
      * @return   the span the view would like to be rendered into.
-     *           Typically the view is told to render into the span
+     *           Typically, the view is told to render into the span
      *           that is returned, although there is no guarantee.
      *           The parent may choose to resize or break the view
      * @see View#getPreferredSpan

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDMetalBumps.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDMetalBumps.java
@@ -36,6 +36,8 @@ import com.donohoedigital.config.ImageDef;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.IndexColorModel;
@@ -43,7 +45,13 @@ import java.util.Enumeration;
 import java.util.Vector;
 
 /**
- * Implements the bump pattern used by various widgets
+ * Implements the bump pattern used by various widgets.
+ *
+ * <p>The pattern is one pixel on, one pixel off, which does not survive being upscaled by the
+ * device transform: at the fractional scales Windows uses (125%, 150%, 175%) each dot lands on a
+ * fractional device pixel and the texture turns into a soft, banded wash.  macOS only ever
+ * reports a whole-number scale, so the same code looks fine there.  The tile is therefore built
+ * at device resolution and blitted 1:1 - see {@link #paintIcon}.
  */
 public class DDMetalBumps implements Icon {
 
@@ -62,9 +70,9 @@ public class DDMetalBumps implements Icon {
         setBumpColors(newTopColor, newShadowColor, newBackColor);
     }
 
-    private BumpBuffer getBuffer(GraphicsConfiguration gc, Color aTopColor,
+    private BumpBuffer getBuffer(GraphicsConfiguration gc, double scale, Color aTopColor,
                                  Color aShadowColor, Color aBackColor) {
-        if (buffer != null && buffer.hasSameConfiguration(gc, aTopColor, aShadowColor, aBackColor)) {
+        if (buffer != null && buffer.hasSameConfiguration(gc, scale, aTopColor, aShadowColor, aBackColor)) {
             return buffer;
         }
         BumpBuffer result = null;
@@ -73,13 +81,13 @@ public class DDMetalBumps implements Icon {
 
         while (elements.hasMoreElements()) {
             BumpBuffer aBuffer = elements.nextElement();
-            if (aBuffer.hasSameConfiguration(gc, aTopColor, aShadowColor, aBackColor)) {
+            if (aBuffer.hasSameConfiguration(gc, scale, aTopColor, aShadowColor, aBackColor)) {
                 result = aBuffer;
                 break;
             }
         }
         if (result == null) {
-            result = new BumpBuffer(gc, topColor, shadowColor, backColor);
+            result = new BumpBuffer(gc, scale, aTopColor, aShadowColor, aBackColor);
             buffers.addElement(result);
         }
         return result;
@@ -101,16 +109,41 @@ public class DDMetalBumps implements Icon {
     }
 
     public void paintIcon(Component c, Graphics g, int x, int y) {
-        GraphicsConfiguration gc = (g instanceof Graphics2D) ? ((Graphics2D) g).getDeviceConfiguration() : null;
+        Graphics2D g2 = (g instanceof Graphics2D) ? (Graphics2D) g : null;
+        GraphicsConfiguration gc = (g2 == null) ? null : g2.getDeviceConfiguration();
+        double scale = RenderUtils.getDeviceScale(g2);
 
-        buffer = getBuffer(gc, topColor, shadowColor, backColor);
+        buffer = getBuffer(gc, scale, topColor, shadowColor, backColor);
 
+        if (scale == 1.0d) {
+            tile(g, x, y, getIconWidth(), getIconHeight());
+            return;
+        }
+
+        // Paint in device space with the transform reset, so the device-resolution tile is
+        // blitted one for one with no resampling.  Changing the transform does not disturb the
+        // clip already set on g2.
+        AffineTransform old = g2.getTransform();
+        Point2D origin = old.transform(new Point2D.Double(x, y), null);
+        Point2D corner = old.transform(new Point2D.Double(x + getIconWidth(), y + getIconHeight()), null);
+        int devX = (int) Math.round(origin.getX());
+        int devY = (int) Math.round(origin.getY());
+        try {
+            g2.setTransform(new AffineTransform());
+            tile(g2, devX, devY,
+                    (int) Math.round(corner.getX()) - devX,
+                    (int) Math.round(corner.getY()) - devY);
+        } finally {
+            g2.setTransform(old);
+        }
+    }
+
+    /** Tile the buffer over the given rectangle, in whatever space {@code g} is currently in. */
+    private void tile(Graphics g, int x, int y, int width, int height) {
         int bufferWidth = buffer.getImageSize().width;
         int bufferHeight = buffer.getImageSize().height;
-        int iconWidth = getIconWidth();
-        int iconHeight = getIconHeight();
-        int x2 = x + iconWidth;
-        int y2 = y + iconHeight;
+        int x2 = x + width;
+        int y2 = y + height;
         int savex = x;
 
         while (y < y2) {
@@ -138,25 +171,29 @@ public class DDMetalBumps implements Icon {
 
 class BumpBuffer {
 
+    /** Logical pixels covered by one tile.  The image itself is this times the device scale. */
     static final int IMAGE_SIZE = 64;
-    static Dimension imageSize = new Dimension(IMAGE_SIZE, IMAGE_SIZE);
 
     transient Image image;
     Color topColor;
     Color shadowColor;
     Color backColor;
     private final GraphicsConfiguration gc;
+    private final double scale;
+    private final Dimension imageSize;
 
-    public BumpBuffer(GraphicsConfiguration gc, Color aTopColor, Color aShadowColor, Color aBackColor) {
+    public BumpBuffer(GraphicsConfiguration gc, double scale, Color aTopColor, Color aShadowColor, Color aBackColor) {
         this.gc = gc;
+        this.scale = scale;
         topColor = aTopColor;
         shadowColor = aShadowColor;
         backColor = aBackColor;
+        imageSize = new Dimension(dev(IMAGE_SIZE), dev(IMAGE_SIZE));
         createImage();
         fillBumpBuffer();
     }
 
-    public boolean hasSameConfiguration(GraphicsConfiguration gc,
+    public boolean hasSameConfiguration(GraphicsConfiguration gc, double aScale,
                                         Color aTopColor, Color aShadowColor,
                                         Color aBackColor) {
         if (this.gc != null) {
@@ -166,36 +203,47 @@ class BumpBuffer {
         } else if (gc != null) {
             return false;
         }
-        return topColor.equals(aTopColor) && shadowColor.equals(aShadowColor) && backColor.equals(aBackColor);
+        return scale == aScale &&
+               topColor.equals(aTopColor) && shadowColor.equals(aShadowColor) && backColor.equals(aBackColor);
     }
 
     public Image getImage() {
         return image;
     }
 
+    /** Size of the tile in device pixels. */
     public Dimension getImageSize() {
         return imageSize;
+    }
+
+    /** Device pixel position/size for a coordinate expressed in the pattern's logical pixels. */
+    private int dev(int logical) {
+        return (int) Math.round(logical * scale);
     }
 
     private void fillBumpBuffer() {
         Graphics g = image.getGraphics();
 
+        // four dots have to fit within each 4-logical-pixel cell, so a dot can be no wider than
+        // the scale factor rounded down (1 device pixel at 125%, 2 at 200%)
+        int dot = Math.max(1, (int) Math.floor(scale));
+
         g.setColor(backColor);
-        g.fillRect(0, 0, IMAGE_SIZE, IMAGE_SIZE);
+        g.fillRect(0, 0, imageSize.width, imageSize.height);
 
         g.setColor(topColor);
         for (int x = 0; x < IMAGE_SIZE; x += 4) {
             for (int y = 0; y < IMAGE_SIZE; y += 4) {
-                g.drawLine(x, y, x, y);
-                g.drawLine(x + 2, y + 2, x + 2, y + 2);
+                g.fillRect(dev(x), dev(y), dot, dot);
+                g.fillRect(dev(x + 2), dev(y + 2), dot, dot);
             }
         }
 
         g.setColor(shadowColor);
         for (int x = 0; x < IMAGE_SIZE; x += 4) {
             for (int y = 0; y < IMAGE_SIZE; y += 4) {
-                g.drawLine(x + 1, y + 1, x + 1, y + 1);
-                g.drawLine(x + 3, y + 3, x + 3, y + 3);
+                g.fillRect(dev(x + 1), dev(y + 1), dot, dot);
+                g.fillRect(dev(x + 3), dev(y + 3), dot, dot);
             }
         }
         g.dispose();
@@ -203,11 +251,11 @@ class BumpBuffer {
 
     private void createImage() {
         if (gc != null) {
-            image = gc.createCompatibleImage(IMAGE_SIZE, IMAGE_SIZE);
+            image = gc.createCompatibleImage(imageSize.width, imageSize.height);
         } else {
             int[] cmap = {backColor.getRGB(), topColor.getRGB(), shadowColor.getRGB()};
             IndexColorModel icm = new IndexColorModel(8, 3, cmap, 0, false, -1, DataBuffer.TYPE_BYTE);
-            image = ImageDef.createBufferedImage(IMAGE_SIZE, IMAGE_SIZE, BufferedImage.TYPE_BYTE_INDEXED, icm);
+            image = ImageDef.createBufferedImage(imageSize.width, imageSize.height, BufferedImage.TYPE_BYTE_INDEXED, icm);
         }
     }
 }

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDMultiResIcon.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDMultiResIcon.java
@@ -1,0 +1,195 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.gui;
+
+import com.donohoedigital.config.ImageConfig;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * An icon that keeps higher-resolution copies of the same artwork and paints whichever one best
+ * matches the display.  A single small bitmap drawn 1:1 in logical pixels is upscaled by the
+ * device transform on a scaled display (Windows at 125%/150%, HiDPI), which is what makes such
+ * icons look soft; here the artwork is resampled once to the exact device size and drawn with
+ * the transform reset, so no scaling happens at paint time.
+ *
+ * <p>Variants are declared in images.xml next to the base image, using the same
+ * <code>{name}.{pixel size}</code> convention {@link BaseFrame} uses for window icons:
+ *
+ * <pre>
+ *   &lt;image name="window-title-icon"    location="icon_20x20.png"/&gt;
+ *   &lt;image name="window-title-icon.32" location="icon_32x32.png"/&gt;
+ * </pre>
+ *
+ * <p>The icon reports the base image's size as its size, so layout is unchanged - the variants
+ * only affect how many real pixels are used to draw it.  Missing variants are skipped, so this
+ * degrades to the base image alone.
+ *
+ * @author Doug Donohoe
+ */
+public class DDMultiResIcon implements Icon
+{
+    /**
+     * Variant sizes looked for in images.xml.  Covers the common scales for the ~20px artwork
+     * this is used for: 125% needs 25 device pixels, 150% 30, 200% 40, 300% 60.
+     */
+    private static final int[] VARIANT_SIZES = {32, 48, 64, 128};
+
+    private final Image base_;
+    private final int width_;
+    private final int height_;
+
+    /** source artwork by pixel width, smallest first */
+    private final TreeMap<Integer, Image> variants_ = new TreeMap<>();
+
+    /** artwork resampled to an exact device width, built on demand */
+    private final Map<Integer, Image> rendered_ = new HashMap<>();
+
+    /**
+     * Load {@code name} from images.xml along with any '{name}.{size}' variants.
+     *
+     * <p>Returns null when the base image is not defined, matching what
+     * {@link ImageConfig#getImageIcon(String, ImageIcon)} does.  Callers rely on that: the
+     * dialog phases look up {@code getString("dialog-windowtitle-image", "dialog-windowtitle-image")},
+     * so a phase that does not set the param resolves to a name no images.xml defines and is
+     * expected to end up with no icon rather than an error.
+     */
+    public static Icon load(String name)
+    {
+        ImageIcon base = ImageConfig.getImageIcon(name, null);
+        if (base == null) return null;
+
+        DDMultiResIcon icon = new DDMultiResIcon(base.getImage());
+
+        for (int size : VARIANT_SIZES)
+        {
+            ImageIcon variant = ImageConfig.getImageIcon(name + "." + size, null);
+            if (variant != null) icon.addVariant(variant.getImage());
+        }
+        return icon;
+    }
+
+    private DDMultiResIcon(Image base)
+    {
+        base_ = base;
+        width_ = base.getWidth(null);
+        height_ = base.getHeight(null);
+        addVariant(base);
+    }
+
+    private void addVariant(Image image)
+    {
+        variants_.put(image.getWidth(null), image);
+    }
+
+    public int getIconWidth()
+    {
+        return width_;
+    }
+
+    public int getIconHeight()
+    {
+        return height_;
+    }
+
+    public void paintIcon(Component c, Graphics g, int x, int y)
+    {
+        Graphics2D g2 = (g instanceof Graphics2D) ? (Graphics2D) g : null;
+        double scale = RenderUtils.getDeviceScale(g2);
+
+        if (scale == 1.0d)
+        {
+            g.drawImage(base_, x, y, width_, height_, null);
+            return;
+        }
+
+        // paint in device space so the artwork is drawn 1:1, at a whole-pixel origin
+        AffineTransform old = g2.getTransform();
+        Point2D origin = old.transform(new Point2D.Double(x, y), null);
+        Point2D corner = old.transform(new Point2D.Double(x + width_, y + height_), null);
+        int devX = (int) Math.round(origin.getX());
+        int devY = (int) Math.round(origin.getY());
+
+        Image image = renderedFor((int) Math.round(corner.getX()) - devX,
+                                  (int) Math.round(corner.getY()) - devY);
+        try
+        {
+            g2.setTransform(new AffineTransform());
+            g2.drawImage(image, devX, devY, null);
+        }
+        finally
+        {
+            g2.setTransform(old);
+        }
+    }
+
+    /**
+     * The artwork at exactly this many device pixels, resampled once from the smallest variant
+     * big enough to cover it (falling back to the largest available) and cached thereafter.
+     */
+    private Image renderedFor(int devWidth, int devHeight)
+    {
+        Image cached = rendered_.get(devWidth);
+        if (cached != null) return cached;
+
+        Map.Entry<Integer, Image> entry = variants_.ceilingEntry(devWidth);
+        Image source = (entry != null) ? entry.getValue() : variants_.lastEntry().getValue();
+
+        Image scaled;
+        if (source.getWidth(null) == devWidth && source.getHeight(null) == devHeight)
+        {
+            scaled = source;
+        }
+        else
+        {
+            BufferedImage buffer = new BufferedImage(devWidth, devHeight, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D bg = buffer.createGraphics();
+            RenderUtils.applyInterpolation(bg, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            bg.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            bg.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            bg.drawImage(source, 0, 0, devWidth, devHeight, null);
+            bg.dispose();
+            scaled = buffer;
+        }
+
+        rendered_.put(devWidth, scaled);
+        return scaled;
+    }
+}

--- a/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
@@ -1170,38 +1170,88 @@ public class GuiUtils
     }
 
     /**
-     * print to jpg image, scaling image into width x height, return BufferedImage for use by printImageToFile
+     * Render a Swing component to an image, scaled down (never up) to fit within width x height
+     * while preserving aspect ratio.  Uses {@link JComponent#print} rather than {@code paint} so the
+     * component renders as it would for printing (no caret blink, correct double-buffer handling),
+     * and applies the scale to the Graphics transform so painting happens directly at the target
+     * size - text and lines stay crisp instead of being downsampled from a full-size raster.
      */
     public static BufferedImage printToImage(JComponent c, int width, int height)
     {
-        double w = (double) width / (Math.max((double) c.getWidth(), width));
-        double h = (double) height / (Math.max((double) c.getHeight(), height));
-
+        double w = (double) width / Math.max((double) c.getWidth(), width);
+        double h = (double) height / Math.max((double) c.getHeight(), height);
         double dScale = Math.min(w, h);
 
-        BufferedImage image = new BufferedImage((int) (c.getWidth() * dScale), (int) (c.getHeight() * dScale),
+        BufferedImage image = new BufferedImage(Math.max(1, (int) (c.getWidth() * dScale)),
+                                                Math.max(1, (int) (c.getHeight() * dScale)),
                                                 BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = (Graphics2D) image.getGraphics();
-
-        g.scale(dScale, dScale);
-        c.print(g);
+        Graphics2D g = image.createGraphics();
+        try
+        {
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+            g.scale(dScale, dScale);
+            c.print(g);
+        }
+        finally
+        {
+            g.dispose();
+        }
         return image;
     }
 
     /**
-     * Write BufferedImage to a file
+     * Write a BufferedImage to a file, picking the format from the file extension (defaults to png).
+     * png is preferred for UI screenshots: it is lossless, so text and thin lines stay sharp, where
+     * jpg leaves ringing artifacts around them; jpg is still honored (at high quality) if requested.
      */
     public static void printImageToFile(BufferedImage image, File file)
     {
-        try
+        String format = formatFor(file);
+        try (FileOutputStream out = new FileOutputStream(file))
         {
-            FileOutputStream out = new FileOutputStream(file);
-            ImageIO.write(image, "jpg", out);
-            out.close();
+            if ("jpg".equals(format) || "jpeg".equals(format))
+            {
+                writeJpeg(image, out, 0.95f);
+            }
+            else if (!ImageIO.write(image, format, out))
+            {
+                logger.error("No image writer found for format '{}' ({})", format, file);
+            }
         }
         catch (IOException ioe)
         {
             logger.error(Utils.formatExceptionText(ioe));
+        }
+    }
+
+    /** Lower-case extension of the file, or "png" if it has none. */
+    private static String formatFor(File file)
+    {
+        String name = file.getName();
+        int dot = name.lastIndexOf('.');
+        return dot >= 0 && dot < name.length() - 1 ? name.substring(dot + 1).toLowerCase() : "png";
+    }
+
+    /** Write a JPEG at an explicit quality (0..1); JPEG can't store alpha, so callers pass RGB images. */
+    private static void writeJpeg(BufferedImage image, FileOutputStream out, float quality) throws IOException
+    {
+        javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName("jpg").next();
+        javax.imageio.ImageWriteParam param = writer.getDefaultWriteParam();
+        param.setCompressionMode(javax.imageio.ImageWriteParam.MODE_EXPLICIT);
+        param.setCompressionQuality(quality);
+        try (javax.imageio.stream.ImageOutputStream ios = ImageIO.createImageOutputStream(out))
+        {
+            writer.setOutput(ios);
+            writer.write(null, new javax.imageio.IIOImage(image, null, null), param);
+        }
+        finally
+        {
+            writer.dispose();
         }
     }
 }

--- a/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
@@ -89,6 +89,7 @@ public class ImageComponent extends JComponent implements Icon
     private boolean bRefreshBuffer_ = false;
     private BufferedImage buffer_ = null;
     private boolean bCenter_ = true;
+    private Object interpolation_ = RenderingHints.VALUE_INTERPOLATION_BILINEAR;
     static int nColor_ = -1;
 
     /**
@@ -156,6 +157,7 @@ public class ImageComponent extends JComponent implements Icon
         sName_ = copy.sName_;
         dScaleFactor_ = copy.dScaleFactor_;
         bimage_ = copy.bimage_;
+        interpolation_ = copy.interpolation_;
         init();
     }
 
@@ -396,6 +398,28 @@ public class ImageComponent extends JComponent implements Icon
     }
 
     /**
+     * Set the interpolation used when the image is drawn at a size other than its natural
+     * size.  Default is {@link RenderingHints#VALUE_INTERPOLATION_BILINEAR}.  Note this
+     * applies to HiDPI displays even when the image is drawn at its natural size in logical
+     * pixels, since the device transform still scales it up.  Pass
+     * {@link RenderingHints#VALUE_INTERPOLATION_BICUBIC} for sharper (but costlier) results
+     * on images that are painted rarely.
+     */
+    public void setInterpolation(Object interpolation)
+    {
+        interpolation_ = interpolation;
+    }
+
+    /**
+     * Apply this component's interpolation hint, returning the previous value so the caller
+     * can restore it with {@link RenderUtils#restoreInterpolation}
+     */
+    private Object applyInterpolation(Graphics2D g)
+    {
+        return RenderUtils.applyInterpolation(g, interpolation_);
+    }
+
+    /**
      * Set whether image is scaled to fit size of this component.  Default is true
      */
     public void setScaleToFit(boolean b)
@@ -459,6 +483,22 @@ public class ImageComponent extends JComponent implements Icon
         if (bHidden_) return;
 
         Graphics2D g = (Graphics2D) g1;
+        Object oldInterpolation = applyInterpolation(g);
+        try
+        {
+            paintImage(g);
+        }
+        finally
+        {
+            RenderUtils.restoreInterpolation(g, oldInterpolation);
+        }
+    }
+
+    /**
+     * Paint the image itself.  Interpolation hint is already set by the caller.
+     */
+    private void paintImage(Graphics2D g)
+    {
         g.getClipBounds(bounds_);
         Image drawThis = whatToDraw();
 
@@ -496,6 +536,7 @@ public class ImageComponent extends JComponent implements Icon
                             //LoggingConfig.debugPrintMemory("After new buffer");
                         }
                         Graphics2D gBuffer = (Graphics2D) buffer_.getGraphics();
+                        applyInterpolation(gBuffer);
 
                         // if a parentTile is specified, paint that first
                         paintParentTile(gBuffer);
@@ -687,10 +728,18 @@ public class ImageComponent extends JComponent implements Icon
      */
     private void drawImageAt(Graphics2D g, Image image, int x, int y, int width, int height)
     {
-        g.drawImage(image, x, y, (x + width), (y + height),
-                    imagebounds_.x, imagebounds_.y,
-                    (imagebounds_.x + imagebounds_.width), (imagebounds_.y + imagebounds_.height),
-                    this);
+        Object oldInterpolation = applyInterpolation(g);
+        try
+        {
+            g.drawImage(image, x, y, (x + width), (y + height),
+                        imagebounds_.x, imagebounds_.y,
+                        (imagebounds_.x + imagebounds_.width), (imagebounds_.y + imagebounds_.height),
+                        this);
+        }
+        finally
+        {
+            RenderUtils.restoreInterpolation(g, oldInterpolation);
+        }
     }
 
     /**

--- a/code/gui/src/main/java/com/donohoedigital/gui/RenderUtils.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/RenderUtils.java
@@ -1,0 +1,129 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.gui;
+
+import java.awt.Component;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+
+/**
+ * Rendering-hint helpers.
+ *
+ * <p>Deliberately free of static state: these are called from {@link ImageComponent#paintComponent},
+ * which paints the splash screen before config files are loaded.  Anything with a static initializer
+ * that touches StylesConfig/PropertyConfig (such as {@link GuiUtils}) blows up if class-loaded that
+ * early, so these cannot live there.
+ *
+ * @author Doug Donohoe
+ */
+public final class RenderUtils
+{
+    private RenderUtils() {}
+
+    /**
+     * Apply an interpolation hint, returning the previous value (possibly null) so the caller
+     * can restore it with {@link #restoreInterpolation}.  Java 2D defaults to nearest-neighbor,
+     * which visibly stair-steps images whenever they are drawn at a size other than their
+     * natural size -- including on scaled displays (Windows at 125%/150%, HiDPI), where the
+     * device transform scales even images drawn 1:1 in logical pixels.
+     */
+    public static Object applyInterpolation(Graphics2D g, Object interpolation)
+    {
+        Object old = g.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
+        return old;
+    }
+
+    /**
+     * Restore the interpolation hint saved by {@link #applyInterpolation}.  A null old value
+     * means the hint was unset, which Java 2D treats as nearest-neighbor.
+     */
+    public static void restoreInterpolation(Graphics2D g, Object old)
+    {
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                           old == null ? RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR : old);
+    }
+
+    /**
+     * Device pixels per logical pixel for {@code g2}'s current transform.  Returns 1.0 for
+     * anything other than a plain uniform scale-and-translate, since only that case can be
+     * painted in device space by resetting the transform and drawing 1:1.
+     *
+     * <p>Use this rather than {@link #getDisplayScale} when the scale is needed during a paint:
+     * it reflects the transform actually in effect, which may not be the screen's (printing, an
+     * off-screen buffer, a component painted into an image).
+     */
+    public static double getDeviceScale(Graphics2D g2)
+    {
+        if (g2 == null) return 1.0d;
+
+        AffineTransform tx = g2.getTransform();
+        if (tx.getShearX() != 0.0d || tx.getShearY() != 0.0d) return 1.0d;
+
+        double scale = tx.getScaleX();
+        return (scale > 0.0d && scale == tx.getScaleY()) ? scale : 1.0d;
+    }
+
+    /**
+     * Device pixels per logical pixel for the screen showing {@code c} (1.0 on an unscaled
+     * display, 1.25 for Windows at 125%, 2.0 for a Retina-class screen).  Falls back to the
+     * default screen when {@code c} is null or not yet realized, and to 1.0 in a headless
+     * environment.
+     *
+     * <p>Multiply by this when generating a bitmap that will be drawn into a logical-pixel box
+     * (thumbnails, scaled artwork): generating at logical size and letting the device transform
+     * upscale is what makes such images look soft.
+     */
+    public static double getDisplayScale(Component c)
+    {
+        try
+        {
+            GraphicsConfiguration gc = (c == null) ? null : c.getGraphicsConfiguration();
+            if (gc == null)
+            {
+                if (GraphicsEnvironment.isHeadless()) return 1.0d;
+                gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                                        .getDefaultScreenDevice().getDefaultConfiguration();
+            }
+            double scale = gc.getDefaultTransform().getScaleX();
+            return (scale > 0) ? scale : 1.0d;
+        }
+        catch (Exception e)
+        {
+            return 1.0d;
+        }
+    }
+}

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -49,7 +49,7 @@
 <!-- 3.1.8 -->
 
 <div style="background-color: #1D4A07; text-align: center; padding: 4px;">
-    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.8 - TBD</span></strong>
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.8 - August 31, 2026</span></strong>
 </div>
 <ul>
     <li>

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -46,6 +46,31 @@
 </table>
 <br>
 
+<!-- 3.1.8 -->
+
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.8 - TBD</span></strong>
+</div>
+<ul>
+    <li>
+        Fixed pixelated graphics on displays that use a scaling factor, such as Windows at 125% or
+        150%.  Cards, chips, the table, the splash screen, dialog icons and the images on help pages
+        were all being enlarged without smoothing, leaving them visibly jagged.  They are now drawn
+        smoothly at every display scale.
+    </li>
+    <li>
+        The textured bumps on scroll bars, sliders, split pane dividers and dialog title bars were
+        smeared into an uneven wash at those same display scales, and now render cleanly.
+    </li>
+    <li>
+        Text styled bold and italic at the same time was displayed as plain text, and now correctly
+        appears in bold italic.
+    </li>
+    <li>
+        Incorporating updates to various software dependencies.
+    </li>
+</ul>
+
 <!-- 3.1.7 -->
 
 <div style="background-color: #1D4A07; text-align: center; padding: 4px;">

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -67,6 +67,11 @@
         appears in bold italic.
     </li>
     <li>
+        Screenshots are sharper.  They are now drawn with antialiasing and saved at a higher JPEG
+        quality, so text and thin lines keep their edges instead of looking soft or picking up
+        speckled artifacts around them.
+    </li>
+    <li>
         Incorporating updates to various software dependencies.
     </li>
 </ul>

--- a/code/poker/src/main/resources/config/poker/images.xml
+++ b/code/poker/src/main/resources/config/poker/images.xml
@@ -129,7 +129,12 @@
   <image name="pokermenu" location="pokermenu.png"/>
   <image name="pokermenu-demo" location="pokermenu-demo.png"/>
   <image name="pokerdialog" location="pokerdialog.png"/>
+  <!-- dialog title bar icon; drawn at 20 logical px, larger variants for scaled displays
+       (see DDMultiResIcon) - 125% needs 25 real pixels, 150% needs 30, 200% needs 40 -->
   <image name="pokerbannerwintitle" location="poker-banner-wintitle.png"/>
+  <image name="pokerbannerwintitle.32" location="pokericon32.png"/>
+  <image name="pokerbannerwintitle.48" location="pokericon48.png"/>
+  <image name="pokerbannerwintitle.128" location="pokericon128.png"/>
   <image name="serverconnect" location="serverconnect.png"/>
   <image name="info" location="info.png"/>
   <image name="resize" location="resize.png"/>

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -54,6 +54,7 @@ public class PokerConstants
      * needed).
      */
     public static final Version VERSION = latest(
+            new Version(3, 1, 8, true), // release 3.1.8 (HiDPI rendering fixes)
             new Version(3, 1, 7, true), // release 3.1.7 (memory fix, dashboard improvements)
             new Version(3, 1, 6, true), // release 3.1.6 (Java 25, dependency updates)
             new Version(3, 1, 5, true), // release 3.1.5 (Java 21, dependency updates)


### PR DESCRIPTION
Ports rendering work from DD Photos back to DD Poker, whose GUI code that work originally came from. Prompted by pixelated graphics on a Windows laptop.

Two related but independent pieces: the HiDPI interpolation fixes (`ddphotos-app` commits `1e931f1`, `cf5ed16`, `a49b010`), and the rewritten screenshot logic.

## Root cause

Java 2D defaults to nearest-neighbor interpolation. Whenever the device transform scales what you draw — which it always does on a Windows display at 125%/150%/175% — 1x bitmaps stair-step. macOS only ever reports whole-number scales, so the same code looks acceptable there.

There was no HiDPI awareness anywhere in the codebase before this: `grep -rn "KEY_INTERPOLATION\|getScaleX\|getDefaultTransform" code/` returned nothing.

## Changes

**New**

- `gui/RenderUtils.java` — interpolation hint save/restore, plus `getDeviceScale` (scale of the transform actually in effect) and `getDisplayScale` (scale of a component's screen). Deliberately free of static state: it is called from `ImageComponent.paintComponent`, which paints the splash screen before config is loaded, so it cannot live in `GuiUtils` (whose static finals initialize from `StylesConfig`).
- `gui/DDMultiResIcon.java` — keeps higher-resolution copies of the same artwork and paints whichever best matches the display, with the transform reset so nothing is resampled at paint time.

**Modified**

- `gui/ImageComponent.java` — bilinear by default; `paintComponent` split into a hint wrapper plus `paintImage`; hint also applied to the offscreen buffer and to `drawImageAt`. This is the high-leverage one: every card, chip, dealer button and territory reaches `g.drawImage` through `EngineGamePiece.drawImageAt` → `ImageComponent.drawImageAt`, and `CardPiece`, `CardPanel` and `DDCardView` funnel in the same way.
- `gui/DDImageView.java` — bicubic on help/HTML images (painted rarely, so the cost is fine).
- `gui/DDImageButton.java` — bilinear around `super.paintComponent`. Bilinear rather than bicubic because these are small icons that repaint on rollover, where bicubic rings.
- `gui/DDMetalBumps.java` — the bump pattern is one pixel on, one pixel off, which does not survive fractional upscaling. The tile is now built at device resolution and blitted 1:1. Also fixes a latent bug where `getBuffer` built its `BumpBuffer` from the fields rather than the parameters.
- `gameengine/SplashScreen.java` — bicubic on the splash.
- `gameengine/{EngineDialog,DialogPhase}.java` — dialog title icons via `DDMultiResIcon`.
- `poker/config/poker/images.xml` — `.32`/`.48`/`.128` variants for `pokerbannerwintitle`.
- `common/StylesConfig.java` — unrelated one-character fix found while surveying: `Font.BOLD & Font.ITALIC` is `Font.PLAIN`, so bold-italic styles had been silently rendering as plain.

## Screenshot quality

Separately, `GuiUtils.printToImage` / `printImageToFile` are brought in line with the DD Photos versions. The old code set no rendering hints, wrote with `getGraphics()` and never disposed, closed the stream outside a `finally`, and ignored the filename entirely — always encoding jpg at ImageIO's default quality.

- `printToImage` — six rendering hints (render quality, antialias, text antialias, fractional metrics, bicubic, pure stroke), a `Math.max(1, ...)` guard so a zero-size component cannot throw, and `createGraphics()` with `try`/`finally` dispose.
- `printImageToFile` — format taken from the file extension (defaulting to png), jpeg written explicitly at 0.95, try-with-resources, and an error logged when ImageIO has no writer for the format. Adds private `formatFor` and `writeJpeg` helpers.

DD Photos also draws a thin border and can matte the shot on white with a drop shadow. Those serve its debug screenshot facility, which writes PNGs for documentation; DD Poker's is a player-facing save feature, so they were deliberately left out and the shots look the same as before apart from being sharper.

`SaveScreenShot` still pins `ext` to jpg (`gamedef.xml:1207`), which is intentional — the save dialog only offers JPG. Note the old behaviour meant a file named `.png` silently received JPEG bytes; extensions are now honoured.

## Two things worth reviewing

**Bilinear is unconditional, not gated on display scale.** The gameboard scales every piece by `dScale_` even at 100%, so those draws already ran through a resampling path — previously nearest-neighbor. Turning bilinear on improves the table at all board scales but does change how it looks on macOS at 100%. If chip/card animation ever stutters, the fallback is gating the hint on `RenderUtils.getDeviceScale(g) != 1.0` in `ImageComponent`.

**`DDMultiResIcon.load` diverges from the DD Photos original** by returning `null` for a missing base image instead of dereferencing it. Both dialog call sites use `getString("dialog-windowtitle-image", "dialog-windowtitle-image")`, so a phase that omits the param looks up a name no `images.xml` defines. `gamedef.xml` has 64 phases with `dialog-windowtitle-prop` but only 16 with `dialog-windowtitle-image`, so 48 dialogs take that path and are expected to end up with no icon rather than an NPE.

No new art was needed — `poker-banner-wintitle.png` turned out to be the same DD-spade artwork as the existing `pokericon32/48/128.png`.

## Verification

Full reactor builds clean; `mvn-test` passes with MySQL up.

Measured headlessly by compiling the pre-fix classes into a shadowing directory and comparing.

Metal bumps, pattern pixels on a 64px tile (ideal 1024):

| scale | before | after |
|---|---|---|
| 100% | 1024, dots {1px} | 1024, dots {1px} |
| 125% | 1792, dots {1px, 2px} | 1024, dots {1px} |
| 150% | 2560, dots {1px, 2px} | 1024, dots {1px} |
| 175% | 3328, dots {1px, 2px} | 1024, dots {1px} |
| 200% | 4096, dots {2px} | 4096, dots {2px} |

At 125% the old code laid down 75% too much ink with mixed dot sizes — the banded wash. Whole-number scales were always fine, which is why macOS looked correct.

`ImageComponent`, drawing an 8x8 black/white checkerboard into a 32px box: before, 2 colors at every scale; after, 26–42 intermediate tones.

`DDMultiResIcon`: `load("dialog-windowtitle-image")` returns `null` without throwing; the icon still reports 20x20 so layout is unchanged; at 2x it produces 810 distinct colors against 229 in the 20x20 source, confirming it draws from the larger artwork rather than upscaling.

Screenshots, rendering a text-and-lines panel through both versions and dumping each one's raster losslessly so the two effects can be told apart:

| | before | after |
|---|---|---|
| distinct tones in raster | 189 | 252 |
| jpeg compression error vs its own raster | 0.712 mean abs error | 0.162 |
| `shot.jpg` | 22,311 bytes | 35,959 bytes |
| `shot.png` | 22,311 bytes — a JPEG in a `.png` file | 21,557 bytes, real PNG |
| no extension | JPEG | PNG |

The render difference alone (old raster vs new, both lossless) is 2.017 mean absolute error, so the hints and the encoder quality are independent wins. Both apply to the player-facing feature, which saves jpg.

Remaining verification is visual on a scaled Windows display.

