### PR TITLE
Upgrade to junit5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
           source ddpoker.rc
           reset_dbs.sh pokertest
           cd code
-          mvn package -Dskip.unit.tests=false
+          mvn package

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -916,11 +916,11 @@ A couple of notes:
 ### PowerShell quirks worth knowing
 
 * **Quote `-D` arguments containing dots.**  PowerShell splits an unquoted
-  `-Dskip.unit.tests=false` at the first `.`, handing Maven a stray `.unit.tests=false` and
-  failing with *"Unknown lifecycle phase"*.  Quote it:
+  `-Ddependency.classpath.outputFile=/tmp/t` at the first `.`, handing Maven a stray
+  `.classpath.outputFile=/tmp/t` and failing with *"Unknown lifecycle phase"*.  Quote it:
 
   ```powershell
-  .\mvn -f code/pom.xml test '-Dskip.unit.tests=false'
+  .\mvn -f code/pom.xml dependency:tree '-Ddependency.classpath.outputFile=/tmp/t'
   ```
 
   `-DskipTests=true` has no dot, so it is fine unquoted.

--- a/code/common/pom.xml
+++ b/code/common/pom.xml
@@ -80,9 +80,8 @@
       <version>2.22.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/common/src/test/java/com/donohoedigital/base/ManagedQueueTest.java
+++ b/code/common/src/test/java/com/donohoedigital/base/ManagedQueueTest.java
@@ -32,11 +32,14 @@
  */
 package com.donohoedigital.base;
 
-import junit.framework.*;
 import org.apache.logging.log4j.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -45,7 +48,7 @@ import java.util.concurrent.*;
  * Time: 3:18:07 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ManagedQueueTest extends TestCase
+public class ManagedQueueTest
 {
     private static final Logger logger = LogManager.getLogger(ManagedQueueTest.class);
 
@@ -53,7 +56,7 @@ public class ManagedQueueTest extends TestCase
     private final List<SampleItem> messages = new ArrayList<SampleItem>();
     private static final SampleItem SAMPLE = new SampleItem();
 
-    @Override
+    @BeforeEach
     public void setUp()
     {
         mainThread = Thread.currentThread();
@@ -101,6 +104,7 @@ public class ManagedQueueTest extends TestCase
         }
     }
 
+    @Test
     public void testQueue()
     {
         TestQueue queue = new TestQueue(10, 100, 0);
@@ -110,10 +114,11 @@ public class ManagedQueueTest extends TestCase
             queue.add(SAMPLE);
         }
         queue.stop(true);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
         assertEquals(num, messages.size());
     }
 
+    @Test
     public void testSlowAdd()
     {
         delay = 100;
@@ -122,10 +127,11 @@ public class ManagedQueueTest extends TestCase
         queue.add(SAMPLE); // second one fills up queue
         queue.add(SAMPLE); // should time out once (visual test - WARN message should show up in log)
         queue.stop(true);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
         assertEquals(3, messages.size());
     }
 
+    @Test
     public void testOverflow()
     {
         delay = TimeConstants.SECOND;
@@ -142,9 +148,10 @@ public class ManagedQueueTest extends TestCase
             logger.debug("Expected error: " + o.getMessage());
         }
         queue.stop(false);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
     }
 
+    @Test
     public void testQuitEarly()
     {
         delay = TimeConstants.MILLISECOND * 10;
@@ -155,10 +162,11 @@ public class ManagedQueueTest extends TestCase
             queue.add(SAMPLE);
         }
         queue.stop(false);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
-        assertTrue("Not all messages should have been processed", num > messages.size());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
+        assertTrue(num > messages.size(), "Not all messages should have been processed");
     }
 
+    @Test
     public void testInterrupt()
     {
         TestQueue queue = new TestQueue(10, 100, 100);
@@ -174,23 +182,25 @@ public class ManagedQueueTest extends TestCase
             }
         }
         queue.stop(true);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
         assertEquals(num, messages.size());
     }
 
+    @Test
     public void testInterruptDuringShutdown()
     {
         delay = TimeConstants.SECOND * 2;
         TestQueue queue = new TestQueue(1, 1, 1);
         queue.add(SAMPLE); // first gets processed right away, but held up by delay
         queue.add(SAMPLE); // second one fills up queue (use handleMessage for code coverage)
-        assertTrue("max one message should have been processed", messages.size() <= 1);
+        assertTrue(messages.size() <= 1, "max one message should have been processed");
         new Interrupter(Thread.currentThread()).start();
         queue.stop(true); // waits because queue is full, should be interrupted
-        assertFalse("thread dead", queue.getProcessor().isAlive());
-        assertTrue("max one message should have been processed", messages.size() <= 1);
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
+        assertTrue(messages.size() <= 1, "max one message should have been processed");
     }
 
+    @Test
     public void testQuitNoItemsNoFinish()
     {
         TestQueue queue = new TestQueue(1, 1, 1);
@@ -199,16 +209,17 @@ public class ManagedQueueTest extends TestCase
         queue.stop(false);
         long after = System.currentTimeMillis();
         assertTrue(after - now < ManagedQueue.WAIT_FOR_THREAD_FINISH);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
     }
 
+    @Test
     public void testInterruptDuringAdd()
     {
         delay = TimeConstants.SECOND * 1;
         TestQueue queue = new TestQueue(1, TimeConstants.MINUTE, 100);
         queue.add(SAMPLE); // first gets processed right away, but held up by delay
         queue.add(SAMPLE); // second one fills up queue (use handleMessage for code coverage)
-        assertTrue("max one message should have been processed", messages.size() <= 1);
+        assertTrue(messages.size() <= 1, "max one message should have been processed");
         new Interrupter(Thread.currentThread()).start();
         try
         {
@@ -220,7 +231,7 @@ public class ManagedQueueTest extends TestCase
             logger.debug("Expected error: " + o.getMessage());
         }
         queue.stop(true);
-        assertFalse("thread dead", queue.getProcessor().isAlive());
+        assertFalse(queue.getProcessor().isAlive(), "thread dead");
     }
 
     private class Interrupter extends Thread

--- a/code/common/src/test/java/com/donohoedigital/base/UtilsTest.java
+++ b/code/common/src/test/java/com/donohoedigital/base/UtilsTest.java
@@ -32,7 +32,9 @@
  */
 package com.donohoedigital.base;
 
-import junit.framework.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -41,8 +43,9 @@ import junit.framework.*;
  * Time: 2:15:08 PM
  * To change this template use File | Settings | File Templates.
  */
-public class UtilsTest extends TestCase
+public class UtilsTest
 {
+    @Test
     public void testIsOs()
     {
         assertTrue(Utils.isLinux("linux"));
@@ -60,6 +63,7 @@ public class UtilsTest extends TestCase
         assertFalse(Utils.isWindows("mac os x"));
     }
 
+    @Test
     public void testJoin()
     {
         assertEquals("a | b", Utils.joinWithDelimiter(" | ", "a", null, "b"));

--- a/code/common/src/test/java/com/donohoedigital/comms/DataMarshallerTest.java
+++ b/code/common/src/test/java/com/donohoedigital/comms/DataMarshallerTest.java
@@ -32,7 +32,9 @@
  */
 package com.donohoedigital.comms;
 
-import junit.framework.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -41,8 +43,9 @@ import junit.framework.*;
  * Time: 1:37:52 PM
  * To change this template use File | Settings | File Templates.
  */
-public class DataMarshallerTest extends TestCase
+public class DataMarshallerTest
 {
+    @Test
     public void testStatic()
     {
         new DataMarshaller();

--- a/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
+++ b/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
@@ -32,10 +32,13 @@
  */
 package com.donohoedigital.comms;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class VersionTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.*;
 
+public class VersionTest {
+
+    @Test
     public void testParseVersion() {
         // major/minor
         Version v = new Version("3.1");

--- a/code/common/src/test/java/com/donohoedigital/config/ActivationTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/ActivationTest.java
@@ -32,8 +32,10 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
 import org.apache.logging.log4j.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -42,10 +44,11 @@ import org.apache.logging.log4j.*;
  * Time: 4:24:58 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ActivationTest extends TestCase
+public class ActivationTest
 {
     private static final Logger logger = LogManager.getLogger(ActivationTest.class);
 
+    @Test
     public void testGuid()
     {
         String key = Activation.createKeyFromGuid(22, "BD4206D4-72B0-EA5D-6FF7-1B50F92CCD49", null);
@@ -57,6 +60,7 @@ public class ActivationTest extends TestCase
         }
     }
 
+    @Test
     public void testValidate()
     {
         assertTrue(Activation.validate(22, "2200-0024-9421-5725", null));

--- a/code/common/src/test/java/com/donohoedigital/config/AudioConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/AudioConfigTest.java
@@ -32,7 +32,9 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -41,8 +43,9 @@ import junit.framework.*;
  * Time: 9:49:51 AM
  * To change this template use File | Settings | File Templates.
  */
-public class AudioConfigTest extends TestCase
+public class AudioConfigTest
 {
+    @Test
     public void testLoad()
     {
         String[] modules = {"common", "testapp"};

--- a/code/common/src/test/java/com/donohoedigital/config/CachedEntityResolverTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/CachedEntityResolverTest.java
@@ -32,25 +32,28 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.TestCase;
-
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Covers the two schemes {@link CachedEntityResolver} understands, which is how
  * &lt;xsd:include schemaLocation="classpath:..."/&gt; is resolved when the JDK
  * parser validates a config file.
  */
-public class CachedEntityResolverTest extends TestCase
+public class CachedEntityResolverTest
 {
+    @Test
     public void testResolvesClasspath() throws MalformedURLException
     {
         URL url = CachedEntityResolver.instance().getMatch("classpath:config/xml-schema/data-elements.xsd");
         assertNotNull(url);
-        assertTrue(url.toString(), url.toString().endsWith("config/xml-schema/data-elements.xsd"));
+        assertTrue(url.toString().endsWith("config/xml-schema/data-elements.xsd"), url.toString());
     }
 
+    @Test
     public void testResolvesFile() throws MalformedURLException
     {
         URL url = CachedEntityResolver.instance().getMatch("file:/tmp/whatever.xsd");
@@ -59,11 +62,13 @@ public class CachedEntityResolverTest extends TestCase
         assertEquals("/tmp/whatever.xsd", url.getPath());
     }
 
+    @Test
     public void testUnknownSchemeReturnsNull() throws MalformedURLException
     {
         assertNull(CachedEntityResolver.instance().getMatch("config/xml-schema/data-elements.xsd"));
     }
 
+    @Test
     public void testResultIsCached() throws MalformedURLException
     {
         CachedEntityResolver resolver = CachedEntityResolver.instance();

--- a/code/common/src/test/java/com/donohoedigital/config/ConfigManagerTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/ConfigManagerTest.java
@@ -32,7 +32,9 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -41,8 +43,9 @@ import junit.framework.*;
  * Time: 2:53:20 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ConfigManagerTest extends TestCase
+public class ConfigManagerTest
 {
+    @Test
     public void testCreate()
     {
         new ConfigManager("testapp", ApplicationType.COMMAND_LINE);

--- a/code/common/src/test/java/com/donohoedigital/config/ConfigUtilsTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/ConfigUtilsTest.java
@@ -32,10 +32,11 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
-
 import java.io.*;
 import java.net.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -44,8 +45,9 @@ import java.net.*;
  * Time: 5:22:52 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ConfigUtilsTest extends TestCase
+public class ConfigUtilsTest
 {
+    @Test
     public void testCopyUrl()
     {
         URL url = new MatchingResources("classpath*:com/donohoedigital/config/ConfigUtilsTest.class").getSingleRequiredResourceURL();

--- a/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
@@ -32,10 +32,12 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
 import org.apache.logging.log4j.*;
 
 import java.util.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -44,7 +46,7 @@ import java.util.*;
  * Time: 8:28:44 AM
  * To change this template use File | Settings | File Templates.
  */
-public class DataElementConfigTest extends TestCase
+public class DataElementConfigTest
 {
     private static Logger logger = LogManager.getLogger(DataElementConfigTest.class);
 
@@ -56,6 +58,7 @@ public class DataElementConfigTest extends TestCase
     }
 
     @SuppressWarnings({"SuspiciousMethodCalls"})
+    @Test
     public void testLoad()
     {
         DataElementConfig dec = load();
@@ -78,6 +81,7 @@ public class DataElementConfigTest extends TestCase
      * Enumeration values must come back in the order they are declared in the
      * xsd - combo boxes are populated straight from this list.
      */
+    @Test
     public void testEnumerationOrder()
     {
         DataElement dogs = load().get("dogs");
@@ -89,6 +93,7 @@ public class DataElementConfigTest extends TestCase
      * Display values are looked up from list.&lt;element&gt;.&lt;value&gt; properties
      * (see testapp/client.properties)
      */
+    @Test
     public void testDisplayValues()
     {
         DataElement dogs = load().get("dogs");
@@ -102,20 +107,22 @@ public class DataElementConfigTest extends TestCase
      * &lt;xsd:include schemaLocation="classpath:..."/&gt; - types declared only
      * there must be present too.
      */
+    @Test
     public void testClasspathIncludeIsFollowed()
     {
         DataElement territoryType = load().get("territoryType");
-        assertNotNull("territoryType comes from the included global data-elements.xsd", territoryType);
+        assertNotNull(territoryType, "territoryType comes from the included global data-elements.xsd");
         assertEquals(Arrays.asList("land", "water", "edge", "decoration"), territoryType.getListValues());
     }
 
     /**
      * A named simple type with no enumeration is still registered, but is not a list
      */
+    @Test
     public void testNonEnumeratedTypeIsNotAList()
     {
         DataElement string = load().get("string");
-        assertNotNull("plain simple types are registered too", string);
+        assertNotNull(string, "plain simple types are registered too");
         assertFalse(string.isList());
         assertNull(string.getListValues());
     }

--- a/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
@@ -32,9 +32,11 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
 import org.apache.logging.log4j.*;
 import com.donohoedigital.base.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -43,9 +45,10 @@ import com.donohoedigital.base.*;
  * Time: 9:49:51 AM
  * To change this template use File | Settings | File Templates.
  */
-public class HelpConfigTest extends TestCase
+public class HelpConfigTest
 {
     private static Logger logger = LogManager.getLogger(HelpConfigTest.class);
+    @Test
     public void testLoad()
     {
         if (Utils.ISMAC) return; // doesn't play nicely on mac

--- a/code/common/src/test/java/com/donohoedigital/config/ImageConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/ImageConfigTest.java
@@ -33,7 +33,6 @@
 package com.donohoedigital.config;
 
 import com.donohoedigital.base.*;
-import junit.framework.*;
 
 import org.apache.commons.io.FileUtils;
 
@@ -41,6 +40,9 @@ import java.awt.image.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -49,10 +51,11 @@ import java.nio.file.Path;
  * Time: 9:49:51 AM
  * To change this template use File | Settings | File Templates.
  */
-public class ImageConfigTest extends TestCase
+public class ImageConfigTest
 {
     //private static Logger logger = LogManager.getLogger(ImageConfigTest.class);
 
+    @Test
     public void testLoad()
     {
         String[] modules = {"common", "testapp"};
@@ -72,12 +75,13 @@ public class ImageConfigTest extends TestCase
      * A file path can legally contain characters ('#', '%') that are not legal in a
      * URL.  ImageDef must escape them, which File.toURI() does and "file:" + path did not.
      */
+    @Test
     public void testGetBufferedImageFromAwkwardlyNamedFile() throws IOException
     {
         Path dir = Files.createTempDirectory("ImageConfigTest");
         Path source = Path.of("src/test/resources/config/testapp/images/donohoedigital.gif");
-        assertTrue(source + " not found - is the test running from the common module?",
-                   Files.exists(source));
+        assertTrue(Files.exists(source),
+                   source + " not found - is the test running from the common module?");
 
         try
         {
@@ -85,7 +89,7 @@ public class ImageConfigTest extends TestCase
             {
                 Path copy = dir.resolve(name);
                 Files.copy(source, copy);
-                assertNotNull(name, ImageDef.getBufferedImage(copy.toFile()));
+                assertNotNull(ImageDef.getBufferedImage(copy.toFile()), name);
             }
         }
         finally

--- a/code/common/src/test/java/com/donohoedigital/config/LoggingConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/LoggingConfigTest.java
@@ -32,11 +32,15 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.TestCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -45,14 +49,14 @@ import java.io.File;
  * Time: 8:16:40 AM
  * To change this template use File | Settings | File Templates.
  */
-public class LoggingConfigTest extends TestCase {
+public class LoggingConfigTest {
     public static final String UNITTEST_APPNAME = "unittests";
     private static final TestRuntimeDirectory runtime = new TestRuntimeDirectory();
 
     /**
      * On setup, verify no temp files exist
      */
-    @Override
+    @BeforeEach
     protected void setUp() {
         LoggingConfig.reset();
         checkDirectoryDoesntExist(runtime.getServerHome());
@@ -69,6 +73,7 @@ public class LoggingConfigTest extends TestCase {
     /**
      * Test client
      */
+    @Test
     public void testClient() {
         process(new LoggingConfig(UNITTEST_APPNAME, ApplicationType.CLIENT, runtime, false),
                 runtime.getClientHome(null), "GUI", true);
@@ -77,6 +82,7 @@ public class LoggingConfigTest extends TestCase {
     /**
      * Test headless client
      */
+    @Test
     public void testHeadlessClient() {
         process(new LoggingConfig(UNITTEST_APPNAME, ApplicationType.HEADLESS_CLIENT, runtime, false),
                 runtime.getClientHome(null), "GUI", true);
@@ -85,6 +91,7 @@ public class LoggingConfigTest extends TestCase {
     /**
      * Test server
      */
+    @Test
     public void testServer() {
         process(new LoggingConfig(UNITTEST_APPNAME, ApplicationType.SERVER, runtime, false),
                 runtime.getServerHome(), "SRV", true);
@@ -93,6 +100,7 @@ public class LoggingConfigTest extends TestCase {
     /**
      * Test command line
      */
+    @Test
     public void testCommandLine() {
         process(new LoggingConfig(UNITTEST_APPNAME, ApplicationType.COMMAND_LINE, runtime, false),
                 runtime.getServerHome(), "CLI", false);
@@ -101,11 +109,13 @@ public class LoggingConfigTest extends TestCase {
     /**
      * Test webapp
      */
+    @Test
     public void testWebapp() {
         process(new LoggingConfig(UNITTEST_APPNAME, ApplicationType.WEBAPP, runtime, false),
                 runtime.getServerHome(), "WEB", true);
     }
 
+    @Test
     public void testOverride() {
         process(new LoggingConfig("unit-test-override", ApplicationType.HEADLESS_CLIENT, runtime, false),
                 runtime.getClientHome(null), "OVER", true);
@@ -134,14 +144,14 @@ public class LoggingConfigTest extends TestCase {
             String[] lines = tee.getCapturedLines();
             assertEquals(expected, lines.length);
             String line = lines[expected - 1];
-            assertTrue("should contain " + slug + " [main", line.contains(" " + slug + " [main"));
-            assertTrue("Stdout file should contain message: " + message, line.contains(message));
+            assertTrue(line.contains(" " + slug + " [main"), "should contain " + slug + " [main");
+            assertTrue(line.contains(message), "Stdout file should contain message: " + message);
 
             if (verifyLogfile) {
                 ConfigUtils.verifyFile(logging.getLogFile());
                 String contents = ConfigUtils.readFile(logging.getLogFile());
-                assertTrue("should contain " + slug + " [main", contents.contains(" " + slug + " [main"));
-                assertTrue("Log file should contain message: " + message, contents.contains(message));
+                assertTrue(contents.contains(" " + slug + " [main"), "should contain " + slug + " [main");
+                assertTrue(contents.contains(message), "Log file should contain message: " + message);
             }
         } finally {
             tee.restoreOriginal();
@@ -152,7 +162,7 @@ public class LoggingConfigTest extends TestCase {
     /**
      * remove temp directories
      */
-    @Override
+    @AfterEach
     protected void tearDown() {
         // remove directories
         cleanup(runtime.getServerHome());

--- a/code/common/src/test/java/com/donohoedigital/config/MatchingResourcesTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/MatchingResourcesTest.java
@@ -32,13 +32,15 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.*;
 import org.apache.logging.log4j.*;
 import org.springframework.core.io.*;
 
 import java.lang.annotation.*;
 import java.net.*;
 import java.util.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -47,10 +49,11 @@ import java.util.*;
  * Time: 3:19:51 PM
  * To change this template use File | Settings | File Templates.
  */
-public class MatchingResourcesTest extends TestCase
+public class MatchingResourcesTest
 {
     Logger logger = LogManager.getLogger(MatchingResourcesTest.class);
 
+    @Test
     public void testFindResources()
     {
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/ConfigUtils.class");
@@ -64,6 +67,7 @@ public class MatchingResourcesTest extends TestCase
         assertTrue(none.length == 0);
     }
 
+    @Test
     public void testFindResource()
     {
         Resource thiz = new MatchingResources("classpath*:com/donohoedigital/config/MatchingResourcesTest.class").getSingleRequiredResource();
@@ -93,6 +97,7 @@ public class MatchingResourcesTest extends TestCase
 
     }
 
+    @Test
     public void testToString()
     {
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/*.class");
@@ -140,6 +145,7 @@ public class MatchingResourcesTest extends TestCase
     {
     }
 
+    @Test
     public void testMatchingAnno()
     {
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/*.class");
@@ -149,6 +155,7 @@ public class MatchingResourcesTest extends TestCase
         assertEquals(2, matches.size());
     }
 
+    @Test
     public void testMatchingImpl()
     {
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/*.class");
@@ -164,6 +171,7 @@ public class MatchingResourcesTest extends TestCase
         assertFalse(matches.contains(MatchTest2.class));
     }
 
+    @Test
     public void testGetSubclasses()
     {
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/*.class");

--- a/code/common/src/test/java/com/donohoedigital/config/PropertyConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/PropertyConfigTest.java
@@ -32,9 +32,10 @@
  */
 package com.donohoedigital.config;
 
-import junit.framework.TestCase;
-
 import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -43,8 +44,9 @@ import java.util.Locale;
  * Time: 4:43:12 PM
  * To change this template use File | Settings | File Templates.
  */
-public class PropertyConfigTest extends TestCase
+public class PropertyConfigTest
 {
+    @Test
     public void testLoadClient()
     {
         System.getProperties().setProperty("user.name", "unit-tester");
@@ -75,6 +77,7 @@ public class PropertyConfigTest extends TestCase
         assertTrue(PropertyConfig.getRequiredBooleanProperty("override.set"));
     }
 
+    @Test
     public void testGetLocale()
     {
         assertSame(Locale.US, PropertyConfig.getLocale(null));

--- a/code/common/src/test/java/com/donohoedigital/config/StylesConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/StylesConfigTest.java
@@ -33,9 +33,11 @@
 package com.donohoedigital.config;
 
 import com.donohoedigital.base.*;
-import junit.framework.*;
 
 import java.awt.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -44,10 +46,11 @@ import java.awt.*;
  * Time: 9:49:51 AM
  * To change this template use File | Settings | File Templates.
  */
-public class StylesConfigTest extends TestCase
+public class StylesConfigTest
 {
     //private static Logger logger = LogManager.getLogger(StylesConfigTest.class);
 
+    @Test
     public void testLoad()
     {
         if (Utils.ISMAC) return; // doesn't play nicely on mac

--- a/code/db/pom.xml
+++ b/code/db/pom.xml
@@ -60,9 +60,8 @@
       <version>3.1.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/ddpoker/pom.xml
+++ b/code/ddpoker/pom.xml
@@ -50,9 +50,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/gamecommon/pom.xml
+++ b/code/gamecommon/pom.xml
@@ -55,9 +55,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/gameengine/pom.xml
+++ b/code/gameengine/pom.xml
@@ -65,9 +65,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/gameserver/pom.xml
+++ b/code/gameserver/pom.xml
@@ -131,9 +131,8 @@
       <version>3.20.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyServiceTest.java
@@ -34,17 +34,17 @@ package com.donohoedigital.games.server;
 
 import com.donohoedigital.games.server.model.BannedKey;
 import com.donohoedigital.games.server.service.BannedKeyService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Calendar;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -53,7 +53,7 @@ import static org.junit.Assert.*;
  * Time: 2:52:25 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class BannedKeyServiceTest

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/BannedKeyTest.java
@@ -35,19 +35,18 @@ package com.donohoedigital.games.server;
 import com.donohoedigital.games.server.dao.BannedKeyDao;
 import com.donohoedigital.games.server.model.BannedKey;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -57,7 +56,7 @@ import static org.junit.Assert.*;
  * To change this template use File | Settings | File Templates.
  */
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class BannedKeyTest {
@@ -79,14 +78,14 @@ public class BannedKeyTest {
         assertNotNull(nullComment.getId());
 
         BannedKey fetch = dao.get(newKey.getId());
-        assertEquals("name should match", newKey.getKey(), fetch.getKey());
+        assertEquals(newKey.getKey(), fetch.getKey(), "name should match");
 
         String key = "1111-1111-1111-1111";
         newKey.setKey(key);
         dao.update(newKey);
 
         BannedKey updated = dao.get(newKey.getId());
-        assertEquals("key should match", key, updated.getKey());
+        assertEquals(key, updated.getKey(), "key should match");
     }
 
     @Test

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
@@ -35,16 +35,16 @@ package com.donohoedigital.games.server;
 import com.donohoedigital.games.server.model.Registration;
 import com.donohoedigital.games.server.service.RegistrationService;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by IntelliJ IDEA.
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
  * Time: 2:52:25 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class RegistrationServiceTest
@@ -76,6 +76,6 @@ public class RegistrationServiceTest
         Registration reg2 = ServerTestData.createRegistration("RegistrationServiceTest", "9999-8888-7777-6666");
         service.saveRegistration(reg2);
         assertNotNull(reg2.getId());
-        assertTrue("Should be a duplicate", reg2.isDuplicate());
+        assertTrue(reg2.isDuplicate(), "Should be a duplicate");
     }
 }

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationTest.java
@@ -39,18 +39,17 @@ import com.donohoedigital.games.server.model.Registration;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -59,7 +58,7 @@ import static org.junit.Assert.*;
  * Time: 2:44:16 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class RegistrationTest
@@ -82,14 +81,14 @@ public class RegistrationTest
         assertNotNull(newProfile.getId());
 
         Registration fetch = dao.get(newProfile.getId());
-        assertEquals("name should match", newProfile.getName(), fetch.getName());
+        assertEquals(newProfile.getName(), fetch.getName(), "name should match");
 
         String key = "1111-1111-1111-1111";
         newProfile.setLicenseKey(key);
         dao.update(newProfile);
 
         Registration updated = dao.get(newProfile.getId());
-        assertEquals("key should match", key, updated.getLicenseKey());
+        assertEquals(key, updated.getLicenseKey(), "key should match");
     }
 
     @Test
@@ -147,33 +146,33 @@ public class RegistrationTest
         assertNotNull(save2.getId());
 
         // match exact
-        assertTrue("Exact same should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Exact same should be a duplicate");
 
         // different email
         likeSave1.setEmail(differentEmail);
-        assertTrue("Different email should still be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Different email should still be a duplicate");
 
         likeSave1.setIp(differentIp);
-        assertTrue("Different ip should still be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Different ip should still be a duplicate");
 
         likeSave1.setHostNameModified("modify.this.com");
-        assertFalse("Different host, now should be no longer be a duplicate", dao.isDuplicate(likeSave1));
+        assertFalse(dao.isDuplicate(likeSave1), "Different host, now should be no longer be a duplicate");
 
         // different registration type
         likeSave1.setEmail(save1.getIp());
         likeSave1.setHostNameModified(save1.getHostNameModified());
         likeSave1.setIp(save1.getIp());
-        assertTrue("Revert back email/host/ip same should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Revert back email/host/ip same should be a duplicate");
         likeSave1.setType(Registration.Type.ACTIVATION);
-        assertTrue("Activation type should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Activation type should be a duplicate");
         likeSave1.setHostNameModified(null);
-        assertTrue("null host should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "null host should be a duplicate");
 
         // something marked as duplicate
-        assertFalse("Marked as duplicate should not be a duplicate", dao.isDuplicate(likeSave2));
+        assertFalse(dao.isDuplicate(likeSave2), "Marked as duplicate should not be a duplicate");
 
         // totally different key
-        assertFalse("Different key should not be a duplicate", dao.isDuplicate(different));
+        assertFalse(dao.isDuplicate(different), "Different key should not be a duplicate");
     }
 
     @Test
@@ -223,37 +222,37 @@ public class RegistrationTest
         assertNotNull(save3.getId());
 
         // match exact
-        assertTrue("Exact same should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Exact same should be a duplicate");
 
         // different ip/null host
         likeSave1.setIp(differentIp);
         likeSave1.setHostNameModified(null);
-        assertFalse("Different ip (null host) should not be a duplicate", dao.isDuplicate(likeSave1));
+        assertFalse(dao.isDuplicate(likeSave1), "Different ip (null host) should not be a duplicate");
 
         // different ip/same host
         likeSave1.setIp(differentIp);
         likeSave1.setHostNameModified(save1.getHostNameModified());
-        assertTrue("Different ip (same host) should be a duplicate", dao.isDuplicate(likeSave1));
+        assertTrue(dao.isDuplicate(likeSave1), "Different ip (same host) should be a duplicate");
 
         // different ip/different host
         likeSave1.setIp(differentIp);
         likeSave1.setHostNameModified("extra." + save1.getHostName());
-        assertFalse("Different ip (diff host) should not be a duplicate", dao.isDuplicate(likeSave1));
+        assertFalse(dao.isDuplicate(likeSave1), "Different ip (diff host) should not be a duplicate");
 
         // different registration type
         likeSave1.setType(Registration.Type.REGISTRATION);
-        assertFalse("Registration type should not be a duplicate", dao.isDuplicate(likeSave1));
+        assertFalse(dao.isDuplicate(likeSave1), "Registration type should not be a duplicate");
 
         // something marked as duplicate
-        assertFalse("Marked as duplicate should not be a duplicate", dao.isDuplicate(likeSave2));
+        assertFalse(dao.isDuplicate(likeSave2), "Marked as duplicate should not be a duplicate");
 
         // null host should be duplicate
-        assertTrue("Null host in db should be duplicate", dao.isDuplicate(likeSave3));
+        assertTrue(dao.isDuplicate(likeSave3), "Null host in db should be duplicate");
         likeSave3.setIp(differentIp);
-        assertFalse("Null host in db, different ip should not be a duplicate", dao.isDuplicate(likeSave3));
+        assertFalse(dao.isDuplicate(likeSave3), "Null host in db, different ip should not be a duplicate");
 
         // totally different key
-        assertFalse("Different key should not be a duplicate", dao.isDuplicate(different));
+        assertFalse(dao.isDuplicate(different), "Different key should not be a duplicate");
     }
 
     @Test
@@ -340,7 +339,7 @@ public class RegistrationTest
         {
             int expected = numSuspect - nMin + 1;
             List<String> list = dao.getAllSuspectKeys(nMin);
-            assertEquals("nMin:" + nMin + " size=" + list.size() + " matches expected=" + expected, list.size(), expected);
+            assertEquals(list.size(), expected, "nMin:" + nMin + " size=" + list.size() + " matches expected=" + expected);
 
             for (String key : list)
             {

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
@@ -34,16 +34,17 @@ package com.donohoedigital.games.server;
 
 import com.donohoedigital.games.server.model.Registration;
 import com.donohoedigital.games.server.service.RegistrationService;
-import junit.framework.TestCase;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.FileNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -52,9 +53,9 @@ import java.io.FileNotFoundException;
  * Time: 9:08:21 PM
  * Simple Spring test - configure logging, load app context, get a bean
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
-public class SpringCreatedServiceTest extends TestCase
+public class SpringCreatedServiceTest
 {
     private final Logger logger = LogManager.getLogger(SpringCreatedServiceTest.class);
 

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/UpgradedKeyTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/UpgradedKeyTest.java
@@ -35,18 +35,17 @@ package com.donohoedigital.games.server;
 import com.donohoedigital.games.server.dao.UpgradedKeyDao;
 import com.donohoedigital.games.server.model.UpgradedKey;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -56,7 +55,7 @@ import static org.junit.Assert.*;
  * To change this template use File | Settings | File Templates.
  */
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-jpatests.xml"})
 public class UpgradedKeyTest
@@ -76,14 +75,14 @@ public class UpgradedKeyTest
         assertNotNull(newKey.getId());
 
         UpgradedKey fetch = dao.get(newKey.getId());
-        assertEquals("name should match", newKey.getLicenseKey(), fetch.getLicenseKey());
+        assertEquals(newKey.getLicenseKey(), fetch.getLicenseKey(), "name should match");
 
         String key = "1111-1111-1111-1111";
         newKey.setLicenseKey(key);
         dao.update(newKey);
 
         UpgradedKey updated = dao.get(newKey.getId());
-        assertEquals("key should match", key, updated.getLicenseKey());
+        assertEquals(key, updated.getLicenseKey(), "key should match");
     }
 
     @Test

--- a/code/gametools/pom.xml
+++ b/code/gametools/pom.xml
@@ -75,9 +75,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/gui/pom.xml
+++ b/code/gui/pom.xml
@@ -55,9 +55,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/gui/src/test/java/com/donohoedigital/GuiTest.java
+++ b/code/gui/src/test/java/com/donohoedigital/GuiTest.java
@@ -32,36 +32,19 @@
  */
 package com.donohoedigital;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit test for simple App.
  */
-public class GuiTest extends TestCase
+public class GuiTest
 {
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public GuiTest( String testName )
-    {
-        super( testName );
-    }
-
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( GuiTest.class );
-    }
-
     /**
      * Rigourous Test :-)
      */
+    @Test
     public void testGui()
     {
         assertTrue( true );

--- a/code/installer/pom.xml
+++ b/code/installer/pom.xml
@@ -61,9 +61,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/jsp/pom.xml
+++ b/code/jsp/pom.xml
@@ -72,9 +72,8 @@
       <version>${tomcat.version}</version>
    </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/jsp/src/test/java/com/donohoedigital/jsp/JspEmailTest.java
+++ b/code/jsp/src/test/java/com/donohoedigital/jsp/JspEmailTest.java
@@ -34,9 +34,9 @@ package com.donohoedigital.jsp;
 
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JspEmailTest {
     @Test

--- a/code/jsp/src/test/java/com/donohoedigital/jsp/JspFileTest.java
+++ b/code/jsp/src/test/java/com/donohoedigital/jsp/JspFileTest.java
@@ -34,8 +34,9 @@ package com.donohoedigital.jsp;
 
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JspFileTest {
 

--- a/code/mail/pom.xml
+++ b/code/mail/pom.xml
@@ -55,9 +55,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/code/poker/pom.xml
+++ b/code/poker/pom.xml
@@ -71,9 +71,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/HandInfoTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/HandInfoTest.java
@@ -36,10 +36,10 @@ import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.engine.Card;
 import com.donohoedigital.games.poker.engine.HandSorted;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.donohoedigital.games.poker.engine.Card.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HandInfoTest {
 
@@ -88,8 +88,8 @@ public class HandInfoTest {
         System.out.println(sName + " - " + info + " fastscore=" + fastScore + " fasterScore=" + fasterScore);
         System.out.println(info.toStringDebug());
         System.out.println();
-        assertEquals("Score doesn't match expected", expected, fastScore);
-        assertEquals("Fast doesn't match score", info.getScore(), fastScore);
-        assertEquals("Faster doesn't match score", info.getScore(), fasterScore);
+        assertEquals(expected, fastScore, "Score doesn't match expected");
+        assertEquals(info.getScore(), fastScore, "Fast doesn't match score");
+        assertEquals(info.getScore(), fasterScore, "Faster doesn't match score");
     }
 }

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDataMarshallerTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDataMarshallerTest.java
@@ -33,7 +33,9 @@
 package com.donohoedigital.games.poker;
 
 import com.donohoedigital.comms.*;
-import junit.framework.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -42,8 +44,9 @@ import junit.framework.*;
  * Time: 1:37:52 PM
  * To change this template use File | Settings | File Templates.
  */
-public class PokerDataMarshallerTest extends TestCase
+public class PokerDataMarshallerTest
 {
+    @Test
     public void testStatic()
     {
         new DataMarshaller();

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDatabaseTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerDatabaseTest.java
@@ -36,15 +36,14 @@ import com.donohoedigital.base.Utils;
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
  * The purpose of this test is to provide a rudimentary way to very our hsqldb
@@ -56,8 +55,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class PokerDatabaseTest {
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir
+    File tempFolder;
 
     /**
      * Unfortunately, there aren't many unit tests of the core poker logic.  In
@@ -75,7 +74,9 @@ public class PokerDatabaseTest {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
 
         // we need a player profile
-        File profileFile = tempFolder.newFile("profile.999.dat");
+        File profileFile = new File(tempFolder, "profile.999.dat");
+        //noinspection ResultOfMethodCallIgnored
+        profileFile.createNewFile();
         PlayerProfile profile = new PlayerProfile("poker-database-test");
         profile.setEmail("test@test.com");
         profile.setName("test");
@@ -83,7 +84,9 @@ public class PokerDatabaseTest {
         //profile.save(); // Not necessary to actually save it
 
         // we need a database, in a temp place
-        File tempDir = tempFolder.newFolder("poker-database-test");
+        File tempDir = new File(tempFolder, "poker-database-test");
+        //noinspection ResultOfMethodCallIgnored
+        tempDir.mkdirs();
         PokerDatabase.init(profile, tempDir);
 
         // we need a game, tournament, poker player, table and hand

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
@@ -36,15 +36,15 @@ import com.donohoedigital.base.ApplicationError;
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.List;
 import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Verifies PokerGame.getRank() counts in a single pass without changing the answer the
@@ -55,7 +55,7 @@ public class PokerGameRankTest
 {
     private PokerGame game_;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
@@ -146,9 +146,9 @@ public class PokerGameRankTest
         PokerPlayer d = add(4, 700);
 
         assertEquals(1, game_.getRank(a));
-        assertEquals("tied players share the better rank", 2, game_.getRank(b));
-        assertEquals("tied players share the better rank", 2, game_.getRank(c));
-        assertEquals("the rank after a tie skips the shared spot", 4, game_.getRank(d));
+        assertEquals(2, game_.getRank(b), "tied players share the better rank");
+        assertEquals(2, game_.getRank(c), "tied players share the better rank");
+        assertEquals(4, game_.getRank(d), "the rank after a tie skips the shared spot");
     }
 
     @Test
@@ -178,8 +178,7 @@ public class PokerGameRankTest
         for (int i = 0; i < game_.getNumPlayers(); i++)
         {
             PokerPlayer p = game_.getPokerPlayerAt(i);
-            assertEquals("rank differs for " + p.getName() + " with $" + p.getChipCount(),
-                         legacyRank(p), game_.getRank(p));
+            assertEquals(legacyRank(p), game_.getRank(p), "rank differs for " + p.getName() + " with $" + p.getChipCount());
         }
     }
 
@@ -196,7 +195,7 @@ public class PokerGameRankTest
 
         assertEquals(1, game_.getRank(a));
         assertEquals(1, game_.getRank(b));
-        assertEquals("legacy version returned 0 here", 0, legacyRank(a));
+        assertEquals(0, legacyRank(a), "legacy version returned 0 here");
     }
 
     /**
@@ -234,10 +233,10 @@ public class PokerGameRankTest
         allin.setChipCount(0);
 
         List<PokerPlayer> rank = game_.getPlayersByRank();
-        assertEquals("live players stay ahead of finishers", leader, rank.get(0));
-        assertEquals("an all-in player is still a live player", allin, rank.get(1));
-        assertEquals("paid finishers keep their index", third, rank.get(2));
-        assertEquals("paid finishers keep their index", fourth, rank.get(3));
+        assertEquals(leader, rank.get(0), "live players stay ahead of finishers");
+        assertEquals(allin, rank.get(1), "an all-in player is still a live player");
+        assertEquals(third, rank.get(2), "paid finishers keep their index");
+        assertEquals(fourth, rank.get(3), "paid finishers keep their index");
     }
 
     /**
@@ -261,13 +260,12 @@ public class PokerGameRankTest
         // hands.  Park the rival between my live count and my settled one.
         HoldemHand hhand = startHand(mine);
         int nCommitted = hhand.getTotalBet(doug);
-        assertTrue("expected the deal to commit chips", nCommitted > 1);
+        assertTrue(nCommitted > 1, "expected the deal to commit chips");
         rival.setChipCount(1000 - nCommitted + 1);
 
-        assertTrue("live counts would invert these two",
-                   doug.getChipCount() < rival.getChipCount());
+        assertTrue(doug.getChipCount() < rival.getChipCount(), "live counts would invert these two");
 
-        assertEquals("chips in the pot must not cost me a place", 1, game_.getRank(doug));
+        assertEquals(1, game_.getRank(doug), "chips in the pot must not cost me a place");
         assertEquals(2, game_.getRank(rival));
     }
 
@@ -286,9 +284,9 @@ public class PokerGameRankTest
         PokerPlayer rival = seat(theirs, 0, 2, 950);
 
         HoldemHand hhand = startHand(mine);
-        assertTrue("expected the deal to commit chips", hhand.getTotalBet(doug) > 0);
+        assertTrue(hhand.getTotalBet(doug) > 0, "expected the deal to commit chips");
 
-        assertEquals("still behind on settled chips", 2, game_.getRank(doug));
+        assertEquals(2, game_.getRank(doug), "still behind on settled chips");
         assertEquals(1, game_.getRank(rival));
     }
 

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
@@ -35,12 +35,12 @@ package com.donohoedigital.games.poker;
 import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies PokerGame.getSettledChipCount() reports a player's chips as of the last
@@ -53,7 +53,7 @@ public class PokerGameSettledChipsTest
 {
     private PokerGame game_;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
@@ -103,16 +103,14 @@ public class PokerGameSettledChipsTest
         PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
         seat(table, 1, 99, "Opponent", 1000); // a hand needs two players
         HoldemHand hhand = startHand(table);
-        assertTrue("expected a hand in progress", table.isHandInProgress());
+        assertTrue(table.isHandInProgress(), "expected a hand in progress");
 
         // dealing posts the blinds, which is chips out of the stack and into the pot
         int nCommitted = hhand.getTotalBet(doug);
-        assertTrue("expected the deal to commit chips", nCommitted > 0);
+        assertTrue(nCommitted > 0, "expected the deal to commit chips");
 
-        assertEquals("live count is down by what is in the pot",
-                     1000 - nCommitted, doug.getChipCount());
-        assertEquals("settled count is the stack before it went in",
-                     1000, game_.getSettledChipCount(doug));
+        assertEquals(1000 - nCommitted, doug.getChipCount(), "live count is down by what is in the pot");
+        assertEquals(1000, game_.getSettledChipCount(doug), "settled count is the stack before it went in");
     }
 
     /**
@@ -131,14 +129,13 @@ public class PokerGameSettledChipsTest
         // won the last hand - live count is now settled at 1400, but the snapshot still
         // holds 1000 until the next deal calls PokerPlayer.newHand()
         doug.setChipCount(1400);
-        assertEquals("snapshot is deliberately stale here", 1000, doug.getChipCountAtStart());
+        assertEquals(1000, doug.getChipCountAtStart(), "snapshot is deliberately stale here");
 
         // new hand created and TYPE_NEW_HAND fired; deal() has not run
         table.setHoldemHand(new HoldemHand(table));
         assertTrue(table.isHandInProgress());
 
-        assertEquals("must not report the previous hand's snapshot",
-                     1400, game_.getSettledChipCount(doug));
+        assertEquals(1400, game_.getSettledChipCount(doug), "must not report the previous hand's snapshot");
     }
 
     @Test
@@ -146,7 +143,7 @@ public class PokerGameSettledChipsTest
     {
         PokerTable table = table(1);
         PokerPlayer doug = seat(table, 0, 1, "Doug", 1000);
-        assertFalse("expected no hand in progress", table.isHandInProgress());
+        assertFalse(table.isHandInProgress(), "expected no hand in progress");
 
         // pot awarded - the live count is the settled count once the hand is over
         doug.setChipCount(1400);
@@ -182,17 +179,15 @@ public class PokerGameSettledChipsTest
         // my table is mid-hand, theirs is between hands
         HoldemHand hhand = startHand(mine);
         int nCommitted = hhand.getTotalBet(doug);
-        assertTrue("expected the deal to commit chips", nCommitted > 1);
+        assertTrue(nCommitted > 1, "expected the deal to commit chips");
 
         // park the rival between my live count and my settled one
         rival.setChipCount(1000 - nCommitted + 1);
 
         // live counts have me behind, which is the bug
-        assertTrue("live comparison sinks the mid-hand player",
-                   doug.getChipCount() < rival.getChipCount());
+        assertTrue(doug.getChipCount() < rival.getChipCount(), "live comparison sinks the mid-hand player");
 
         // settled counts have me ahead, which is the truth
-        assertTrue("settled comparison keeps the mid-hand player ahead",
-                   game_.getSettledChipCount(doug) > game_.getSettledChipCount(rival));
+        assertTrue(game_.getSettledChipCount(doug) > game_.getSettledChipCount(rival), "settled comparison keeps the mid-hand player ahead");
     }
 }

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
@@ -36,11 +36,11 @@ import com.donohoedigital.config.ApplicationType;
 import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.engine.PokerConstants;
 import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies PokerTable.getRank() ranks a player among those seated at one table, using
@@ -56,7 +56,7 @@ public class PokerTableRankTest
 {
     private PokerGame game_;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
@@ -135,9 +135,9 @@ public class PokerTableRankTest
         PokerPlayer d = seat(table, 3, 4, 700);
 
         assertEquals(1, table.getRank(a));
-        assertEquals("tied players share the better rank", 2, table.getRank(b));
-        assertEquals("tied players share the better rank", 2, table.getRank(c));
-        assertEquals("the rank after a tie skips the shared spot", 4, table.getRank(d));
+        assertEquals(2, table.getRank(b), "tied players share the better rank");
+        assertEquals(2, table.getRank(c), "tied players share the better rank");
+        assertEquals(4, table.getRank(d), "the rank after a tie skips the shared spot");
     }
 
     /**
@@ -154,14 +154,13 @@ public class PokerTableRankTest
     {
         game_.getProfile().getMap().setInteger(TournamentProfile.PARAM_TABLE_SEATS, 6);
         PokerTable table = table(1);
-        assertTrue("expected a short table", table.getSeats() < PokerConstants.SEATS);
+        assertTrue(table.getSeats() < PokerConstants.SEATS, "expected a short table");
 
         PokerPlayer low = seat(table, 0, 1, 500);
         PokerPlayer high = seat(table, PokerConstants.SEATS - 1, 2, 1500);
 
         assertEquals(1, table.getRank(high));
-        assertEquals("the player past the last seat of a short table has to be counted",
-                     2, table.getRank(low));
+        assertEquals(2, table.getRank(low), "the player past the last seat of a short table has to be counted");
     }
 
     /**
@@ -179,8 +178,8 @@ public class PokerTableRankTest
         seat(theirs, 0, 3, 9000);
         seat(theirs, 1, 4, 8000);
 
-        assertEquals("first of two here", 1, ours.getRank(shortStack));
-        assertEquals("but third of four overall", 3, game_.getRank(shortStack));
+        assertEquals(1, ours.getRank(shortStack), "first of two here");
+        assertEquals(3, game_.getRank(shortStack), "but third of four overall");
     }
 
     @Test
@@ -222,8 +221,7 @@ public class PokerTableRankTest
         p.setChipCount(1000);
         orphan.setPlayer(p, 0);
 
-        assertEquals("no game to read chip counts through, seated or not",
-                     0, orphan.getRank(p));
+        assertEquals(0, orphan.getRank(p), "no game to read chip counts through, seated or not");
     }
 
     /**
@@ -274,21 +272,19 @@ public class PokerTableRankTest
         PokerPlayer leader = seat(table, 3, 1, 1000);
         HoldemHand hhand = startHand(table);
 
-        assertTrue("expected a hand in progress", table.isHandInProgress());
+        assertTrue(table.isHandInProgress(), "expected a hand in progress");
         int nCommitted = hhand.getTotalBet(leader);
         int nRivalCommitted = hhand.getTotalBet(rival);
-        assertTrue("expected the blind to cost the leader more than the rival paid",
-                   nCommitted - nRivalCommitted > 1);
+        assertTrue(nCommitted - nRivalCommitted > 1, "expected the blind to cost the leader more than the rival paid");
 
         // Leave the rival one chip behind on settled counts, which puts them ahead on
         // live ones - the leader has more in the pot.  Derived from what the deal
         // actually charged rather than assuming it: the stakes belong to the profile,
         // and a failure here should be about ranking, not about level one being 1/2.
         rival.setChipCount(leader.getChipCount() + nCommitted - nRivalCommitted - 1);
-        assertTrue("the leader's live count must have dropped below the rival's",
-                   leader.getChipCount() < rival.getChipCount());
+        assertTrue(leader.getChipCount() < rival.getChipCount(), "the leader's live count must have dropped below the rival's");
 
-        assertEquals("settled counts still put the leader first", 1, table.getRank(leader));
+        assertEquals(1, table.getRank(leader), "settled counts still put the leader first");
         assertEquals(2, table.getRank(rival));
     }
 
@@ -306,19 +302,17 @@ public class PokerTableRankTest
         PokerPlayer rival = seat(table, 1, 2, 1000);
         HoldemHand hhand = startHand(table);
 
-        assertTrue("expected a hand in progress", table.isHandInProgress());
-        assertTrue("expected both players to post", hhand.getTotalBet(leader) > 0 &&
-                                                    hhand.getTotalBet(rival) > 0);
-        assertTrue("the button takes the small blind, so seat 0 must have posted more",
-                   hhand.getTotalBet(leader) > hhand.getTotalBet(rival));
+        assertTrue(table.isHandInProgress(), "expected a hand in progress");
+        assertTrue(hhand.getTotalBet(leader) > 0 &&
+                                                    hhand.getTotalBet(rival) > 0, "expected both players to post");
+        assertTrue(hhand.getTotalBet(leader) > hhand.getTotalBet(rival), "the button takes the small blind, so seat 0 must have posted more");
 
         // level the live counts, whatever the blinds cost: settled is live plus what is
         // in the pot, so the big blind stays ahead by the difference between the posts
         rival.setChipCount(leader.getChipCount());
 
-        assertEquals("settled counts still put the leader first", 1, table.getRank(leader));
-        assertEquals("and the rival second, where a live count would tie them",
-                     2, table.getRank(rival));
+        assertEquals(1, table.getRank(leader), "settled counts still put the leader first");
+        assertEquals(2, table.getRank(rival), "and the rival second, where a live count would tie them");
     }
 
     /**
@@ -338,8 +332,7 @@ public class PokerTableRankTest
         for (int i = 0; i < game_.getNumPlayers(); i++)
         {
             PokerPlayer p = game_.getPokerPlayerAt(i);
-            assertEquals("table and tournament rank differ for " + p.getName(),
-                         game_.getRank(p), table.getRank(p));
+            assertEquals(game_.getRank(p), table.getRank(p), "table and tournament rank differ for " + p.getName());
         }
     }
 }

--- a/code/pokerengine/pom.xml
+++ b/code/pokerengine/pom.xml
@@ -65,9 +65,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/pokernetwork/pom.xml
+++ b/code/pokernetwork/pom.xml
@@ -60,9 +60,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/pokerserver/pom.xml
+++ b/code/pokerserver/pom.xml
@@ -65,9 +65,8 @@
       <version>${spring.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/ConfigTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/ConfigTest.java
@@ -32,12 +32,14 @@
  */
 package com.donohoedigital.games.poker.server;
 
-import junit.framework.*;
 import org.springframework.context.support.*;
 import org.springframework.context.*;
 import org.springframework.util.*;
 
 import java.io.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -47,19 +49,21 @@ import java.io.*;
  *
  * Simple Spring test - configure logging, load app context, get a bean
  */
-public class ConfigTest extends TestCase
+public class ConfigTest
 {
     /**
      * Load app config
      */
+    @Test
     public void testSpring() throws FileNotFoundException
     {
         String[] contextPaths = new String[] {"app-context-configtest.xml"};
         ApplicationContext ctx = new ClassPathXmlApplicationContext(contextPaths);
         String test = (String) ctx.getBean("test");
-        assertEquals("test bean", "Test", test);
+        assertEquals("Test", test, "test bean");
     }
 
+    @Test
     public void testTrue()
     {
         assertTrue(true);

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/DisallowedManagerTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/DisallowedManagerTest.java
@@ -34,9 +34,11 @@ package com.donohoedigital.games.poker.server;
 
 import com.donohoedigital.config.*;
 import com.donohoedigital.games.poker.service.helper.*;
-import junit.framework.*;
 
 import java.net.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -45,12 +47,13 @@ import java.net.*;
  * Time: 10:57:08 AM
  * To change this template use File | Settings | File Templates.
  */
-public class DisallowedManagerTest extends TestCase
+public class DisallowedManagerTest
 {
     //private static final Logger logger = LogManager.getLogger(DisallowedManagerTest.class);
 
     DisallowedManager manager = new DisallowedManager();
 
+    @Test
     public void testInvalid()
     {
         assertTrue(manager.isNameValid("Dexter"));
@@ -69,6 +72,7 @@ public class DisallowedManagerTest extends TestCase
 
     }
 
+    @Test
     public void testUTF8()
     {
         verifyFile("greek.utf8.txt");

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/HibernateTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/HibernateTest.java
@@ -38,12 +38,14 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
-import junit.framework.TestCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.FileNotFoundException;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -53,9 +55,10 @@ import java.util.List;
  *
  * Test of Hibernate/JPA without Spring.
  */
-public class HibernateTest extends TestCase
+public class HibernateTest
 {
     @SuppressWarnings({"RawUseOfParameterizedType"})
+    @Test
     public void testHibernate() throws FileNotFoundException
     {
         Logger logger = LogManager.getLogger(HibernateTest.class);

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameServiceTest.java
@@ -34,15 +34,15 @@ package com.donohoedigital.games.poker.server;
 
 import com.donohoedigital.games.poker.model.OnlineGame;
 import com.donohoedigital.games.poker.service.OnlineGameService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -51,7 +51,7 @@ import static org.junit.Assert.*;
  * Time: 2:52:25 PM
  * Test items in OnlineGameService that are more than pass-throughs to the OnlineGame DAO
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineGameServiceTest

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineGameTest.java
@@ -43,20 +43,19 @@ import com.donohoedigital.games.poker.model.OnlineGame;
 import com.donohoedigital.games.poker.model.util.OnlineGameList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -65,7 +64,7 @@ import static org.junit.Assert.*;
  * Time: 2:44:16 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineGameTest
@@ -88,14 +87,14 @@ public class OnlineGameTest
         assertNotNull(newGame.getId());
 
         OnlineGame fetch = dao.get(newGame.getId());
-        assertEquals("license key should match", newGame.getLicenseKey(), fetch.getLicenseKey());
+        assertEquals(newGame.getLicenseKey(), fetch.getLicenseKey(), "license key should match");
 
         String key = "1111-1111-1111-1111";
         newGame.setLicenseKey(key);
         dao.update(newGame);
 
         OnlineGame updated = dao.get(newGame.getId());
-        assertEquals("key should match", key, updated.getLicenseKey());
+        assertEquals(key, updated.getLicenseKey(), "key should match");
     }
 
     @Test
@@ -167,8 +166,8 @@ public class OnlineGameTest
             OnlineGameList fetch = dao.getByMode(count, fetched, pagesize, modes, null, null, null, true);
             fetched += fetch.size();
 
-            assertEquals("total rows should match", expectedCount, fetch.getTotalSize());
-            assertTrue("rows returned should be <= pagesize", fetch.size() <= pagesize);
+            assertEquals(expectedCount, fetch.getTotalSize(), "total rows should match");
+            assertTrue(fetch.size() <= pagesize, "rows returned should be <= pagesize");
             if (fetch.isEmpty()) break;
 
             // sorting by mode first, verify that first half are REG
@@ -195,7 +194,7 @@ public class OnlineGameTest
             }
         }
 
-        assertEquals("total fetched should equal all games", gameCount, fetched);
+        assertEquals(gameCount, fetched, "total fetched should equal all games");
 
         // test fetch of just end/stop and sort normally
         pagesize = 4;
@@ -211,8 +210,8 @@ public class OnlineGameTest
             OnlineGameList fetch = dao.getByMode(count, fetched, pagesize, modes2, null, null, null, false);
             fetched += fetch.size();
 
-            assertEquals("total rows should match", expectedCount, fetch.getTotalSize());
-            assertTrue("rows returned should be <= pagesize", fetch.size() <= pagesize);
+            assertEquals(expectedCount, fetch.getTotalSize(), "total rows should match");
+            assertTrue(fetch.size() <= pagesize, "rows returned should be <= pagesize");
             if (fetch.isEmpty()) break;
 
             // sorting by mode first, verify that first half are REG
@@ -223,15 +222,15 @@ public class OnlineGameTest
                 int name = Integer.parseInt(og.getHostPlayer());
                 long date = og.getEndDate().getTime();
 
-                assertTrue(date + " <= " + lastDate, date <= lastDate);
-                if (date == lastDate) assertTrue(name + " > " + lastName, name > lastName);
+                assertTrue(date <= lastDate, date + " <= " + lastDate);
+                if (date == lastDate) assertTrue(name > lastName, name + " > " + lastName);
 
                 lastName = name;
                 lastDate = date;
             }
         }
 
-        assertEquals("total fetched should equal half of games", fetched, expectedCount);
+        assertEquals(fetched, expectedCount, "total fetched should equal half of games");
 
         // test fetch of just each type
         for (int i = OnlineGame.MODE_REG; i <= OnlineGame.MODE_END; i++)
@@ -248,8 +247,8 @@ public class OnlineGameTest
                 OnlineGameList fetch = dao.getByMode(count, fetched, pagesize, modes3, null, null, null, false);
                 fetched += fetch.size();
 
-                assertEquals("total rows should match", expectedCount, fetch.getTotalSize());
-                assertTrue("rows returned should be <= pagesize", fetch.size() <= pagesize);
+                assertEquals(expectedCount, fetch.getTotalSize(), "total rows should match");
+                assertTrue(fetch.size() <= pagesize, "rows returned should be <= pagesize");
                 if (fetch.isEmpty()) break;
 
                 // verify ordering correct
@@ -275,13 +274,13 @@ public class OnlineGameTest
                             date = og.getCreateDate().getTime();
                     }
 
-                    assertTrue(modes3[0] + " " + date + " <= " + lastDate, date <= lastDate);
+                    assertTrue(date <= lastDate, modes3[0] + " " + date + " <= " + lastDate);
 
                     lastDate = date;
                 }
             }
 
-            assertEquals("total fetched should equal half of games", fetched, expectedCount);
+            assertEquals(fetched, expectedCount, "total fetched should equal half of games");
         }
     }
 

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceDummyTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceDummyTest.java
@@ -32,12 +32,12 @@
  */
 package com.donohoedigital.games.poker.server;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Created by IntelliJ IDEA.
@@ -47,7 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
  * <p/>
  * Test items in OnlineProfileService that are more than pass-throughs to the OnlineProfile DAO
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileServiceDummyTest

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileServiceTest.java
@@ -34,15 +34,15 @@ package com.donohoedigital.games.poker.server;
 
 import com.donohoedigital.games.poker.model.OnlineProfile;
 import com.donohoedigital.games.poker.service.OnlineProfileService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -52,7 +52,7 @@ import static org.junit.Assert.*;
  * <p/>
  * Test items in OnlineProfileService that are more than pass-throughs to the OnlineProfile DAO
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileServiceTest

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/OnlineProfileTest.java
@@ -38,19 +38,18 @@ import com.donohoedigital.games.poker.dao.OnlineProfileDao;
 import com.donohoedigital.games.poker.model.OnlineProfile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URL;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -59,7 +58,7 @@ import static org.junit.Assert.*;
  * Time: 2:44:16 PM
  * To change this template use File | Settings | File Templates.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class OnlineProfileTest
@@ -81,15 +80,15 @@ public class OnlineProfileTest
         assertNotNull(newProfile.getId());
 
         OnlineProfile fetch = dao.get(newProfile.getId());
-        assertEquals("name should match", newProfile.getName(), fetch.getName());
-        assertEquals("passwords should match", sPassword, fetch.getPassword());
+        assertEquals(newProfile.getName(), fetch.getName(), "name should match");
+        assertEquals(sPassword, fetch.getPassword(), "passwords should match");
 
         String key = "1111-1111-1111-1111";
         newProfile.setLicenseKey(key);
         dao.update(newProfile);
 
         OnlineProfile updated = dao.get(newProfile.getId());
-        assertEquals("key should match", key, updated.getLicenseKey());
+        assertEquals(key, updated.getLicenseKey(), "key should match");
     }
 
     @Test
@@ -252,7 +251,7 @@ public class OnlineProfileTest
 
         OnlineProfile fetch = dao.get(newProfile.getId());
         assertNotSame(newProfile, fetch);
-        assertEquals("name should match", newProfile.getName(), fetch.getName());
+        assertEquals(newProfile.getName(), fetch.getName(), "name should match");
         assertEquals(utf8, fetch.getName());
         logger.debug("Name: " + utf8);
     }

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
@@ -40,16 +40,16 @@ import com.donohoedigital.games.poker.service.OnlineGameService;
 import com.donohoedigital.games.poker.service.OnlineProfileService;
 import com.donohoedigital.games.poker.service.TournamentHistoryService;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.donohoedigital.games.poker.model.TournamentHistory.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by IntelliJ IDEA.
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertEquals;
  * Time: 2:52:25 PM
  * Test items in TournamentHistoryService that are more than pass-throughs to the TournamentHistory DAO
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class TournamentHistoryServiceTest

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryTest.java
@@ -41,19 +41,18 @@ import com.donohoedigital.games.poker.model.OnlineProfile;
 import com.donohoedigital.games.poker.model.TournamentHistory;
 import com.donohoedigital.games.poker.model.util.TournamentHistoryList;
 import org.apache.logging.log4j.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -62,7 +61,7 @@ import static org.junit.Assert.*;
  * Time: 2:44:16 PM
  * Test TournamentHistory DAO
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 @ContextConfiguration(locations = {"/app-context-pokerservertests.xml"})
 public class TournamentHistoryTest
@@ -90,14 +89,14 @@ public class TournamentHistoryTest
         assertNotNull(newHistory.getId());
 
         TournamentHistory fetch = histDao.get(newHistory.getId());
-        assertEquals("name should match", newHistory.getPlayerName(), fetch.getPlayerName());
+        assertEquals(newHistory.getPlayerName(), fetch.getPlayerName(), "name should match");
 
         int prize = 12345;
         newHistory.setPrize(prize);
         histDao.update(newHistory);
 
         TournamentHistory updated = histDao.get(newHistory.getId());
-        assertEquals("prize should match", prize, updated.getPrize());
+        assertEquals(prize, updated.getPrize(), "prize should match");
     }
 
     @Test
@@ -313,7 +312,7 @@ public class TournamentHistoryTest
         assertEquals(list.size(), histCount / 2);
         for (TournamentHistory hist : list)
         {
-            assertEquals(hist.getPlayerName() + " == " + one.getName(), hist.getPlayerName(), one.getName());
+            assertEquals(hist.getPlayerName(), one.getName(), hist.getPlayerName() + " == " + one.getName());
         }
 
         list = histDao.getAllForGame(null, 0, histCount, game1.getId());

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/XMLExportTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/XMLExportTest.java
@@ -37,16 +37,19 @@ import com.donohoedigital.games.config.*;
 import com.donohoedigital.games.poker.model.*;
 import com.donohoedigital.xml.*;
 import com.donohoedigital.base.*;
-import junit.framework.*;
 import org.apache.logging.log4j.*;
 
 import java.util.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Doug Donohoe
  */
-public class XMLExportTest extends TestCase
+public class XMLExportTest
 {
+    @Test
     public void testSimpleXMLEncoder()
     {
         // setup config manager (so we know where profiles live)

--- a/code/pokerwicket/pom.xml
+++ b/code/pokerwicket/pom.xml
@@ -76,9 +76,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/ApplicationTest.java
+++ b/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/ApplicationTest.java
@@ -39,7 +39,6 @@ import com.donohoedigital.games.poker.service.OnlineGameService;
 import com.donohoedigital.games.poker.service.OnlineProfileService;
 import com.donohoedigital.games.poker.wicket.pages.online.Search;
 import com.donohoedigital.games.server.service.BannedKeyService;
-import junit.framework.TestCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.wicket.spring.test.ApplicationContextMock;
@@ -47,8 +46,11 @@ import org.apache.wicket.util.tester.WicketTester;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.easymock.EasyMock.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -57,7 +59,7 @@ import static org.easymock.EasyMock.*;
  * Time: 10:47:51 AM
  * Rudimentary test which uses mocking and WicketTester
  */
-public class ApplicationTest extends TestCase
+public class ApplicationTest
 {
     Logger logger = LogManager.getLogger(ApplicationTest.class);
 
@@ -67,7 +69,7 @@ public class ApplicationTest extends TestCase
 
     private final String searchString = "+";
 
-    @Override
+    @BeforeEach
     public void setUp()
     {
         new ConfigManager("test", ApplicationType.WEBAPP);
@@ -114,6 +116,7 @@ public class ApplicationTest extends TestCase
         tester = new WicketTester(wicketApplication);
     }
 
+    @Test
     public void testSearch()
     {
         // start and render the test page

--- a/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/rss/RssTest.java
+++ b/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/rss/RssTest.java
@@ -39,20 +39,23 @@ import com.rometools.rome.feed.rss.Item;
 import com.rometools.rome.feed.rss.Source;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.WireFeedOutput;
-import junit.framework.*;
 
 import java.util.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Doug Donohoe
  */
-public class RssTest extends TestCase
+public class RssTest
 {
     //private static final Logger logger = LogManager.getLogger(RssTest.class);
 
     /**
      * This test basically verifies dependencies for rome (rss) are working
      */
+    @Test
     public void testRSS()
     {
         Channel channel = new Channel("rss_2.0");

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -75,11 +75,23 @@
     <spring.version>6.2.19</spring.version>
     <hibernate.version>6.6.56.Final</hibernate.version>
     <jetty.version>12.1.12</jetty.version>
-    <junit.version>4.13.2</junit.version>
+    <junit.version>5.14.4</junit.version>
     <wicket.version>10.11.0</wicket.version>
     <wicket.jquery.ui.version>10.0.0-M1</wicket.jquery.ui.version>
     <dependency.classpath.outputFile>target/classpath.txt</dependency.classpath.outputFile>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
 
@@ -124,6 +136,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.5.1</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.4</version>
       </plugin>
 
     </plugins>

--- a/code/proto/pom.xml
+++ b/code/proto/pom.xml
@@ -75,9 +75,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
@@ -33,7 +33,6 @@
 package com.donohoedigital.proto.tests;
 
 import com.donohoedigital.base.Utils;
-import junit.framework.TestCase;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.wicket.util.convert.converter.DateConverter;
@@ -47,6 +46,9 @@ import java.net.URLEncoder;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -55,10 +57,11 @@ import java.util.Properties;
  * Time: 12:53:22 PM
  * To change this template use File | Settings | File Templates.
  */
-public class Experiments extends TestCase
+public class Experiments
 {
     private Logger logger = LogManager.getLogger(Experiments.class);
 
+    @Test
     public void testNullEquals()
     {
         String foo = null;
@@ -67,6 +70,7 @@ public class Experiments extends TestCase
         logger.debug("bar.equals(foo): " + bar.equals(foo));
     }
 
+    @Test
     public void testResourceLoader()
     {
         ClassLoader cl = getClass().getClassLoader();
@@ -84,6 +88,7 @@ public class Experiments extends TestCase
         }
     }
 
+    @Test
     public void testSpringResolver()
     {
         PathMatchingResourcePatternResolver match;
@@ -102,6 +107,7 @@ public class Experiments extends TestCase
         }
     }
 
+    @Test
     public void testPrimitiveArray()
     {
         byte[] data = new byte[0];
@@ -110,6 +116,7 @@ public class Experiments extends TestCase
     }
 
     @SuppressWarnings({"UseOfSystemOutOrSystemErr"})
+    @Test
     public void testNoLog4j()
     {
         System.out.println("Before log4j logger call");
@@ -119,6 +126,7 @@ public class Experiments extends TestCase
         System.out.println("After log4j logger call");
     }
 
+    @Test
     public void testNullInstanceOf()
     {
         Object foo = null;
@@ -128,9 +136,10 @@ public class Experiments extends TestCase
             logger.debug("never true");
         }
 
-        assertTrue("null instanceof works if we get here", true);
+        assertTrue(true, "null instanceof works if we get here");
     }
 
+    @Test
     public void testURLEncoder()
     {
         String dot = ".|";
@@ -145,6 +154,7 @@ public class Experiments extends TestCase
         }
     }
 
+    @Test
     public void testEncodeSlash()
     {
         String enc = "><//'>";
@@ -152,11 +162,13 @@ public class Experiments extends TestCase
         logger.debug("ENCODE: " + enc);
     }
 
+    @Test
     public void testReplacePercent()
     {
         logger.debug("PERCENT: " + "%and%that%".replaceAll("%", "\\\\%"));
     }
 
+    @Test
     public void testDateConverter()
     {
         DateConverter c = new DateConverter();
@@ -166,6 +178,7 @@ public class Experiments extends TestCase
         logger.debug("Reversed: " + c.convertToObject(s, null));
     }
 
+    @Test
     public void testUser()
     {
         Properties props = System.getProperties();

--- a/code/server/pom.xml
+++ b/code/server/pom.xml
@@ -60,9 +60,8 @@
       <version>${servlet.api.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/tools/pom.xml
+++ b/code/tools/pom.xml
@@ -65,9 +65,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/udp/pom.xml
+++ b/code/udp/pom.xml
@@ -55,9 +55,8 @@
       <version>3.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/wicket/pom.xml
+++ b/code/wicket/pom.xml
@@ -128,9 +128,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/code/wicket/src/test/java/com/donohoedigital/wicket/WicketUtilsTest.java
+++ b/code/wicket/src/test/java/com/donohoedigital/wicket/WicketUtilsTest.java
@@ -33,12 +33,14 @@
 package com.donohoedigital.wicket;
 
 import com.donohoedigital.wicket.converters.ParamDateConverter;
-import junit.framework.TestCase;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Created by IntelliJ IDEA.
@@ -47,8 +49,9 @@ import java.util.GregorianCalendar;
  * Time: 10:30:48 AM
  * To change this template use File | Settings | File Templates.
  */
-public class WicketUtilsTest extends TestCase
+public class WicketUtilsTest
 {
+	@Test
 	public void testDate()
 	{
         ParamDateConverter conv = new ParamDateConverter();

--- a/code/wicket/src/test/java/com/donohoedigital/wicket/annotations/MixedParamEncoderTest.java
+++ b/code/wicket/src/test/java/com/donohoedigital/wicket/annotations/MixedParamEncoderTest.java
@@ -34,9 +34,9 @@ package com.donohoedigital.wicket.annotations;
 
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MixedParamEncoderTest {
 

--- a/ddpoker.rc
+++ b/ddpoker.rc
@@ -48,7 +48,7 @@ alias mvn-install='(cd $CODE;mvn install)'
 alias mvn-clean='(cd $CODE;mvn clean)'
 alias mvn-package-notests='(cd $CODE;mvn package -DskipTests=true)'
 alias mvn-package='(cd $CODE;mvn package)'
-alias mvn-test='(cd $CODE;mvn test -Dskip.unit.tests=false)'
+alias mvn-test='(cd $CODE;mvn test)'
 alias mvn-tree='mvn dependency:tree -q -Dscope=runtime -Ddependency.classpath.outputFile=/tmp/t && cat /tmp/t && rm -f /tmp/t'
 
 # act shortcut


### PR DESCRIPTION
Migrates every test in the tree to JUnit 5 (Jupiter). Previously the tests were split across three generations: 27 classes still extended `junit.framework.TestCase`, 20 were on JUnit 4, and none were on JUnit 5.

## Why 5 and not 4

Bringing the JUnit 3 classes up to JUnit 4 would have been throwaway work:

- JUnit 4.13.2 has had no release since Feb 2021.
- **Spring Framework 7.0 deprecates the entire `org.springframework.test.context.junit4` package** (`SpringJUnit4ClassRunner`, `SpringRunner`, `SpringClassRule`, `AbstractJUnit4SpringContextTests`), with removal targeted for Spring 8. 13 classes here used `SpringJUnit4ClassRunner`, so a Spring 7 bump forces this migration regardless — and this build compiles with `-Xlint:deprecation,removal`.
- The JUnit 3 → 5 edit is essentially the same edit as JUnit 3 → 4 (swap imports, add `@Test`, rename `setUp`/`tearDown`).

Landing on **5.14.4 rather than JUnit 6** is deliberate: `SpringExtension` only targets Jupiter 6 as of Spring Framework 7.0, and we're on Spring 6.2.19. JUnit 6 is a one-property change later — Jupiter kept the `org.junit.jupiter.*` package names — and belongs with the Spring 7 upgrade.

## A bug this surfaced

`pokerwicket` pulls `junit-jupiter` in transitively from Wicket, which flipped surefire to the JUnit Platform provider for that module. With no vintage engine on the classpath, its two `TestCase` classes — `ApplicationTest` and `RssTest` — **were silently not running at all**. They run now, and pass.

That is the entire test-count change: **137 → 139**.

## Changes

**Build (22 poms)**
- Root pom: `junit.version` → 5.14.4, new `<dependencyManagement>` importing `org.junit:junit-bom`, and `maven-surefire-plugin` pinned at 3.5.4 (it was the only unpinned plugin; Maven 3.9.15 happens to bind that version, but CI's Maven version isn't pinned).
- 21 module poms: `junit:junit` → `org.junit.jupiter:junit-jupiter`, versions now managed by the BOM. `proto` stays at compile scope since `Experiments.java` lives under `src/main`.
- No `junit-vintage-engine` — everything migrated, so nothing needs it. JUnit 4 is gone from every module's resolved dependency tree.

**Tests (47 classes)**
- 27 JUnit 3: dropped `extends TestCase`, added `@Test`, `setUp`/`tearDown` → `@BeforeEach`/`@AfterEach`. `GuiTest` also lost its JUnit 3 constructor and `suite()`/`TestSuite` archetype boilerplate.
- 20 JUnit 4: `@RunWith(SpringJUnit4ClassRunner.class)` → `@ExtendWith(SpringExtension.class)` (13 classes; `@ContextConfiguration` left separate so the context path stays visible), `@Before` → `@BeforeEach`, and `PokerDatabaseTest`'s `@Rule TemporaryFolder` → `@TempDir`.

**Cleanup**
- Removed `-Dskip.unit.tests=false` from `ci.yml` and the `mvn-test` alias — no pom, profile, or surefire config ever read it. `README-DEV.md` used it as the worked example for a real PowerShell quoting rule, so that example now points at `-Ddependency.classpath.outputFile`, a dotted property this build actually defines.

## The risky part: assertion argument order

JUnit 5 moves the assertion message from the **first** argument to the **last**. 115 call sites needed reordering.

Most are compiler-checked — `assertTrue("msg", bool)` won't compile reversed. The dangerous ones are 3-arg `assertEquals` where both value args are `String`: leaving the message first silently makes it the *expected value*, and the test then compares the message against the actual. Those compile clean and pass nothing useful.

An automated pass keyed on a leading string literal caught 108 sites. It missed sites whose message *starts with an expression*; javac caught three of those, and one would have compiled silently wrong:

```java
// TournamentHistoryTest — all three arguments are String
assertEquals(hist.getPlayerName() + " == " + one.getName(), hist.getPlayerName(), one.getName());
```

A second scan for arguments *containing* a string literal without starting with one found it, plus three message-first `assertTrue` calls in `OnlineGameTest`. Re-scanned until clean.

## Verification

- Captured a per-class test-count baseline **before** any edits — JUnit 3 auto-discovered `test*` methods and Jupiter does not, so a missed `@Test` would otherwise vanish silently.
- Per-class counts are identical to baseline except the two pokerwicket gains.
- Separately verified by parsing every `test*` method in every test file that all carry `@Test`.
- `junit.framework`, non-Jupiter `org.junit.*`, `@RunWith`, `TemporaryFolder` and `junit:junit` are absent from the tree and from all resolved dependencies.
- Full `mvn package` green locally against MySQL: 139 tests, 0 failures.
