### PR TITLE
Add OpenRewrite for automated code modernization

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -242,6 +242,53 @@ to the latest versions that work with Java 25.  The only exception is `HSQLDB`, 
 have at 1.8.0.10. The latest is 2.7.4, but this requires updating existing databases, which
 we don't want to deal with at this time.
 
+### Code Modernization (OpenRewrite)
+
+Because the code started life on Java 5, a lot of it predates language features we now take
+for granted.  [OpenRewrite](https://docs.openrewrite.org) is wired into `code/pom.xml` to
+automate the mechanical parts of catching up.  It is not bound to any lifecycle phase, so
+ordinary builds are unaffected.
+
+Recipes are grouped in `rewrite.yml` (repo root), one group per reviewable change:
+
+| Recipe | What it does |
+|--------|--------------|
+| `com.donohoedigital.TypeCleanup` | Diamond operator, redundant casts, C-style arrays, unused imports |
+| `com.donohoedigital.Lambdas` | Anonymous functional interfaces to lambdas and method references |
+| `com.donohoedigital.StringsAndCollections` | `isEmpty()`, `contains()`, `valueOf()`, `StringBuilder` |
+| `com.donohoedigital.FinalAndModifiers` | `final` private fields, redundant modifiers, `@Override` |
+| `com.donohoedigital.ParameterizedLogging` | `log.debug("x " + y)` becomes `log.debug("x {}", y)` |
+| `com.donohoedigital.DeadCode` | Unused private members — **risky, see below** |
+| `com.donohoedigital.RedundantInitializers` | Drop `= null` / `= false` / `= 0` from field declarations |
+
+```shell
+cd code
+mvn rewrite:dryRun -Drewrite.activeRecipes=com.donohoedigital.TypeCleanup   # preview only
+mvn rewrite:run    -Drewrite.activeRecipes=com.donohoedigital.TypeCleanup   # apply
+mvn rewrite:discover                                                        # list all recipes
+```
+
+`dryRun` writes a patch to `code/target/rewrite/rewrite.patch` and changes nothing.  **Always
+dry-run and read the patch first.**  Recipes are idempotent — re-running one over already-fixed
+code is a no-op, so an empty patch means that group is fully applied.
+
+`DeadCode` needs particular care.  Hibernate, Wicket (which binds markup to component ids) and
+the gameengine XML save-game code all reach members reflectively, and OpenRewrite cannot see
+those references.  Check each deletion against a grep of `.java`, `.html` and `.xml`.
+
+Three things are deliberately *not* automated, because they are matters of taste rather than
+correctness: converting locals to `var`, adding `final` to locals and parameters, and expanding
+star imports.  That last one is why `RemoveUnusedImports` is not in `TypeCleanup` — OpenRewrite
+rewrites `import javax.swing.*` into one line per class, which would touch ~370 files here.
+
+If you use IntelliJ, its own inspections can be run headlessly to see what it would flag.  This
+requires IntelliJ to be **closed**, since the inspector will not start alongside a running IDE:
+
+```shell
+"/Applications/IntelliJ IDEA.app/Contents/bin/inspect.sh" \
+    "$DDHOME" "$DDHOME/.idea/inspectionProfiles/Project_Default.xml" /tmp/inspect -v1 -format json
+```
+
 ### Modules
 
 Here is a brief overview of the modules in this repo, in the order maven builds them, which

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -144,6 +144,38 @@
         <version>3.6.0</version>
       </plugin>
 
+      <!--
+        OpenRewrite - automated source modernization.  Not bound to any lifecycle phase, so
+        ordinary builds are unaffected.  Recipes are defined in rewrite.yml in the repo root
+        (the plugin's default location - Maven treats the repo root as the multi-module root
+        because .mvn/ lives there).  See "Code Modernization" in README-DEV.md for usage.
+      -->
+      <plugin>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite-maven-plugin</artifactId>
+        <version>6.46.1</version>
+        <!-- Versions are those pinned by rewrite-recipe-bom 3.37.0.  A BOM cannot be
+             imported here - Maven only honours scope=import in dependencyManagement -
+             so they are listed explicitly and should be bumped as a set. -->
+        <dependencies>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-static-analysis</artifactId>
+            <version>2.41.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-logging-frameworks</artifactId>
+            <version>3.32.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-migrate-java</artifactId>
+            <version>3.42.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
     </plugins>
 
     <resources>

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,144 @@
+# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+# DD Poker - Source Code
+# Copyright (c) 2003-2026 Doug Donohoe
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# For the full License text, please see the LICENSE.txt file
+# in the root directory of this project.
+#
+# The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+# graphics, text, and documentation found in this repository (including but not
+# limited to written documentation, website content, and marketing materials)
+# are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+# 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+# without explicit written permission for any uses not covered by this License.
+# For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+# in the root directory of this project.
+#
+# For inquiries regarding commercial licensing of this source code or
+# the use of names, logos, images, text, or other assets, please contact
+# doug [at] donohoe [dot] info.
+# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+#
+# OpenRewrite recipe definitions for the Java modernization sweep.
+# See the "Code Modernization" section of README-DEV.md for how to run these.
+# Recipes are grouped so each one lands as a single reviewable PR.
+# =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.TypeCleanup
+displayName: Generics and type cleanup
+description: >
+  Diamond operator, redundant casts and C-style array declarations.
+  The lowest-risk group - none of these change behaviour.
+  NOTE: org.openrewrite.java.RemoveUnusedImports is deliberately NOT here.  It expands
+  star imports (import javax.swing.* becomes one line per class), which this code base
+  uses on purpose - it would touch ~370 files for no benefit.
+recipeList:
+  - org.openrewrite.staticanalysis.UseDiamondOperator
+  - org.openrewrite.staticanalysis.RemoveRedundantTypeCast
+  - org.openrewrite.staticanalysis.UseJavaStyleArrayDeclarations
+  - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
+  - org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
+  - org.openrewrite.staticanalysis.RemoveExtraSemicolons
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.Lambdas
+displayName: Lambdas and method references
+description: >
+  Replace anonymous implementations of functional interfaces with lambdas, and lambdas
+  that merely delegate with method references. Mostly Swing listeners in gui/ and poker/.
+  Anonymous classes that hold state or reference the enclosing instance are left alone.
+recipeList:
+  - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
+  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
+  - org.openrewrite.staticanalysis.LambdaBlockToExpression
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.StringsAndCollections
+displayName: String and collection API modernization
+description: >
+  isEmpty() over size() == 0, contains() over indexOf(), constant-first equals(),
+  valueOf() over wrapper constructors, StringBuilder over StringBuffer, and friends.
+recipeList:
+  - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
+  - org.openrewrite.staticanalysis.IndexOfReplaceableByContains
+  - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  - org.openrewrite.staticanalysis.StringLiteralEquality
+  - org.openrewrite.staticanalysis.NoValueOfOnStringType
+  - org.openrewrite.staticanalysis.NoToStringOnStringType
+  - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
+  - org.openrewrite.staticanalysis.UseStandardCharset
+  - org.openrewrite.staticanalysis.ExplicitCharsetOnStringGetBytes
+  - org.openrewrite.staticanalysis.UseListSort
+  - org.openrewrite.staticanalysis.UseStringReplace
+  - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
+  - org.openrewrite.staticanalysis.ReplaceStringBufferWithStringBuilder
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.FinalAndModifiers
+displayName: Final fields and modifier hygiene
+description: >
+  Mark private fields final where they are assigned exactly once, drop redundant
+  modifiers, and add missing @Override.  Deliberately does NOT finalize locals or
+  parameters (see FinalizeLocalVariables) - that is line noise, not information.
+  REVIEW: verify Hibernate entity classes are untouched before applying.
+recipeList:
+  - org.openrewrite.staticanalysis.FinalizePrivateFields
+  - org.openrewrite.staticanalysis.FinalClass
+  - org.openrewrite.staticanalysis.ModifierOrder
+  - org.openrewrite.staticanalysis.StaticAccessViaInstance
+  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+  - org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.ParameterizedLogging
+displayName: Parameterized logging
+description: >
+  Rewrite log.debug("x " + y) as log.debug("x {}", y) so the concatenation no longer
+  happens when the level is disabled.
+recipeList:
+  - org.openrewrite.java.logging.ParameterizedLogging
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.DeadCode
+displayName: Dead code removal
+description: >
+  RISKY - Hibernate, Wicket and the gameengine XML save-game code all reach members
+  reflectively, and OpenRewrite cannot see those references.  Always dryRun and review
+  each deletion against a grep of .java, .html and .xml before applying.
+recipeList:
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
+  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+  - org.openrewrite.staticanalysis.UnnecessaryThrows
+  - org.openrewrite.staticanalysis.RemoveUnneededBlock
+  - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
+  - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.RedundantInitializers
+displayName: Redundant field initializers
+description: >
+  Drop "= null", "= false", "= 0" from field declarations, where the JVM already
+  guarantees that value.  Safe (fields only, never locals) but touches ~730 lines and
+  IntelliJ does not flag it by default, so it is kept opt-in rather than folded into
+  TypeCleanup.
+recipeList:
+  - org.openrewrite.staticanalysis.ExplicitInitialization


### PR DESCRIPTION
First PR in the code modernization series. **Tooling only — no source changes.**

## What this adds

| File | Change |
|------|--------|
| `code/pom.xml` | `rewrite-maven-plugin` 6.46.1 + three recipe artifacts |
| `rewrite.yml` (new) | 7 recipe groups, 37 recipes — one group per planned PR |
| `README-DEV.md` | "Code Modernization" section under *Warning — This Code is Old!* |

The plugin is not bound to any lifecycle phase, so ordinary builds are unaffected.

```shell
cd code
mvn rewrite:dryRun -Drewrite.activeRecipes=com.donohoedigital.TypeCleanup   # preview
mvn rewrite:run    -Drewrite.activeRecipes=com.donohoedigital.TypeCleanup   # apply
```

## Recipe groups

| Recipe | Planned PR |
|--------|-----------|
| `TypeCleanup` | PR 2 — diamond operator, redundant casts, C-style arrays |
| `Lambdas` | PR 3 — anonymous classes to lambdas / method refs |
| `StringsAndCollections` | PR 4 |
| `FinalAndModifiers` | PR 5 |
| `ParameterizedLogging` | PR 6 |
| `DeadCode` | PR 7 |
| `RedundantInitializers` | opt-in, unscheduled |

## Three non-obvious decisions

**`rewrite.yml` is in the repo root, not `code/`.** `.mvn/wrapper/` is tracked at the root, so
Maven computes `maven.multiModuleProjectDirectory` as the repo root — which is where the
plugin's default `configLocation` looks. A `rewrite.yml` under `code/` is silently ignored:
recipes simply aren't found, with no warning that the config file was missing.

**Recipe artifacts carry explicit versions rather than importing `rewrite-recipe-bom`.** Maven
only honours `scope=import` in `dependencyManagement`, not in a plugin's `dependencies`. The
pinned versions are the set from `rewrite-recipe-bom` 3.37.0 and should be bumped together.
Note that BOM 3.38.0 references artifact versions that are not published to Maven Central.

**`RemoveUnusedImports` is deliberately excluded from `TypeCleanup`.** A dry-run showed it
expands star imports — `import javax.swing.*` becomes one line per class — touching 369 files,
367 of them import-only. That undoes a convention this code base uses on purpose. IntelliJ's
own Optimize Imports handles genuinely unused imports while respecting the star threshold.

## Verification

- `mvn package -DskipTests` — BUILD SUCCESS, all 22 modules
- `mvn package` — BUILD SUCCESS, 139 tests, 0 failures / 0 errors
- All 7 recipe groups confirmed to load (`rewrite:dryRun` resolves each by name)
- All 37 recipe names verified to exist on the resolved classpath
- `TypeCleanup` dry-run produces a valid patch across the full reactor