### PR TITLE
Apply diamond operator and Java-style array declarations

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/Base64.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Base64.java
@@ -1339,7 +1339,7 @@ public class Base64
         
     }   // end inner class OutputStream
     
-    public static void main(String s[])
+    public static void main(String[] s)
     {
         System.out.println(s[0] +" equals " + Base64.encodeBytes(s[0].getBytes()));
     }

--- a/code/common/src/main/java/com/donohoedigital/base/CommandLine.java
+++ b/code/common/src/main/java/com/donohoedigital/base/CommandLine.java
@@ -48,7 +48,7 @@ public class CommandLine
     private static String sParamName_ = "[file]";
     private static String sParamUsage_ = "[file 1] ... [file N]";
     private static String sParamDesc_ = "a file";
-    private static Map<String, Option> htOpts_ = new HashMap<String, Option>(); // options to gather
+    private static Map<String, Option> htOpts_ = new HashMap<>(); // options to gather
 
     private static TypedHashMap htValues_ = new TypedHashMap(); // options gathered
     private static String[] saRemainingArgs_ = null; // command line values not part of args
@@ -234,7 +234,7 @@ public class CommandLine
         String sArg;
         boolean bDone = false;
         htValues_ = new TypedHashMap();
-        List<String> vArgs = new ArrayList<String>();
+        List<String> vArgs = new ArrayList<>();
 
         for (int i = 0; i < args.length; i++)
         {

--- a/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
+++ b/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
@@ -163,9 +163,9 @@ public class MersenneTwisterFast implements Serializable, Cloneable
     private static final int TEMPERING_MASK_B = 0x9d2c5680;
     private static final int TEMPERING_MASK_C = 0xefc60000;
     
-    private int mt[]; // the array for the state vector
+    private int[] mt; // the array for the state vector
     private int mti; // mti==N+1 means mt[N] is not initialized
-    private int mag01[];
+    private int[] mag01;
     
     // a good initial seed (of int size, though stored in a long)
     //private static final long GOOD_SEED = 4357;
@@ -1152,7 +1152,7 @@ public class MersenneTwisterFast implements Serializable, Cloneable
     /**
      * Tests the code.
      */
-    public static void main(String args[])
+    public static void main(String[] args)
         { 
         int j;
 

--- a/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
+++ b/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
@@ -222,7 +222,7 @@ public class RandomGUID extends Object
     /*
      * Demonstraton and self test of class
      */
-    public static void main(String args[])
+    public static void main(String[] args)
     {
         for (int i = 0; i < 100; i++)
         {

--- a/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
@@ -328,7 +328,7 @@ public class SecurityUtils
     /**
      * get MD5 hash of string
      */
-    public static String getMD5Hash(String s, byte key[])
+    public static String getMD5Hash(String s, byte[] key)
     {
         return hash(s.getBytes(), key, "MD5");
     }

--- a/code/common/src/main/java/com/donohoedigital/base/Utils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Utils.java
@@ -301,11 +301,11 @@ public class Utils
         Map<Thread, StackTraceElement[]> map = Thread.getAllStackTraces();
 
         // sort map
-        Map<Thread, StackTraceElement[]> smap = new TreeMap<Thread, StackTraceElement[]>(TC);
+        Map<Thread, StackTraceElement[]> smap = new TreeMap<>(TC);
         smap.putAll(map);
         Iterator<Thread> iter = smap.keySet().iterator();
         Thread t;
-        Object stackitems[];
+        Object[] stackitems;
         while (iter.hasNext())
         {
             t = iter.next();
@@ -853,7 +853,7 @@ public class Utils
     public static File[] getFileList(File fDir, String sExt, String sBeginsWith)
     {
         UtilFileFilter filter = new UtilFileFilter(sExt, sBeginsWith);
-        File list[] = fDir.listFiles(filter);
+        File[] list = fDir.listFiles(filter);
         Arrays.sort(list);
         return list;
     }

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
@@ -411,7 +411,7 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
     {
         if (msgdata_ == null)
         {
-            msgdata_ = new ArrayList<MessageData>();
+            msgdata_ = new ArrayList<>();
         }
         return msgdata_;
     }
@@ -445,7 +445,7 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
     /**
      * add string data chunk
      */
-    public void addData(File fDatas[])
+    public void addData(File[] fDatas)
     {
         if (fDatas == null || fDatas.length == 0) return;
         List<MessageData> msgdata = getDataList();
@@ -674,7 +674,7 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
         if (msgdata_ != null && !msgdata_.isEmpty())
         {
             int nNumData = msgdata_.size();
-            DMArrayList<Integer> sizes = new DMArrayList<Integer>(nNumData);
+            DMArrayList<Integer> sizes = new DMArrayList<>(nNumData);
             MessageData data;
             
             for (int i = 0; i < nNumData; i++)

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
@@ -441,7 +441,7 @@ public class DDMessenger
             this.bytes=Utils.encode(s);
         }
         
-        public BytePostWriter(byte b[])
+        public BytePostWriter(byte[] b)
         {
             bytes = b;
         }

--- a/code/common/src/main/java/com/donohoedigital/comms/MsgState.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/MsgState.java
@@ -55,14 +55,14 @@ public class MsgState
     private static final int NEXT_ID_NOTSET = -1;
     
     // ids
-    private Map<Object, Integer> ids_ = new HashMap<Object, Integer>();
-    private Map<Integer, Object> reverseids_ = new HashMap<Integer, Object>();
+    private Map<Object, Integer> ids_ = new HashMap<>();
+    private Map<Integer, Object> reverseids_ = new HashMap<>();
     private int nextid_ = NEXT_ID_NOTSET;
     
     // class info
     private TokenizedList classNames_;
-    private Map<String, Integer> classids_ = new HashMap<String, Integer>();
-    private Map<Integer, String> reverseclassids_ = new HashMap<Integer, String>();
+    private Map<String, Integer> classids_ = new HashMap<>();
+    private Map<Integer, String> reverseclassids_ = new HashMap<>();
     private int nextclassid_ = 0;
     
     /**

--- a/code/common/src/main/java/com/donohoedigital/comms/TokenizedList.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/TokenizedList.java
@@ -61,7 +61,7 @@ public class TokenizedList implements DataMarshal
     public static final int TOKEN_READ_ALL = Integer.MAX_VALUE;
     
     // data
-    protected List<DataMarshal> tokens_ = new ArrayList<DataMarshal>();
+    protected List<DataMarshal> tokens_ = new ArrayList<>();
     protected EscapeStringTokenizer tokenizer_;
     
     /**

--- a/code/common/src/main/java/com/donohoedigital/config/Activation.java
+++ b/code/common/src/main/java/com/donohoedigital/config/Activation.java
@@ -122,7 +122,7 @@ public class Activation
      * Return a hash of the given id
      */
     private static MessageDigest md_ = null;
-    private static byte foo[] = new byte[25];
+    private static byte[] foo = new byte[25];
     private static StringBuilder sb_ = new StringBuilder(20);
 
     /**

--- a/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
@@ -60,7 +60,7 @@ public class AudioConfig extends XMLConfigFileLoader
 
     private static AudioConfig audioConfig = null;
 
-    private Map<String, AudioDef> audios_ = new HashMap<String, AudioDef>();
+    private Map<String, AudioDef> audios_ = new HashMap<>();
 
     private static boolean bMuteFX_ = false;
     private static float fFXGain_ = .8f;

--- a/code/common/src/main/java/com/donohoedigital/config/AudioPlayer.java
+++ b/code/common/src/main/java/com/donohoedigital/config/AudioPlayer.java
@@ -338,7 +338,7 @@ public class AudioPlayer implements Runnable, LineListener
         else
         {
             SourceDataLine line = (SourceDataLine) dataline_;
-            byte tempBuffer[] = new byte[25000 * 4];
+            byte[] tempBuffer = new byte[25000 * 4];
             int cnt = 0;
 
             try 

--- a/code/common/src/main/java/com/donohoedigital/config/CustomCachingMetadataReaderFactory.java
+++ b/code/common/src/main/java/com/donohoedigital/config/CustomCachingMetadataReaderFactory.java
@@ -48,7 +48,7 @@ import java.util.*;
 class CustomCachingMetadataReaderFactory extends SimpleMetadataReaderFactory
 {
 
-    private final Map<Resource, MetadataReader> classReaderCache = new HashMap<Resource, MetadataReader>();
+    private final Map<Resource, MetadataReader> classReaderCache = new HashMap<>();
 
 
     /**

--- a/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
@@ -47,7 +47,7 @@ public class DebugConfig
 {
     private static Logger logger = LogManager.getLogger(DebugConfig.class);
     private static Boolean TESTING_ENABLED = null;
-    private static final Map<String, Boolean> cache = new HashMap<String, Boolean>();
+    private static final Map<String, Boolean> cache = new HashMap<>();
 
     /**
      * Return true if given debug testing property is on.

--- a/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
@@ -59,8 +59,8 @@ public class HelpConfig extends XMLConfigFileLoader
 
     private static HelpConfig helpConfig = null;
     
-    private Map<String, HelpTopic> helps_ = new HashMap<String, HelpTopic>();
-    private List<HelpTopic> helparray_ = new ArrayList<HelpTopic>();
+    private Map<String, HelpTopic> helps_ = new HashMap<>();
+    private List<HelpTopic> helparray_ = new ArrayList<>();
     
     /** 
      * Creates a new instance of HelpConfig from the Appconfig file 

--- a/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
@@ -63,7 +63,7 @@ public class ImageConfig extends XMLConfigFileLoader
 
     private static ImageConfig imageConfig = null;
     
-    private Map<String, ImageDef> images_ = new HashMap<String, ImageDef>();
+    private Map<String, ImageDef> images_ = new HashMap<>();
     
     /** 
      * Creates a new instance of ImageConfig from the Appconfig file 

--- a/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
@@ -91,7 +91,7 @@ public class ImageDef
         bComposite_ = bComposite;
         if (sComponents != null)
         {
-            List<String> a = new ArrayList<String>();
+            List<String> a = new ArrayList<>();
             StringTokenizer tok = new StringTokenizer(sComponents, " ,");
             while (tok.hasMoreTokens())
             {

--- a/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
@@ -209,7 +209,7 @@ public class PropertyConfig extends Properties
     @SuppressWarnings({"unchecked"})
     public Map<String, String> getMatching(String sStartsWith)
     {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         Enumeration<String> enumer = (Enumeration<String>) propertyNames();
         while (enumer.hasMoreElements())
         {
@@ -370,7 +370,7 @@ public class PropertyConfig extends Properties
     }
 
     // cache formats
-    private static final Map<String, MessageFormat> formats_ = new HashMap<String, MessageFormat>();
+    private static final Map<String, MessageFormat> formats_ = new HashMap<>();
 
     /**
      * Get a message and insert the params into it (params replaced
@@ -466,8 +466,8 @@ public class PropertyConfig extends Properties
     }
 
     // store locales
-    private static final Map<String, SimpleDateFormat> dates_ = new HashMap<String, SimpleDateFormat>();
-    private static final Map<String, Locale> locales_ = new HashMap<String, Locale>();
+    private static final Map<String, SimpleDateFormat> dates_ = new HashMap<>();
+    private static final Map<String, Locale> locales_ = new HashMap<>();
 
     /**
      * get date format (msg.format.datetime key)

--- a/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
@@ -63,7 +63,7 @@ public class ShutdownManager implements Thread.UncaughtExceptionHandler
     }
 
     // shutdown listeners
-    private final List<ShutdownListener> listeners = new ArrayList<ShutdownListener>();
+    private final List<ShutdownListener> listeners = new ArrayList<>();
 
     // shutdown type and reason (default to normal)
     private Type shutdownType = NORMAL;

--- a/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
@@ -63,9 +63,9 @@ public class StylesConfig extends XMLConfigFileLoader
 
     private static StylesConfig stylesConfig = null;
 
-    private Map<String, Color> colors_ = new HashMap<String, Color>();
-    private Map<String, Font> fonts_ = new HashMap<String, Font>();
-    private Map<String, Font> fontdefs_ = new HashMap<String, Font>();
+    private Map<String, Color> colors_ = new HashMap<>();
+    private Map<String, Font> fonts_ = new HashMap<>();
+    private Map<String, Font> fontdefs_ = new HashMap<>();
 
     /**
      * Creates a new instance of StylesConfig from the Appconfig file

--- a/code/common/src/main/java/com/donohoedigital/config/XMLConfigFileLoader.java
+++ b/code/common/src/main/java/com/donohoedigital/config/XMLConfigFileLoader.java
@@ -848,7 +848,7 @@ public class XMLConfigFileLoader implements ErrorHandler
         {
             sAttrErrorDesc = "Paramlist #" + (i + 1) + " of " + sErrLocation;
             param = paramlist.get(i);
-            list = new ArrayList<Object>();
+            list = new ArrayList<>();
 
             sName = getStringAttributeValue(param, "name", true, sAttrErrorDesc);
 

--- a/code/common/src/main/java/com/donohoedigital/html/Table.java
+++ b/code/common/src/main/java/com/donohoedigital/html/Table.java
@@ -43,8 +43,8 @@ import java.util.*;
  */
 public class Table
 {
-    private ArrayList<TableColumn> cols_ = new ArrayList<TableColumn>();
-    private ArrayList<TableRow> rows_ = new ArrayList<TableRow>();
+    private ArrayList<TableColumn> cols_ = new ArrayList<>();
+    private ArrayList<TableRow> rows_ = new ArrayList<>();
 
     private int CELLPADDING, CELLSPACING;
 

--- a/code/common/src/main/java/com/donohoedigital/html/TableRow.java
+++ b/code/common/src/main/java/com/donohoedigital/html/TableRow.java
@@ -43,7 +43,7 @@ import java.util.*;
  */
 public class TableRow
 {
-    private ArrayList<TableData> data_ = new ArrayList<TableData>();
+    private ArrayList<TableData> data_ = new ArrayList<>();
 
     public TableRow()
     {

--- a/code/common/src/main/java/com/donohoedigital/xml/SimpleXMLEncoder.java
+++ b/code/common/src/main/java/com/donohoedigital/xml/SimpleXMLEncoder.java
@@ -48,7 +48,7 @@ public class SimpleXMLEncoder
     SimpleDateFormat format = Utils.getRFC822();
 
     private StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    private Stack<EncoderObject> currentObject = new Stack<EncoderObject>();
+    private Stack<EncoderObject> currentObject = new Stack<>();
 
     /**
      * Set current object null and start new tag with name "alias".
@@ -180,8 +180,8 @@ public class SimpleXMLEncoder
      */
     public SimpleXMLEncoder addAllTagsExcept(String... names)
     {
-        List<String> include = new ArrayList<String>();
-        List<String> except = new ArrayList<String>();
+        List<String> include = new ArrayList<>();
+        List<String> except = new ArrayList<>();
         except.add("class");
         except.addAll(Arrays.asList(names));
 

--- a/code/common/src/test/java/com/donohoedigital/base/ManagedQueueTest.java
+++ b/code/common/src/test/java/com/donohoedigital/base/ManagedQueueTest.java
@@ -53,7 +53,7 @@ public class ManagedQueueTest
     private static final Logger logger = LogManager.getLogger(ManagedQueueTest.class);
 
     private Thread mainThread;
-    private final List<SampleItem> messages = new ArrayList<SampleItem>();
+    private final List<SampleItem> messages = new ArrayList<>();
     private static final SampleItem SAMPLE = new SampleItem();
 
     @BeforeEach
@@ -79,7 +79,7 @@ public class ManagedQueueTest
         @Override
         protected BlockingQueue<SampleItem> createQueue(int c)
         {
-            return new ArrayBlockingQueue<SampleItem>(c);
+            return new ArrayBlockingQueue<>(c);
         }
 
         @Override

--- a/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
+++ b/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
@@ -62,7 +62,7 @@ public class DatabaseManager
     public static final String PARAM_PASSWORD = "password";
 
     private static boolean initialized_ = false;
-    private static Map<String, Database> hmDatabases_ = new HashMap<String, Database>();
+    private static Map<String, Database> hmDatabases_ = new HashMap<>();
 
     /**
      * Determine if the manager has been initialized.
@@ -184,7 +184,7 @@ public class DatabaseManager
                 long after = System.currentTimeMillis();
 
                 //noinspection ThrowableInstanceNeverThrown
-                StackTraceElement stack[] = new Throwable().getStackTrace();
+                StackTraceElement[] stack = new Throwable().getStackTrace();
                 StringBuilder buf = new StringBuilder();
 
                 String className;

--- a/code/db/src/main/java/com/donohoedigital/db/DatabaseQuery.java
+++ b/code/db/src/main/java/com/donohoedigital/db/DatabaseQuery.java
@@ -156,7 +156,7 @@ public class DatabaseQuery
         if (joinTables_ == null)
         {
             // Assume common case of one table.
-            joinTables_ = new ArrayList<String>(1);
+            joinTables_ = new ArrayList<>(1);
         }
 
         joinTables_.add(tableName);
@@ -248,7 +248,7 @@ public class DatabaseQuery
 
         if (bindValues_ == null)
         {
-            bindValues_ = new ArrayList<Object>();
+            bindValues_ = new ArrayList<>();
         }
 
         bindValues_.add(bindValue);

--- a/code/db/src/main/java/com/donohoedigital/db/dao/impl/JpaBaseDao.java
+++ b/code/db/src/main/java/com/donohoedigital/db/dao/impl/JpaBaseDao.java
@@ -306,7 +306,7 @@ public abstract class JpaBaseDao<T extends BaseModel<ID>, ID extends Serializabl
         }
 
         // return all results
-        PagedList<T> list = new PagedList<T>(results);
+        PagedList<T> list = new PagedList<>(results);
         list.setTotalSize(count);
 
         return list;

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/AbstractPlayerList.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/AbstractPlayerList.java
@@ -195,7 +195,7 @@ public abstract class AbstractPlayerList extends ArrayList<AbstractPlayerList.Pl
     public void fromCSV(String sText, boolean bSave)
     {
         sText = sText.replace('\n', ',');
-        List<PlayerInfo> keep = new ArrayList<PlayerInfo>(size());
+        List<PlayerInfo> keep = new ArrayList<>(size());
         String sName;
         PlayerInfo search = new PlayerInfo(null, null);
         String[] names = CSVParser.parseLine(sText);

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Area.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Area.java
@@ -189,7 +189,7 @@ public class Area
     //// GAME MODE FUNCTIONALITY
     ////
     
-    Territory ts_[] = null;
+    Territory[] ts_ = null;
     private int nNumRegions_;
     private int nNumIslands_;
     private int nTotalAdjacentLandRegions_;
@@ -213,7 +213,7 @@ public class Area
      */
     private Territory[] createTerritoryArray()
     {
-        Territory all[] = Territory.getTerritoryArrayCached();
+        Territory[] all = Territory.getTerritoryArrayCached();
         int nNum = 0;
         // first get count
         for (int i = 0; i < all.length; i++)
@@ -357,7 +357,7 @@ public class Area
      */
     public short[] getCountByPlayer(int nNumPlayers)
     {
-        short count[] = new short[nNumPlayers];
+        short[] count = new short[nNumPlayers];
         Territory[] ts = getTerritories();
         GamePlayer player;
         
@@ -386,7 +386,7 @@ public class Area
     public boolean allBelongTo(GamePlayer pl)
     {
         int nCnt = 0;
-        Territory ts[] = getTerritories();
+        Territory[] ts = getTerritories();
         for (int i = 0; i < ts.length; i++)
         {
             if (ts[i].getGamePlayer() != pl)

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Areas.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Areas.java
@@ -120,7 +120,7 @@ public class Areas extends TreeMap {
      */
     public Area[] getAreaArray()
     {
-        Area array[] = new Area[size()];
+        Area[] array = new Area[size()];
         Set areas = this.keySet();
         Iterator iter = areas.iterator();
         String sAreaName;
@@ -133,7 +133,7 @@ public class Areas extends TreeMap {
         return array;
     }
     
-    Area cached_[];
+    Area[] cached_;
     
     /**
      * Get cached copy of areas array
@@ -153,7 +153,7 @@ public class Areas extends TreeMap {
      */
     public void calculateStats()
     {
-        Area areas[] = getAreaArrayCached();
+        Area[] areas = getAreaArrayCached();
         for (int i = 0; i < areas.length; i++)
         {
             areas[i].calculateStats();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/DDGeneralPathIterator.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/DDGeneralPathIterator.java
@@ -52,9 +52,9 @@ public class DDGeneralPathIterator implements PathIterator
     //static Logger logger = LogManager.getLogger(DDGeneralPathIterator.class);
     
     private GeneralPath path_;
-    private static final int curvesize[] = {2, 2, 4, 6, 0};
+    private static final int[] curvesize = {2, 2, 4, 6, 0};
     private ArrayList points_ = new ArrayList();
-    float current_[];
+    float[] current_;
     private int index_ = 0;
     
     /**
@@ -69,8 +69,8 @@ public class DDGeneralPathIterator implements PathIterator
     {
         path_ = path;
         PathIterator iter = path.getPathIterator(null);
-        float coord[] = new float[6];
-        float newd[];
+        float[] coord = new float[6];
+        float[] newd;
         int ret;
         int num;
         int i = 0;

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameConfigUtils.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameConfigUtils.java
@@ -55,7 +55,7 @@ public class GameConfigUtils
     public static final String SAVE_DIR = "save";
 
     private static File saveDir = null;
-    private static final Map<String, ObjectLock> lockMap = new HashMap<String, ObjectLock>();
+    private static final Map<String, ObjectLock> lockMap = new HashMap<>();
 
     /**
      * Get the location for save files, creating the directory if not there.

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
@@ -68,7 +68,7 @@ public class GameState extends MsgState implements SaveFile
     private byte[] savedata_;
     private String sName_;
     private String sDesc_;
-    private List<GameStateEntry> entries_ = new ArrayList<GameStateEntry>();
+    private List<GameStateEntry> entries_ = new ArrayList<>();
     private TypedHashMap gamedata_;
     private SaveDetails details_;
     
@@ -861,8 +861,8 @@ public class GameState extends MsgState implements SaveFile
      */
     public static GameState[] getSaveFileList(File fDir, String sBegin, String sExt)
     {
-        File files[] = Utils.getFileList(fDir, SaveFile.DELIM + sExt, sBegin);
-        List<GameState> newst = new ArrayList<GameState>();
+        File[] files = Utils.getFileList(fDir, SaveFile.DELIM + sExt, sBegin);
+        List<GameState> newst = new ArrayList<>();
 
         for (File file : files)
         {

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameboardConfig.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameboardConfig.java
@@ -512,7 +512,7 @@ public class GameboardConfig extends XMLConfigFileLoader
     {
         TerritoryPoint point;
         TerritoryPoints points;
-        Territory ta[] = this.territories_.getTerritoryArrayCached();
+        Territory[] ta = this.territories_.getTerritoryArrayCached();
 
         for (Territory adj : ta)
         {

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Territories.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Territories.java
@@ -123,7 +123,7 @@ public class Territories extends TreeMap {
      */
     public Territory[] getTerritoryArray()
     {
-        Territory array[] = new Territory[size()];
+        Territory[] array = new Territory[size()];
         Set territories = this.keySet();
         Iterator iter = territories.iterator();
         String sTerritoryName;
@@ -136,7 +136,7 @@ public class Territories extends TreeMap {
         return array;
     }
     
-    Territory cached_[];
+    Territory[] cached_;
     /**
      * Get cached copy of territories array
      */
@@ -156,7 +156,7 @@ public class Territories extends TreeMap {
     public void initForGame()
     {   
         // Create path in each territory
-        Territory ts[] = getTerritoryArrayCached();
+        Territory[] ts = getTerritoryArrayCached();
         for (int i = 0; i < ts.length; i++)
         {
             ts[i].initForGame();
@@ -170,7 +170,7 @@ public class Territories extends TreeMap {
     public void createPaths()
     {   
         // Create path in each territory
-        Territory ts[] = getTerritoryArrayCached();
+        Territory[] ts = getTerritoryArrayCached();
         for (int i = 0; i < ts.length; i++)
         {
             ts[i].createPath();
@@ -184,7 +184,7 @@ public class Territories extends TreeMap {
     public void determineAdjacentTerritories(boolean bClearBorders)
     {
         // figure adjacent territories
-        Territory ts[] = getTerritoryArrayCached();
+        Territory[] ts = getTerritoryArrayCached();
         for (int i = 0; i < ts.length; i++)
         {
             ts[i].determineAdjacentTerritories(bClearBorders);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
@@ -59,7 +59,7 @@ public class DiceRoller {
      */
     public static Integer[] rollDice(int nSides, int nNum)
     {
-        Integer results[] = new Integer[nNum];
+        Integer[] results = new Integer[nNum];
         for (int i = 0; i < nNum; i++)
         {
             results[i] = rollDie(nSides);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGameAI.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGameAI.java
@@ -49,7 +49,7 @@ import com.donohoedigital.games.config.*;
 public abstract class EngineGameAI extends GameAI
 {
     protected GamePlayer gamePlayer_;
-    protected Territory my_[];
+    protected Territory[] my_;
     protected int myNum_ = 0;
 
     /** 
@@ -93,7 +93,7 @@ public abstract class EngineGameAI extends GameAI
      */
     protected void determineMyTerritories()
     {
-        Territory ts[] = Territory.getTerritoryArrayCached();
+        Territory[] ts = Territory.getTerritoryArrayCached();
         myNum_ = 0;
         for (int i = 0; i < ts.length; i++)
         {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -453,7 +453,7 @@ public class EngineUtils
      */
     public static List<GamePiece> getMatchingPieces(GamePieceContainer container, int nType)
     {
-        List<GamePiece> list = new ArrayList<GamePiece>();
+        List<GamePiece> list = new ArrayList<>();
         if (container == null) return list;
         GamePiece piece;
         synchronized (container.getMap())

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
@@ -93,12 +93,12 @@ public class GameContext
     private GamePhase lastLoopPhase_ = null;
 
     // Stack of GamePhase's that have history=true
-    private Stack<GamePhase> pastPhases_ = new Stack<GamePhase>();
+    private Stack<GamePhase> pastPhases_ = new Stack<>();
 
     // Cached phases are Phase instances that are saved
     // for reuse because they typically retain state (e.g., loop phases and
     // menu phases which has user input
-    private Map<String, Phase> cachedPhases_ = new HashMap<String, Phase>();
+    private Map<String, Phase> cachedPhases_ = new HashMap<>();
 
 
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -1001,7 +1001,7 @@ public abstract class GameEngine extends BaseApp
     ////
 
     // list of contexts
-    private Map<String, ContextTracker> contexts_ = new HashMap<String, ContextTracker>();
+    private Map<String, ContextTracker> contexts_ = new HashMap<>();
 
     /**
      * note that a context was created
@@ -1056,7 +1056,7 @@ public abstract class GameEngine extends BaseApp
     {
         int nNum;
         String sName;
-        List<GameContext> contexts = new ArrayList<GameContext>();
+        List<GameContext> contexts = new ArrayList<>();
 
         // constructor
         ContextTracker(String sName)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
@@ -453,7 +453,7 @@ public class GameListPanel extends DDPanel implements ListSelectionListener,
      */
     private SaveTableModel getSavedFileModel()
     {
-        GameState saved[] = GameState.getSaveFileList(sBegin_, SAVE_EXT);
+        GameState[] saved = GameState.getSaveFileList(sBegin_, SAVE_EXT);
         return new SaveTableModel(saved);
     }
     

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Gameboard.java
@@ -1461,8 +1461,8 @@ public class Gameboard extends ImageComponent implements Scrollable,
     /// Territory listeners
     ///
     
-    private List<TerritorySelectionListener> tlisteners_ = new ArrayList<TerritorySelectionListener>();
-    private List<GamePieceSelectionListener> elisteners_ = new ArrayList<GamePieceSelectionListener>();
+    private List<TerritorySelectionListener> tlisteners_ = new ArrayList<>();
+    private List<GamePieceSelectionListener> elisteners_ = new ArrayList<>();
     
     /**
      * Add a territory selection listener

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
@@ -66,7 +66,7 @@ public class Help extends BasePhase implements ListSelectionListener,
     private TableModel model_;
     private DDImageButton bak_, fwd_;
     private int nHistIndex_ = 0;
-    private List<HelpTopic> history_ = new ArrayList<HelpTopic>();
+    private List<HelpTopic> history_ = new ArrayList<>();
     private String STYLE;
     private boolean bRunning_ = false;
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/OptionMenu.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/OptionMenu.java
@@ -59,7 +59,7 @@ public abstract class OptionMenu extends BasePhase implements ChangeListener, Gu
     private MenuBackground menu_;
     protected DDPanel data_;
     private DDButton defaultButton_;
-    protected List<DDOption> options_ = new ArrayList<DDOption>();
+    protected List<DDOption> options_ = new ArrayList<>();
 
     /**
      * Get focus - typically overriden

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/OptionMenuDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/OptionMenuDialog.java
@@ -57,7 +57,7 @@ public abstract class OptionMenuDialog extends DialogPhase implements ChangeList
     private DDHtmlArea text_;
     private DDPanel data_;
     protected DDButton defaultButton_;
-    protected List<DDOption> options_ = new ArrayList<DDOption>();
+    protected List<DDOption> options_ = new ArrayList<>();
 
     /**
      * Create contents

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/PlayersDieRoll6x2.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/PlayersDieRoll6x2.java
@@ -52,7 +52,7 @@ public class PlayersDieRoll6x2 implements DataMarshal
     //static Logger logger = LogManager.getLogger(PlayersDieRoll6x2.class);
     
     int nIndex_;
-    DMArrayList dieRolls_[];
+    DMArrayList[] dieRolls_;
     GameInfo game_;
     
     /** 
@@ -98,7 +98,7 @@ public class PlayersDieRoll6x2 implements DataMarshal
         return dieRolls_;
     }
 
-    private int getIndexOfMax(DMArrayList dieRolls[], int nMax, int nMinRolls)
+    private int getIndexOfMax(DMArrayList[] dieRolls, int nMax, int nMinRolls)
     {   
         int nCnt = 0;
         for (int i = 0; i < dieRolls.length; i++)
@@ -113,7 +113,7 @@ public class PlayersDieRoll6x2 implements DataMarshal
         return 0;   
     }
     
-    private int getNumAtMax(DMArrayList dieRolls[], int nMax, int nMinRolls)
+    private int getNumAtMax(DMArrayList[] dieRolls, int nMax, int nMinRolls)
     {
         // special case for 1st time, need to roll all die
         if (nMax == -1) return dieRolls.length;
@@ -131,7 +131,7 @@ public class PlayersDieRoll6x2 implements DataMarshal
         return nCnt;   
     }
     
-    private int rollDieAtMax(DMArrayList dieRolls[], int nMax, int nMinRolls)
+    private int rollDieAtMax(DMArrayList[] dieRolls, int nMax, int nMinRolls)
     {
         DieRoll6x2 roll;
         int nNewMax = -1;

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
@@ -68,7 +68,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
     private GameContext context_;
     private String STYLE;
     private List<BaseProfile> profiles_;
-    private List<ProfilePanel> profilePanels_ = new ArrayList<ProfilePanel>();
+    private List<ProfilePanel> profilePanels_ = new ArrayList<>();
     private DDPanel profilesParent_;
     private DDScrollPane scroll_;
     private BaseProfile selected_ = null;
@@ -549,7 +549,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
         ProfilePanel pp;
         
         // manage parent (remove all and re-add so sort order is good)
-        List<ProfilePanel> newPP = new ArrayList<ProfilePanel>();
+        List<ProfilePanel> newPP = new ArrayList<>();
         profilesParent_.removeAll();
         for (BaseProfile aProfiles_ : profiles_)
         {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
@@ -1002,7 +1002,7 @@ public class ScrollGameboard extends JViewport implements
     
     // handler for modal panels
     ModalHandler handler_ = new ModalHandler();
-    private Stack<JPanel> topPanels_ = new Stack<JPanel>();
+    private Stack<JPanel> topPanels_ = new Stack<>();
     private JPanel topPanel_ = null; // last modal panel
     
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
@@ -224,7 +224,7 @@ public class UDPStatus extends BasePhase implements DDTable.TableMenuItems
      */
     private class UDPModel extends DefaultTableModel implements UDPManagerMonitor
     {
-        private ArrayList<UDPLink> list = new ArrayList<UDPLink>();
+        private ArrayList<UDPLink> list = new ArrayList<>();
 
         public UDPModel()
         {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UserRegistration.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UserRegistration.java
@@ -69,7 +69,7 @@ public class UserRegistration extends BasePhase implements PropertyChangeListene
     private DDButton reregButton_;
     private JComponent focus_;
     private RegistrationMessage msg_ = new RegistrationMessage(EngineMessage.CAT_USER_REG);
-    private List<DDOption> options_ = new ArrayList<DDOption>();
+    private List<DDOption> options_ = new ArrayList<>();
     private long nRegTime_ = 0;
     private Preferences prefs_;
     private static String REGTIME = "regtime";

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
@@ -86,14 +86,14 @@ public class RegAnalyzer
     private int numMac;
     private int numWindows;
     private int numLinux;
-    private List<Counter> monthCnt_ = new ArrayList<Counter>();
-    private List<Counter> weekCnt_ = new ArrayList<Counter>();
-    private List<Counter> dayCnt_ = new ArrayList<Counter>();
+    private List<Counter> monthCnt_ = new ArrayList<>();
+    private List<Counter> weekCnt_ = new ArrayList<>();
+    private List<Counter> dayCnt_ = new ArrayList<>();
     private int[] hourCnt_ = new int[24];
 
     // keys members
-    private List<RegInfo> suspectKeys_ = new ArrayList<RegInfo>();
-    private List<RegInfo> bannedKeys_ = new ArrayList<RegInfo>();
+    private List<RegInfo> suspectKeys_ = new ArrayList<>();
+    private List<RegInfo> bannedKeys_ = new ArrayList<>();
 
     // services
     private BannedKeyService bannedService;

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
@@ -913,7 +913,7 @@ public class ServerSideGame extends ServerDataFile implements GameInfo
      */
     private int getNextSaveNumber(File dir, String sExt)
     {
-        File files[] = Utils.getFileList(dir, DELIM + sExt, null);
+        File[] files = Utils.getFileList(dir, DELIM + sExt, null);
         int nNum = 1;
         if (files != null && files.length > 0)
         {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/BannedKeyImplJpa.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/BannedKeyImplJpa.java
@@ -57,7 +57,7 @@ public class BannedKeyImplJpa extends JpaBaseDao<BannedKey, Long> implements Ban
 
     public List<BannedKey> getByKeys(String... keys)
     {
-        if (keys.length == 0) return new ArrayList<BannedKey>();
+        if (keys.length == 0) return new ArrayList<>();
 
         return getList("select b from BannedKey b " +
                        "where b.key in " + getInClause(1, keys.length) + " " +

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/RegistrationImplJpa.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/RegistrationImplJpa.java
@@ -106,7 +106,7 @@ public class RegistrationImplJpa extends JpaBaseDao<Registration, Long> implemen
         );
         query.setParameter("key", keyStart);
         List<Object[]> results = query.getResultList();
-        List<RegDayOfYearCount> list = new ArrayList<RegDayOfYearCount>(results.size());
+        List<RegDayOfYearCount> list = new ArrayList<>(results.size());
         for (Object[] objs : results)
         {
             list.add(new RegDayOfYearCount(
@@ -139,7 +139,7 @@ public class RegistrationImplJpa extends JpaBaseDao<Registration, Long> implemen
         );
         query.setParameter("key", keyStart);
         List<Object[]> results = query.getResultList();
-        List<RegHourCount> list = new ArrayList<RegHourCount>(results.size());
+        List<RegHourCount> list = new ArrayList<>(results.size());
         for (Object[] objs : results)
         {
             list.add(new RegHourCount(
@@ -193,7 +193,7 @@ public class RegistrationImplJpa extends JpaBaseDao<Registration, Long> implemen
 
         List<Registration> list = (List<Registration>) query.getResultList();
 
-        PagedList<Registration> pList = new PagedList<Registration>(list.size());
+        PagedList<Registration> pList = new PagedList<>(list.size());
         pList.addAll(list);
         pList.setTotalSize(count);
         return pList;

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/util/RegInfo.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/util/RegInfo.java
@@ -54,11 +54,11 @@ public class RegInfo implements Comparable<RegInfo>
     
     // info
     private String sKey_;
-    private List<Registration> msgs_ = new ArrayList<Registration>();
-    private List<Registration> reg_msgs_ = new ArrayList<Registration>();
-    private List<Registration> act_msgs_ = new ArrayList<Registration>();
-    private List<Registration> patch_msgs_ = new ArrayList<Registration>();
-    private List<Registration> dup_msgs_ = new ArrayList<Registration>();
+    private List<Registration> msgs_ = new ArrayList<>();
+    private List<Registration> reg_msgs_ = new ArrayList<>();
+    private List<Registration> act_msgs_ = new ArrayList<>();
+    private List<Registration> patch_msgs_ = new ArrayList<>();
+    private List<Registration> dup_msgs_ = new ArrayList<>();
     private long mostRecent_;
     private static SimpleDateFormat date_ = new SimpleDateFormat("MM/dd/yyyy 'at' HH:mm:ss", Locale.US);
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/service/impl/RegistrationServiceImpl.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/service/impl/RegistrationServiceImpl.java
@@ -127,7 +127,7 @@ public class RegistrationServiceImpl implements RegistrationService
     @Transactional(readOnly = true)
     public List<RegInfo> getBannedKeys(String keyStart)
     {
-        Map<String, RegInfo> regInfoMap = new HashMap<String, RegInfo>();
+        Map<String, RegInfo> regInfoMap = new HashMap<>();
 
         // get banned keys and create RegInfo for each
         List<BannedKey> banned = bannedDao.getAll();
@@ -149,7 +149,7 @@ public class RegistrationServiceImpl implements RegistrationService
         }
 
         // return sorted array
-        List<RegInfo> all = new ArrayList<RegInfo>(regInfoMap.values());
+        List<RegInfo> all = new ArrayList<>(regInfoMap.values());
         Collections.sort(all);
         return all;
     }
@@ -157,7 +157,7 @@ public class RegistrationServiceImpl implements RegistrationService
     @Transactional(readOnly = true)
     public List<RegInfo> getSuspectKeys(String keyStart, int nMin)
     {
-        Map<String, RegInfo> regInfoMap = new HashMap<String, RegInfo>();
+        Map<String, RegInfo> regInfoMap = new HashMap<>();
 
         // get all suspect keys
         List<String> suspectKeys = dao.getAllSuspectKeys(nMin);
@@ -183,7 +183,7 @@ public class RegistrationServiceImpl implements RegistrationService
         }
 
         // return sorted array
-        List<RegInfo> all = new ArrayList<RegInfo>(regInfoMap.values());
+        List<RegInfo> all = new ArrayList<>(regInfoMap.values());
         Collections.sort(all);
         return all;
     }

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/ChatValidate.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/ChatValidate.java
@@ -48,7 +48,7 @@ import java.util.*;
  */
 public class ChatValidate
 {
-    public static void main(String argv[])
+    public static void main(String[] argv)
     {
         if (argv.length == 0)
         {

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
@@ -109,7 +109,7 @@ public class PokerRankUpdater extends BaseCommandLineApp
      */
     private void doRank()
     {
-        Integer modes[] = new Integer[2];
+        Integer[] modes = new Integer[2];
         modes[0] = OnlineGame.MODE_END;
         modes[1] = OnlineGame.MODE_STOP;
         int offset = 0;

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/WhatIsMyIp.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/WhatIsMyIp.java
@@ -95,7 +95,7 @@ public class WhatIsMyIp implements DDMessageListener
                                  EngineMessage.CAT_PUBLIC_IP);
     }
 
-    public static void main(String args[])
+    public static void main(String[] args)
     {
 
         new ConfigManager("poker", ApplicationType.COMMAND_LINE, false);

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlEditorKit.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlEditorKit.java
@@ -72,7 +72,7 @@ public class DDHtmlEditorKit extends HTMLEditorKit
     
     public static class HTMLFactoryX extends HTMLFactory
     {
-        Class ctorArgs_[] = new Class[] { Element.class };
+        Class[] ctorArgs_ = new Class[] { Element.class };
 
         public View create(Element elem)
         {

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDScrollTable.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDScrollTable.java
@@ -49,7 +49,7 @@ import java.awt.*;
 public class DDScrollTable extends DDScrollPane
 {
     DDTable table_;
-    int columnWidths_[];
+    int[] columnWidths_;
 
     /**
      * Creates a new instance of DDScrollTable - with a DDTable inside.  The

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDTabPanel.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDTabPanel.java
@@ -49,7 +49,7 @@ public abstract class DDTabPanel extends DDPanel implements AncestorListener
     private int nTabNum_;
     private Icon icon_;
     private Icon error_;
-    private List<DDOption> options_ = new ArrayList<DDOption>();
+    private List<DDOption> options_ = new ArrayList<>();
     private String sHelp_;
 
     public DDTabPanel()

--- a/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GuiUtils.java
@@ -447,7 +447,7 @@ public class GuiUtils
      */
     public static void setDDOptionLabelWidths(Container container)
     {
-        List<DDOption> options = new ArrayList<DDOption>();
+        List<DDOption> options = new ArrayList<>();
         getDDOptions(container, options);
 
         int nNum = options.size();
@@ -482,7 +482,7 @@ public class GuiUtils
         GeneralPath path = new GeneralPath();
         StringTokenizer st = new StringTokenizer(sPath, "McCsSzZhHvVlL,-", true);
         String token;
-        float nums[] = new float[6];
+        float[] nums = new float[6];
         int idx = 0;
         int needed = 0;
         boolean bRelative = false;

--- a/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ImageComponent.java
@@ -67,9 +67,9 @@ public class ImageComponent extends JComponent implements Icon
     protected String sName_;
     protected BufferedImage bimage_;
     protected boolean bComposite_ = false;
-    protected BufferedImage composites_[];
-    protected int compositeXs_[];
-    protected int compositeYs_[];
+    protected BufferedImage[] composites_;
+    protected int[] compositeXs_;
+    protected int[] compositeYs_;
     protected int nCompositeHeight_, nCompositeWidth_;
     protected Image grayimage_;
     protected Image hiliteimage_;

--- a/code/gui/src/main/java/com/donohoedigital/gui/PieChartPanel.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/PieChartPanel.java
@@ -58,7 +58,7 @@ public class PieChartPanel extends DDPanel
         // also compute total of all values
         // and determine if more than one wedge has a non-zero value
 
-        double wedgeValue[] = new double[wedgeCount];
+        double[] wedgeValue = new double[wedgeCount];
         double totalValues = 0;
         int nonZeroWedgeCount = 0;
         int lastNonZeroWedge = 0;
@@ -166,7 +166,7 @@ public class PieChartPanel extends DDPanel
     {
         private static final DefaultPieChartModel INSTANCE = new DefaultPieChartModel();
 
-        private double value_[] = new double[] { 10, 25, 65 };
+        private double[] value_ = new double[] { 10, 25, 65 };
 
         public int getWedgeCount()
         {

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/EmbeddedServletConfig.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/EmbeddedServletConfig.java
@@ -82,7 +82,7 @@ public class EmbeddedServletConfig implements ServletConfig
     @SuppressWarnings({"RawUseOfParameterizedType"})
     public Enumeration<String> getInitParameterNames()
     {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         return Collections.enumeration(params);
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/CardSelectorPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/CardSelectorPanel.java
@@ -42,9 +42,9 @@ import java.awt.event.*;
 
 public class CardSelectorPanel extends DDPanel implements ActionListener
 {
-    CardPiece cardPieces[][] = new CardPiece[CardSuit.SPADES_RANK + 1][Card.ACE + 1];
-    ButtonPanel cardButtons[][] = new ButtonPanel[CardSuit.SPADES_RANK + 1][Card.ACE + 1];
-    ButtonPanel unknownButtons[] = new ButtonPanel[CardSuit.SPADES_RANK + 1];
+    CardPiece[][] cardPieces = new CardPiece[CardSuit.SPADES_RANK + 1][Card.ACE + 1];
+    ButtonPanel[][] cardButtons = new ButtonPanel[CardSuit.SPADES_RANK + 1][Card.ACE + 1];
+    ButtonPanel[] unknownButtons = new ButtonPanel[CardSuit.SPADES_RANK + 1];
 
     private static final int INIT = -9;
     private static final int NONE = -10;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
@@ -77,15 +77,15 @@ public class ChipLeaderPanel extends DDTabPanel
         // which can otherwise throw "Comparison method violates its general contract!"
         // if the tournament director moves chips while the sort is running.
         List<PokerPlayer> all = game_.getPokerPlayersCopy();
-        List<RankInfo> leaders = new ArrayList<RankInfo>(all.size());
+        List<RankInfo> leaders = new ArrayList<>(all.size());
         for (PokerPlayer each : all)
         {
             leaders.add(new RankInfo(each, 0, game_.getSettledChipCount(each)));
         }
         Collections.sort(leaders, SORT_SETTLED);
 
-        List<RankInfo> finished = new ArrayList<RankInfo>();
-        List<RankInfo> current = new ArrayList<RankInfo>();
+        List<RankInfo> finished = new ArrayList<>();
+        List<RankInfo> current = new ArrayList<>();
         int nNum = leaders.size();
         boolean bDone = game_.getNumPlayers() - game_.getNumPlayersOut() == 0;
         int min = Integer.MAX_VALUE;
@@ -273,7 +273,7 @@ public class ChipLeaderPanel extends DDTabPanel
      * the captured count rather than the live one so the ordering cannot change
      * underneath the sort.
      */
-    private static final Comparator<RankInfo> SORT_SETTLED = new Comparator<RankInfo>()
+    private static final Comparator<RankInfo> SORT_SETTLED = new Comparator<>()
     {
         public int compare(RankInfo r1, RankInfo r2)
         {
@@ -337,7 +337,7 @@ public class ChipLeaderPanel extends DDTabPanel
         int[] widths;
         boolean bShowPlayerType;
 
-        public PlayerModel(PokerGame game, List<RankInfo> players, String names[], int[] widths)
+        public PlayerModel(PokerGame game, List<RankInfo> players, String[] names, int[] widths)
         {
             this.game = game;
             this.names = names;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingPanel.java
@@ -46,7 +46,7 @@ public class ChipRatingPanel extends DDPanel
     private static final ImageIcon halfChip_ = ImageConfig.getImageIcon("rating16_half");
     private static final ImageIcon emptyChip_ = ImageConfig.getImageIcon("rating16_empty");
 
-    private JLabel chips_[] = new JLabel[5];
+    private JLabel[] chips_ = new JLabel[5];
 
     int value_ = 0;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -191,7 +191,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
      */
     private abstract class OptionTab extends DDTabPanel
     {
-        private final List<DDOption> localOptions = new ArrayList<DDOption>();
+        private final List<DDOption> localOptions = new ArrayList<>();
 
         OptionTab()
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
@@ -626,7 +626,7 @@ public String getFileName() {
     {
         group.clearContents();
         group.setStrength(strength);
-        String items[] = hands.split(",");
+        String[] items = hands.split(",");
         for (String item : items)
         {
             int rank1 = Card.getRank(item.charAt(0));
@@ -723,7 +723,7 @@ public String getFileName() {
 
         if (s != null)
         {
-            String v[] = s.split("\\|");
+            String[] v = s.split("\\|");
             parse(this, v[0], Integer.parseInt(v[1]));
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupGridPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupGridPanel.java
@@ -47,7 +47,7 @@ public class HandGroupGridPanel extends DDPanel implements ActionListener, KeyLi
 {
     //static Logger logger = LogManager.getLogger(HandGroupGridPanel.class);
 
-    private HandButton handButtons[][] = new HandButton[Card.ACE + 1][Card.ACE + 1];
+    private HandButton[][] handButtons = new HandButton[Card.ACE + 1][Card.ACE + 1];
     private DDLabel summaryLabel_;
 
     private HandGroup group_ = null;
@@ -391,8 +391,8 @@ public class HandGroupGridPanel extends DDPanel implements ActionListener, KeyLi
             setBorderGap(0, 0, 0, 0);
             setIsToggle(true);
             setFocusPainted(false);
-            setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.EMPTY_SET);
-            setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.EMPTY_SET);
+            setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet());
+            setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.emptySet());
             addKeyListener(HandGroupGridPanel.this);
             addFocusListener(HandGroupGridPanel.this);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
@@ -277,7 +277,7 @@ public class HandHistoryPanel extends DDPanel
     private void setHands()
     {
         List<Integer> hands = PokerDatabase.getHandIDs(where_, bindArray_, handFirst_, pageSize_);
-        hands_ = new ArrayList<Object>(hands.size());
+        hands_ = new ArrayList<>(hands.size());
         for (int i = hands.size() - 1; i >= 0; --i)
         {
             hands_.add(hands.get(i));

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
@@ -53,12 +53,12 @@ public class HandLadder
     private int handScore_;
     private int handType_;
 
-    private HandList ladder_[];
+    private HandList[] ladder_;
 
-    private HandList strongerHandsByType_[];
-    private HandList weakerHandsByType_[];
+    private HandList[] strongerHandsByType_;
+    private HandList[] weakerHandsByType_;
 
-    private int countByType_[];
+    private int[] countByType_;
     private int totalCount_;
 
     HandInfoFast handInfo_ = new HandInfoFast();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
@@ -505,7 +505,7 @@ public class HoldemSimulator
         PokerTable table = hhand.getTable();
         PokerPlayer player;
 
-        Hand hands[] = new Hand[10];
+        Hand[] hands = new Hand[10];
 
         for (int seat = 0; seat < 10; ++seat)
         {
@@ -753,7 +753,7 @@ public class HoldemSimulator
         IndexKeeper ik = new IndexKeeper();
         HandInfoFaster fast = new HandInfoFaster();
         Deck deck = new Deck(false);
-        StatResult results[] = new StatResult[hands.length];
+        StatResult[] results = new StatResult[hands.length];
 
         // remove dealt cards from deck
         for (int i = 0; i < results.length; i++)
@@ -764,7 +764,7 @@ public class HoldemSimulator
         deck.removeCards(community);
 
         // create array of all hands plus community at end
-        Hand allhands[] = new Hand[hands.length + 1];
+        Hand[] allhands = new Hand[hands.length + 1];
         System.arraycopy(hands, 0, allhands, 0, hands.length);
         allhands[hands.length] = community;
 
@@ -794,7 +794,7 @@ public class HoldemSimulator
     /**
      * recursive algorithm to iterate through all combinations
      */
-    private static void iterate(HandInfoFaster fast, StatResult results[],
+    private static void iterate(HandInfoFaster fast, StatResult[] results,
                                 Deck deck, Hand[] allhands,
                                 DDProgressFeedback progress,
                                 IndexKeeper ik, int nDeckStartIdx)
@@ -873,7 +873,7 @@ public class HoldemSimulator
         int updateResultsInterval = 50000;
         int updateBarInterval = 10000;
 
-        void nextIndex(Hand allhands[])
+        void nextIndex(Hand[] allhands)
         {
             if (nHandIdx == INIT)
             {
@@ -887,7 +887,7 @@ public class HoldemSimulator
             }
         }
 
-        private void nextHand(Hand allhands[])
+        private void nextHand(Hand[] allhands)
         {
             while (true)
             {
@@ -908,7 +908,7 @@ public class HoldemSimulator
         /**
          * return true if index incremented and still in current hand
          */
-        private boolean nextCard(Hand allhands[])
+        private boolean nextCard(Hand[] allhands)
         {
             Card c;
             boolean bDone = false;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/OtherTables.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/OtherTables.java
@@ -105,7 +105,7 @@ public class OtherTables
         // sort array if more than one table
         if (tables.size() > 1)
         {
-            tables = new ArrayList<PokerTable>(tables);
+            tables = new ArrayList<>(tables);
             Collections.sort(tables, SORTFILLEDSEATS);
         }
 
@@ -290,7 +290,7 @@ public class OtherTables
 
         // get sorted array of tables (do each time since as players added, things change)
         // this is not super expensive as not many players are moved at any given time
-        List<PokerTable> tables = new ArrayList<PokerTable>(game.getTables());
+        List<PokerTable> tables = new ArrayList<>(game.getTables());
         Collections.sort(tables, SORTFILLEDSEATS);
         
         // otherwise add to table with least spots open

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
@@ -1065,7 +1065,7 @@ public class PokerDatabase
 
     public static List<TournamentHistory> getTournamentHistory(PlayerProfile profile)
     {
-        List<TournamentHistory> hist = new ArrayList<TournamentHistory>();
+        List<TournamentHistory> hist = new ArrayList<>();
 
         if (profile == null)
         {
@@ -1564,7 +1564,7 @@ public class PokerDatabase
         Database database = getDatabase();
         Connection conn = database.getConnection();
 
-        List<Integer> hands = new ArrayList<Integer>();
+        List<Integer> hands = new ArrayList<>();
 
         try
         {
@@ -1909,11 +1909,11 @@ public class PokerDatabase
                 pstmt.close();
             }
 
-            PokerPlayer players[] = new PokerPlayer[PokerConstants.SEATS];
-            int over[] = new int[PokerConstants.SEATS];
-            int win[] = new int[PokerConstants.SEATS];
-            int start[] = new int[PokerConstants.SEATS];
-            int end[] = new int[PokerConstants.SEATS];
+            PokerPlayer[] players = new PokerPlayer[PokerConstants.SEATS];
+            int[] over = new int[PokerConstants.SEATS];
+            int[] win = new int[PokerConstants.SEATS];
+            int[] start = new int[PokerConstants.SEATS];
+            int[] end = new int[PokerConstants.SEATS];
 
             pstmt = conn.prepareStatement(
                     "SELECT DISTINCT\n" +
@@ -2537,7 +2537,7 @@ public class PokerDatabase
         String driverURL = DATABASE_DRIVER_URL_PREFIX + clientPath.getAbsolutePath();
 
         // Add the database.
-        Map<String, String> htParams = new HashMap<String, String>();
+        Map<String, String> htParams = new HashMap<>();
         htParams.put(DatabaseManager.PARAM_DRIVER_CLASS, DATABASE_DRIVER_CLASS);
         htParams.put(DatabaseManager.PARAM_DRIVER_URL, driverURL);
         htParams.put(DatabaseManager.PARAM_USERNAME, DATABASE_USERNAME);
@@ -2619,7 +2619,7 @@ public class PokerDatabase
                     "WHERE PLH_HAND_ID=?\n" +
                     "  AND PLH_PLAYER_ID=TPL_ID AND TPL_PROFILE_CREATE_DATE=?");
 
-            String holeCards[] = new String[2];
+            String[] holeCards = new String[2];
 
             try
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -76,7 +76,7 @@ public class PokerGame extends Game implements PlayerActionListener
     public static final String HOME_BEGIN = "home";
 
     // denominations for chips
-    private static final int nChipDenom_[] = new int[]{1, 5, 25, 100, 500, 1000, 5000, 10000, 50000, 100000};
+    private static final int[] nChipDenom_ = new int[]{1, 5, 25, 100, 500, 1000, 5000, 10000, 50000, 100000};
 
     /**
      * Name used in PropertyChangeEvents when current table changed
@@ -104,7 +104,7 @@ public class PokerGame extends Game implements PlayerActionListener
     public static final String PROP_PLAYER_FINISHED = "_busted_";
 
     // game info
-    private DMArrayList<PokerTable> tables_ = new DMArrayList<PokerTable>();
+    private DMArrayList<PokerTable> tables_ = new DMArrayList<>();
     private TournamentProfile profile_;
     private int nLevel_ = 0;
     private boolean bClockMode_ = false;
@@ -293,7 +293,7 @@ public class PokerGame extends Game implements PlayerActionListener
      */
     public List<PokerPlayer> getPokerPlayersCopy()
     {
-        List<PokerPlayer> copy = new ArrayList<PokerPlayer>();
+        List<PokerPlayer> copy = new ArrayList<>();
         for (GamePlayer p : players_)
         {
             copy.add((PokerPlayer) p);
@@ -319,7 +319,7 @@ public class PokerGame extends Game implements PlayerActionListener
     {
         if (profile_ != null)
         {
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             int nNum = getNumPlayers();
             for (int i = 0; i < nNum; i++)
             {
@@ -1134,7 +1134,7 @@ public class PokerGame extends Game implements PlayerActionListener
     private void setupComputerPlayers(int nNumPlayers)
     {
         PokerPlayer player;
-        List<String> names = new ArrayList<String>(PokerMain.getPokerMain().getNames());
+        List<String> names = new ArrayList<>(PokerMain.getPokerMain().getNames());
         int nNumHumans = getNumPlayers();
 
         // if we don't have enough names, add more (enough
@@ -1151,7 +1151,7 @@ public class PokerGame extends Game implements PlayerActionListener
             }
         }
 
-        Set<String> hsUsed = new HashSet<String>();
+        Set<String> hsUsed = new HashSet<>();
 
         for (int i = 0; i < nNumHumans; i++)
         {
@@ -1162,7 +1162,7 @@ public class PokerGame extends Game implements PlayerActionListener
         PlayerType playerType;
         String sName;
         String sKey = getPublicUseKey();
-        Map<String, List<String>> hmRoster = new HashMap<String, List<String>>();
+        Map<String, List<String>> hmRoster = new HashMap<>();
         List<String> roster;
         for (int i = getNumPlayers(); i < nNumPlayers; i++)
         {
@@ -1434,7 +1434,7 @@ public class PokerGame extends Game implements PlayerActionListener
             p = getPokerPlayerAt(i);
             if (p.isWaiting())
             {
-                if (wait == null) wait = new ArrayList<PokerPlayer>();
+                if (wait == null) wait = new ArrayList<>();
                 wait.add(p);
             }
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGameState.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGameState.java
@@ -148,7 +148,7 @@ public class PokerGameState extends GameState implements PropertyChangeListener
     public void setIds()
     {
         resetIds();
-        Territory territories[] = Territory.getTerritoryArrayCached();
+        Territory[] territories = Territory.getTerritoryArrayCached();
         prepopulateIds(game_, territories, game_, game_);
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPrefsPlayerList.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPrefsPlayerList.java
@@ -66,7 +66,7 @@ public class PokerPrefsPlayerList extends AbstractPlayerList
     {
         if (share_ == null)
         {
-            share_ = new HashMap<String, PokerPrefsPlayerList>();
+            share_ = new HashMap<>();
         }
 
         PokerPrefsPlayerList list = share_.get(sListName);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
@@ -62,7 +62,7 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
     private SimulatorDialog sim_;
     private OptionInteger numOpponents_, numSims_;
     private DDRadioButton allcombo_, simcombo_;
-    private List<DDLabelBorder> opponents_ = new ArrayList<DDLabelBorder>();
+    private List<DDLabelBorder> opponents_ = new ArrayList<>();
     private boolean bStopRequested_ = false;
     private boolean bIterWayBig_;
     private GlassButton run_, stop_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -66,7 +66,7 @@ public class PokerTable implements ObjectID
 
     // data
     private PokerGame game_;
-    PokerPlayer players_[] = new PokerPlayer[PokerConstants.SEATS];
+    PokerPlayer[] players_ = new PokerPlayer[PokerConstants.SEATS];
     private int nNum_;
     private String sName_;
     private int nButton_ = NO_SEAT;
@@ -79,11 +79,11 @@ public class PokerTable implements ObjectID
     private boolean bCurrent_ = false;
     private boolean bZipMode_ = false;
     private HoldemHand hhand_;
-    private List<PokerPlayer> waitList_ = new ArrayList<PokerPlayer>();
-    private List<PokerPlayer> addedList_ = new ArrayList<PokerPlayer>();
-    private List<PokerPlayer> addonList_ = new ArrayList<PokerPlayer>();
-    private List<PokerPlayer> rebuyList_ = new ArrayList<PokerPlayer>();
-    private List<PokerPlayer> observers_ = new ArrayList<PokerPlayer>();
+    private List<PokerPlayer> waitList_ = new ArrayList<>();
+    private List<PokerPlayer> addedList_ = new ArrayList<>();
+    private List<PokerPlayer> addonList_ = new ArrayList<>();
+    private List<PokerPlayer> rebuyList_ = new ArrayList<>();
+    private List<PokerPlayer> observers_ = new ArrayList<>();
     private int nTableState_ = STATE_NONE;
     private int nPrevState_ = STATE_NONE;
     private int nPendingState_ = STATE_NONE;
@@ -458,7 +458,7 @@ public class PokerTable implements ObjectID
     public PokerPlayer[] getPlayersSortedByLastMove()
     {
         int nOcc = getNumOccupiedSeats();
-        PokerPlayer players[] = new PokerPlayer[nOcc];
+        PokerPlayer[] players = new PokerPlayer[nOcc];
         PokerPlayer player;
         int nCnt = 0;
         for (int i = 0; i < PokerConstants.SEATS; i++)
@@ -1243,7 +1243,7 @@ public class PokerTable implements ObjectID
     {    
         int nMin = getNextMinChip();
         int nMinLast = getMinChip();
-        List<PokerPlayer> players = new ArrayList<PokerPlayer>();
+        List<PokerPlayer> players = new ArrayList<>();
         PokerPlayer player;
         int nTotalOdd = 0;
         int nOdd;
@@ -1872,7 +1872,7 @@ public class PokerTable implements ObjectID
     ////
     //// PokerTableListener
     ////
-    private List<ListenerInfo> listeners_ = new ArrayList<ListenerInfo>();
+    private List<ListenerInfo> listeners_ = new ArrayList<>();
     
     /**
      * notify table that display preferences changed so listeners can react
@@ -2128,7 +2128,7 @@ public class PokerTable implements ObjectID
     {
         // create list of players loaded
         int nNum = entry.removeIntToken();
-        List<PokerPlayer> load = new ArrayList<PokerPlayer>(nNum);
+        List<PokerPlayer> load = new ArrayList<>(nNum);
         for (int i = 0; i < nNum; i++)
         {
             load.add((PokerPlayer)state.getObject(entry.removeIntegerToken()));

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUtils.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUtils.java
@@ -62,7 +62,7 @@ public class PokerUtils extends EngineUtils
 {
     private static final Logger logger = LogManager.getLogger(PokerUtils.class);
 
-    private static final BigInteger factorial_[] = new BigInteger[53];
+    private static final BigInteger[] factorial_ = new BigInteger[53];
 
     static Territory tPot_ = null;
     static Territory tFlop_ = null;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/Pot.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/Pot.java
@@ -56,8 +56,8 @@ public class Pot implements DataMarshal
     private boolean bBaseAllIn_ = false;
     private int nSideBet_ = NO_SIDE; // used for side pots
     private int nRound_;
-    private List<PokerPlayer> players_ = new ArrayList<PokerPlayer>();
-    private List<PokerPlayer> winners_ = new ArrayList<PokerPlayer>();
+    private List<PokerPlayer> players_ = new ArrayList<>();
+    private List<PokerPlayer> winners_ = new ArrayList<>();
 
     /**
      * empty constructor for loading

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/SendWanProfile.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/SendWanProfile.java
@@ -57,7 +57,7 @@ public class SendWanProfile extends SendMessageDialog
     public static final String PARAM_CATEGORY = "category";
     public static final String PARAM_PROFILE = "profile";
 
-    private static final Map<Integer, String> hmMessages_ = new HashMap<Integer, String>();
+    private static final Map<Integer, String> hmMessages_ = new HashMap<>();
 
     static
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/SidePotsDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/SidePotsDialog.java
@@ -140,7 +140,7 @@ public class SidePotsDialog extends DialogPhase
         
         PokerPlayer pl;
         StringBuilder sb = new StringBuilder();
-        List<PokerPlayer> players = new ArrayList<PokerPlayer>(p.getPlayers());
+        List<PokerPlayer> players = new ArrayList<>(p.getPlayers());
         Collections.sort(players, PokerPlayer.SORTBYNAME);
         boolean bWinner;
         for (int i = 0; i < nNum; i++)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/StatisticsViewer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/StatisticsViewer.java
@@ -1016,7 +1016,7 @@ public class StatisticsViewer extends BasePhase implements ActionListener
         String[] names;
         int[] widths;
 
-        public ResultsModel(List<TournamentHistory> finishes, String names[], int[] widths)
+        public ResultsModel(List<TournamentHistory> finishes, String[] names, int[] widths)
         {
             this.finishes = finishes;
             this.names = names;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TableListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TableListPanel.java
@@ -60,7 +60,7 @@ public class TableListPanel extends DDTabPanel implements ChangeListener, Action
     private PokerGame game_;
     private String STYLE;
     private DDPanel tbls_;
-    private TablePanel tables_[];
+    private TablePanel[] tables_;
     private DDSlider slider_;
     private DDCheckBox showtype_;
 
@@ -221,7 +221,7 @@ public class TableListPanel extends DDTabPanel implements ChangeListener, Action
             clabel.setText("<HTML><B><font color=yellow>"+table.getName()+"</font></B>");
 
             int nNumObs = table.getNumObservers();
-            List<ChipLeaderPanel.RankInfo> players = new ArrayList<ChipLeaderPanel.RankInfo>(PokerConstants.SEATS + nNumObs);
+            List<ChipLeaderPanel.RankInfo> players = new ArrayList<>(PokerConstants.SEATS + nNumObs);
             PokerPlayer p;
             for (int i = 0; i < PokerConstants.SEATS; i++)
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
@@ -87,9 +87,9 @@ public class TournamentProfileDialog extends OptionMenuDialog implements Propert
     private DDRadioButton buttonAuto_, buttonPerc_, buttonAmount_;
     private DDRadioButton buttonSatellite_;
     private boolean bDetailsTabReady_ = false;
-    private SpotPanel spots_[] = new SpotPanel[TournamentProfile.MAX_SPOTS];
-    private String saveA_[] = new String[TournamentProfile.MAX_SPOTS];
-    private String saveP_[] = new String[TournamentProfile.MAX_SPOTS];
+    private SpotPanel[] spots_ = new SpotPanel[TournamentProfile.MAX_SPOTS];
+    private String[] saveA_ = new String[TournamentProfile.MAX_SPOTS];
+    private String[] saveP_ = new String[TournamentProfile.MAX_SPOTS];
     private int nNumSpots_ = 0;
     private DDRadioButton buttonSelected_;
     private DDButton clear_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentSummaryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentSummaryPanel.java
@@ -433,7 +433,7 @@ public class TournamentSummaryPanel extends DDPanel
         boolean bPayout;
         boolean bOppMix;
 
-        TournamentModel(GameContext context, TournamentProfileHtml profileHtml, String names[], int[] widths)
+        TournamentModel(GameContext context, TournamentProfileHtml profileHtml, String[] names, int[] widths)
         {
             this.context = context;
             this.names = names;
@@ -450,7 +450,7 @@ public class TournamentSummaryPanel extends DDPanel
             html = h;
             if (bOppMix && profile != null)
             {
-                playerTypes = new ArrayList<BaseProfile>();
+                playerTypes = new ArrayList<>();
                 List<BaseProfile> types = PlayerType.getProfileListCached();
 
                 for (BaseProfile profile1 : types)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AITest.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AITest.java
@@ -196,7 +196,7 @@ public class AITest
 
             File fDir = getTestCaseDir();
 
-            File files[] = fDir.listFiles(new FilenameFilter()
+            File[] files = fDir.listFiles(new FilenameFilter()
             {
                 public boolean accept(File dir, String name)
                 {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandProbabilityMatrix.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandProbabilityMatrix.java
@@ -37,8 +37,8 @@ import com.donohoedigital.games.poker.engine.*;
 
 public class HandProbabilityMatrix
 {
-    float prob_[][] = new float[52][52];
-    float score_[][] = new float[52][52];
+    float[][] prob_ = new float[52][52];
+    float[][] score_ = new float[52][52];
 
     Deck deck = new Deck(false);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandSelectionScheme.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandSelectionScheme.java
@@ -64,7 +64,7 @@ public class HandSelectionScheme extends BaseProfile
     {
         super(sName);
         map_ = new DMTypedHashMap();
-        handgroups_ = new ArrayList<HandGroup>();
+        handgroups_ = new ArrayList<>();
     }
 
     /**
@@ -141,7 +141,7 @@ public class HandSelectionScheme extends BaseProfile
     {
         if (handgroups_ == null)
         {
-            handgroups_ = new ArrayList<HandGroup>();
+            handgroups_ = new ArrayList<>();
         }
         else
         {
@@ -154,7 +154,7 @@ public class HandSelectionScheme extends BaseProfile
         while ((s = map_.getString("hands" + i)) != null)
         {
             i++;
-            String v[] = s.split("\\|");
+            String[] v = s.split("\\|");
             handgroups_.add(HandGroup.parse(v[0], Integer.parseInt(v[1])));
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/OpponentModel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/OpponentModel.java
@@ -43,8 +43,8 @@ public class OpponentModel
 {
     int handsPlayed;
 
-    FloatTracker tightness[] = new FloatTracker[6];
-    FloatTracker aggression[] = new FloatTracker[6];
+    FloatTracker[] tightness = new FloatTracker[6];
+    FloatTracker[] aggression = new FloatTracker[6];
 
     BooleanTracker handsPaid;
     BooleanTracker handsLimped;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
@@ -53,9 +53,9 @@ public class PocketWeights
 
     private HoldemHand hhand_ = null;
 
-    private PocketMatrixFloat weights_[] = null;
+    private PocketMatrixFloat[] weights_ = null;
 
-    private float apparentStrength_[] = new float[10];
+    private float[] apparentStrength_ = new float[10];
     private int callCount_;
     private int raiseCount_;
     private int potSize_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/Roster.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/Roster.java
@@ -75,7 +75,7 @@ public class Roster
                 (",+", ",").replaceAll
                 ("^,|,$", "").split(",");
 
-        List<String> list = new ArrayList<String>(names.length);
+        List<String> list = new ArrayList<>(names.length);
 
         if (names[0].length() == 0) return list;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
@@ -127,10 +127,10 @@ public class RuleEngine implements AIConstants
     public static final int CURVE_CUBE = 3;
 
     private V2Player ai_;
-    private float score_[];
-    private boolean eligible_[];
-    private float weights_[];
-    private OutcomeAdjustment adjustments_[][];
+    private float[] score_;
+    private boolean[] eligible_;
+    private float[] weights_;
+    private OutcomeAdjustment[][] adjustments_;
 
     private int strongestOutcome_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/V2Player.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/V2Player.java
@@ -55,20 +55,20 @@ public class V2Player extends V1Player implements AIConstants
     private float biasedNegativePotential_;
     private float behs_;
 
-    private float positivePotential_[][] = null;
-    private float negativePotential_[][] = null;
+    private float[][] positivePotential_ = null;
+    private float[][] negativePotential_ = null;
     private PocketMatrixFloat fieldMatrix_ = null;
 
     private float rawHandStrength_;
     private float biasedHandStrength_;
 
     private int myHandScore_;
-    private int otherHandScore_[][] = null;
+    private int[][] otherHandScore_ = null;
 
     private long fpPocket_ = 0;
     private long fpCommunity_ = 0;
 
-    private boolean potRaised_[] = new boolean[10];
+    private boolean[] potRaised_ = new boolean[10];
 
     private int maPotRaised_ = 0;
 
@@ -742,15 +742,15 @@ public class V2Player extends V1Player implements AIConstants
         Card card2;
 
         float weight;
-        float bhs[] = new float[10];
-        float total[] = new float[10];
+        float[] bhs = new float[10];
+        float[] total = new float[10];
 
         int skip = player.getSeat();
 
         HoldemHand hhand = player.getHoldemHand();
 
         //boolean couldLimp[] = new boolean[hhand.getNumPlayers()];
-        boolean paid[] = new boolean[hhand.getNumPlayers()];
+        boolean[] paid = new boolean[hhand.getNumPlayers()];
         //boolean limped[] = new boolean[hhand.getNumPlayers()];
 
         for (int p = hhand.getNumPlayers() - 1; p >= 0; --p)
@@ -989,9 +989,9 @@ public class V2Player extends V1Player implements AIConstants
 
         HoldemHand hhand = player.getHoldemHand();
 
-        boolean couldLimp[] = new boolean[hhand.getNumPlayers()];
-        boolean paid[] = new boolean[hhand.getNumPlayers()];
-        boolean limped[] = new boolean[hhand.getNumPlayers()];
+        boolean[] couldLimp = new boolean[hhand.getNumPlayers()];
+        boolean[] paid = new boolean[hhand.getNumPlayers()];
+        boolean[] limped = new boolean[hhand.getNumPlayers()];
 
         for (int p = hhand.getNumPlayers() - 1; p >= 0; --p)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorGridPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorGridPanel.java
@@ -193,7 +193,7 @@ public class AdvisorGridPanel extends DDPanel
         }
     }
 
-    private static final Color colors_[] = new Color[] {
+    private static final Color[] colors_ = new Color[] {
         Color.RED.darker().darker(),
         Color.RED.darker(),
         Color.YELLOW.darker().darker(),

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
@@ -517,7 +517,7 @@ public class AdvisorInfoDialog extends DialogPhase
                 pocket.addCard(Card.BLANK);
                 pocket.addCard(Card.BLANK);
 
-                int suitEquivalenceValues[] = new int[13*13];
+                int[] suitEquivalenceValues = new int[13*13];
 
                 int suitCount = community.getNumSuits();
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandProbabilityMatrixPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandProbabilityMatrixPanel.java
@@ -42,7 +42,7 @@ public class HandProbabilityMatrixPanel extends DDPanel
 {
     private HandProbabilityMatrix matrix_;
 
-    private DDPanel panels_[][] = new DDPanel[52][52];
+    private DDPanel[][] panels_ = new DDPanel[52][52];
 
     private static int gridline_ = 1;
     private static int subgridline_ = 1;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
@@ -58,7 +58,7 @@ public class OpponentMixPanel extends DDTabPanel
         String sStyle = "OptionsDialog";
 
         List<BaseProfile> listItems = PlayerType.getProfileList();
-        List<TypeListItem> typeItems = new ArrayList<TypeListItem>();
+        List<TypeListItem> typeItems = new ArrayList<>();
 
         Collections.sort(listItems);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/WeightGridPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/WeightGridPanel.java
@@ -40,7 +40,7 @@ import java.awt.*;
 
 public class WeightGridPanel extends AdvisorGridPanel
 {
-    private Color colors_[] = new Color[101];
+    private Color[] colors_ = new Color[101];
 
     private PokerPlayer player_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/CheatDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/CheatDash.java
@@ -54,7 +54,7 @@ import java.util.List;
 public class CheatDash extends DashboardItem implements ChangeListener
 {
     private static CheatDash impl_ = null;
-    private List<DDOption> options_ = new ArrayList<DDOption>();
+    private List<DDOption> options_ = new ArrayList<>();
     private boolean bUpdating_ = false;
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpHand.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpHand.java
@@ -57,11 +57,11 @@ public class ImpExpHand
     public int bigBlind;
     public int buttonSeat;
     public int localHumanPlayerSeat = -1;
-    public PokerPlayer players[] = new PokerPlayer[PokerConstants.SEATS];
-    public int betChips[] = new int[PokerConstants.SEATS];
-    public int overbetChips[] = new int[PokerConstants.SEATS];
-    public int winChips[] = new int[PokerConstants.SEATS];
-    public int startChips[] = new int[PokerConstants.SEATS];
-    public int endChips[] = new int[PokerConstants.SEATS];
+    public PokerPlayer[] players = new PokerPlayer[PokerConstants.SEATS];
+    public int[] betChips = new int[PokerConstants.SEATS];
+    public int[] overbetChips = new int[PokerConstants.SEATS];
+    public int[] winChips = new int[PokerConstants.SEATS];
+    public int[] startChips = new int[PokerConstants.SEATS];
+    public int[] endChips = new int[PokerConstants.SEATS];
     public ArrayList hist = new ArrayList();
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
@@ -510,7 +510,7 @@ public class ImpExpParadise implements ImpExp
         }
     }
 
-    private static final String rankName_[] = new String[]
+    private static final String[] rankName_ = new String[]
     {
         null,null,
         "two",
@@ -528,7 +528,7 @@ public class ImpExpParadise implements ImpExp
         "ace"
     };
 
-    private static final String rankPName_[] = new String[]
+    private static final String[] rankPName_ = new String[]
     {
         null,null,
         "twos",

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
@@ -716,7 +716,7 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
             // replace /[card][card]...[card] with DDCard
             StringBuilder sb = new StringBuilder(sMsg.length());
             char c;
-            char lookahead[] = new char[2];
+            char[] lookahead = new char[2];
             int search = 0;
             for (int i = 0; i < sMsg.length(); i++)
             {
@@ -782,7 +782,7 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
             this.bTable = sMsg.toLowerCase().contains("table");
         }
 
-        private void getLookAhead(char lookahead[], String s, int index)
+        private void getLookAhead(char[] lookahead, String s, int index)
         {
             Arrays.fill(lookahead, ':');
             int look = 0;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
@@ -298,7 +298,7 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
      */
     private class PlayerModel extends DefaultTableModel
     {
-        private List<OnlinePlayerInfo> list = new ArrayList<OnlinePlayerInfo>();
+        private List<OnlinePlayerInfo> list = new ArrayList<>();
 
         @Override
         public String getColumnName(int c) {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
@@ -82,14 +82,14 @@ public class OnlineManager implements ChatManager
 
     // chat
     private ChatHandler chat_ = null;
-    private final List<OnlineMessage> chatQueue_ = new ArrayList<OnlineMessage>();
+    private final List<OnlineMessage> chatQueue_ = new ArrayList<>();
 
     // tournament director
     private TournamentDirector td_;
-    private final List<OnlineMessage> tdQueue_ = new ArrayList<OnlineMessage>();
+    private final List<OnlineMessage> tdQueue_ = new ArrayList<>();
     private OnlineManagerQueue oQueue_ = null;
     private PokerPrefsPlayerList banned_;
-    private Set<String> sentMessageAboutRejectedPlayer = new HashSet<String>();
+    private Set<String> sentMessageAboutRejectedPlayer = new HashSet<>();
 
     /**
      * Creates a new instance of OnlineManager
@@ -1252,7 +1252,7 @@ public class OnlineManager implements ChatManager
     {
         if (tables == null || tables.isEmpty()) return null;
 
-        int removed[] = new int[tables.size()];
+        int[] removed = new int[tables.size()];
         for (int i = 0; i < removed.length; i++)
         {
             removed[i] = tables.get(i).getNumber();
@@ -2606,7 +2606,7 @@ public class OnlineManager implements ChatManager
     ////
 
     // listener list
-    protected List<OnlineMessageListener> listenerList = new ArrayList<OnlineMessageListener>();
+    protected List<OnlineMessageListener> listenerList = new ArrayList<>();
 
     /**
      * Adds a listener to the list

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
@@ -186,7 +186,7 @@ public class OnlineServer
 
             if (histories == null)
             {
-                histories = new DMArrayList<TournamentHistory>();
+                histories = new DMArrayList<>();
             }
 
             history = createTournamentHistory(game, player, nRank);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/SendWanGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/SendWanGame.java
@@ -49,7 +49,7 @@ public class SendWanGame extends SendMessageDialog
     public static final String PARAM_GAME = "game";
     public static final String PARAM_AUTH = "auth";
 
-    private static final Map<Integer, String> hmMessages_ = new HashMap<Integer, String>();
+    private static final Map<Integer, String> hmMessages_ = new HashMap<>();
 
     static
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
@@ -587,7 +587,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
 
         public void tableEventOccurred(PokerTableEvent event)
         {
-            if (events == null) events = new DMArrayList<PokerTableEvent>();
+            if (events == null) events = new DMArrayList<>();
             if (DEBUG_EVENT) logger.debug("TDReturn event: " + event);
             events.add(event);
         }
@@ -1463,15 +1463,15 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
     private class TDClean implements PokerTableListener
     {
         List<PokerTable> tables;
-        List<PokerTable> tablesRemoved = new ArrayList<PokerTable>(1);
-        List<PokerPlayer> playersTouched = new ArrayList<PokerPlayer>(10);
-        List<PokerTable> tablesTouched = new ArrayList<PokerTable>(3);
-        List<PokerPlayer> playersBusted = new ArrayList<PokerPlayer>(3);
-        List<PokerPlayer> playersWaiting = new ArrayList<PokerPlayer>(1);
+        List<PokerTable> tablesRemoved = new ArrayList<>(1);
+        List<PokerPlayer> playersTouched = new ArrayList<>(10);
+        List<PokerTable> tablesTouched = new ArrayList<>(3);
+        List<PokerPlayer> playersBusted = new ArrayList<>(3);
+        List<PokerPlayer> playersWaiting = new ArrayList<>(1);
 
         public TDClean(PokerTable active)
         {
-            tables = new ArrayList<PokerTable>(game_.getTables());
+            tables = new ArrayList<>(game_.getTables());
             listen(true);
 
             // need to make sure players on current table are included
@@ -1619,7 +1619,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
             if (bOnline_)
             {
                 // Online - see if we can break this table.
-                tables = new ArrayList<PokerTable>();
+                tables = new ArrayList<>();
                 tables.add(table);
 
                 // if current table (on host), add all computer
@@ -1868,7 +1868,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
      */
     public void cleanTables(PokerTable table, boolean bRemovePlayers)
     {
-        List<PokerPlayer> removed = new ArrayList<PokerPlayer>();
+        List<PokerPlayer> removed = new ArrayList<>();
 
         // clean tables (storing removed players in array)
         cleanTable(table, removed, bRemovePlayers);
@@ -1900,7 +1900,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
      */
     private void cleanTable(PokerTable table, List<PokerPlayer> removed, boolean bRemovePlayers)
     {
-        List<PokerPlayer> removedThisTable = new ArrayList<PokerPlayer>();
+        List<PokerPlayer> removedThisTable = new ArrayList<>();
         boolean bAllComputerPrior = table.isAllComputer() && table.getNumObservers() == 0;
 
         // remove any left-over ai (if table used to have humans and the human was moved
@@ -2417,7 +2417,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
                 if (p.isHuman() && p.isAskShowWinning() && hhand.isUncontested())
                 {
                     table.addWait(p);
-                    if (win_ids == null) win_ids = new DMArrayList<Integer>();
+                    if (win_ids == null) win_ids = new DMArrayList<>();
                     win_ids.add(p.getID());
                     if (p == local) bLocalInList = true;
                 }

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/Hand.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/Hand.java
@@ -592,7 +592,7 @@ public class Hand extends DMArrayList<Card>
 
     private int getMaxSuitCount()
     {
-        int suit[] = new int[CardSuit.NUM_SUITS];
+        int[] suit = new int[CardSuit.NUM_SUITS];
         for (int i = size()-1; i >= 0; --i)
         {
             ++suit[getCard(i).getSuit()];
@@ -618,7 +618,7 @@ public class Hand extends DMArrayList<Card>
                 return getCard(0).getRank() == getCard(1).getRank();
             default:
                 {
-                    int rank[] = new int[Card.ACE+1];
+                    int[] rank = new int[Card.ACE+1];
                     for (int i = size()-1; i >= 0; --i)
                     {
                         ++rank[getCard(i).getRank()];
@@ -649,7 +649,7 @@ public class Hand extends DMArrayList<Card>
                 }
             default:
                 {
-                    int rank[] = new int[Card.ACE+1];
+                    int[] rank = new int[Card.ACE+1];
                     for (int i = size() - 1; i >= 0; --i)
                     {
                         ++rank[getCard(i).getRank()];
@@ -684,7 +684,7 @@ public class Hand extends DMArrayList<Card>
                 }
             default:
                 {
-                    int rank[] = new int[Card.ACE+1];
+                    int[] rank = new int[Card.ACE+1];
                     for (int i = size() - 1; i >= 0; --i)
                     {
                         ++rank[getCard(i).getRank()];

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -277,7 +277,7 @@ public class PokerConstants
 
     // chat/info server
     @SuppressWarnings({"PublicStaticArrayField"})
-    public static final byte CHAT_BYTES[] = {'6', 'e', 'h', 'g', '@', '!', 'T', 'A', 'Z', 'D', 'C', '%'};
+    public static final byte[] CHAT_BYTES = {'6', 'e', 'h', 'g', '@', '!', 'T', 'A', 'Z', 'D', 'C', '%'};
     public static final byte USERTYPE_CHAT = 1;
     public static final byte USERTYPE_HELLO = 2;
 

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/TournamentProfileHtml.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/TournamentProfileHtml.java
@@ -82,7 +82,7 @@ public class TournamentProfileHtml
         if (htmlSummaryCache_ != null && htmlSummaryMode_ == bListMode) return htmlSummaryCache_;
 
         String sDate = PropertyConfig.getDateFormat(sLocale).format(new Date(profile.getCreateDate()));
-        Object params[] = new Object[16];
+        Object[] params = new Object[16];
 
         params[0] = DataElement.getDisplayValue(DATA_ELEMENT_GAMETYPE, profile.getDefaultGameTypeString());
         params[1] = Utils.encodeHTML(profile.getDescription());
@@ -217,7 +217,7 @@ public class TournamentProfileHtml
         String sDate = PropertyConfig.getDateFormat(sLocale).format(new Date(profile.getCreateDate()));
 
 
-        Object params[] = new Object[18];
+        Object[] params = new Object[18];
 
         params[0] = Utils.encodeHTML(profile.getName());
         params[1] = sDate;

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentProfile.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentProfile.java
@@ -335,7 +335,7 @@ public class TournamentProfile extends BaseProfile implements DataMarshal, Simpl
         DMArrayList<String> list = (DMArrayList<String>) map_.getList(PARAM_PLAYERS);
         if (list == null)
         {
-            list = new DMArrayList<String>();
+            list = new DMArrayList<>();
             map_.setList(PARAM_PLAYERS, list);
         }
         else
@@ -358,7 +358,7 @@ public class TournamentProfile extends BaseProfile implements DataMarshal, Simpl
     public List<String> getPlayers()
     {
         DMArrayList<String> players = (DMArrayList<String>) map_.getList(PARAM_PLAYERS);
-        if (players == null) players = new DMArrayList<String>();
+        if (players == null) players = new DMArrayList<>();
         return players;
     }
 
@@ -1090,7 +1090,7 @@ public class TournamentProfile extends BaseProfile implements DataMarshal, Simpl
         int nPool = getPrizePool();
         int nNumSpots = getNumSpots();
         int nNonFinal = nNumSpots - nFinalSpots;
-        int amount[] = new int[nNumSpots];
+        int[] amount = new int[nNumSpots];
 
         int nMin = getTrueBuyin();
         // add a rebuy to min in actual tournament calculation
@@ -1187,7 +1187,7 @@ public class TournamentProfile extends BaseProfile implements DataMarshal, Simpl
         }
         int nLeft = nNumSpots - nIndex;
         int sum;
-        int fibo[] = new int[Math.max(2, nNumSpots)];
+        int[] fibo = new int[Math.max(2, nNumSpots)];
 
         // STEP 1: do fibonnaci sequence
         fibo[0] = 2;

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/util/OnlineGameList.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/util/OnlineGameList.java
@@ -49,7 +49,7 @@ public class OnlineGameList extends PagedList<OnlineGame> implements SimpleXMLEn
      */
     public DMArrayList<DMTypedHashMap> getAsDMList()
     {
-        DMArrayList<DMTypedHashMap> dmList = new DMArrayList<DMTypedHashMap>(size());
+        DMArrayList<DMTypedHashMap> dmList = new DMArrayList<>(size());
 
         for (OnlineGame game : this) {
             dmList.add(game.getData());

--- a/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/OnlineMessage.java
+++ b/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/OnlineMessage.java
@@ -741,7 +741,7 @@ public class OnlineMessage
     public List<OnlinePlayerInfo> getPlayerList()
     {
         DMArrayList<DMTypedHashMap> raw = (DMArrayList<DMTypedHashMap>) data_.getList(ON_PLAYER_LIST);
-        List<OnlinePlayerInfo> list = new ArrayList<OnlinePlayerInfo>(raw.size());
+        List<OnlinePlayerInfo> list = new ArrayList<>(raw.size());
         for (DMTypedHashMap map : raw)
         {
             list.add(new OnlinePlayerInfo(map));

--- a/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/OnlinePlayerInfo.java
+++ b/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/OnlinePlayerInfo.java
@@ -150,7 +150,7 @@ public class OnlinePlayerInfo implements Comparable<OnlinePlayerInfo>
         DMArrayList<?> raw = (DMArrayList<?>) data_.getList(ONLINE_ALIASES);
         if (raw == null) return null;
 
-        List<OnlinePlayerInfo> list = new ArrayList<OnlinePlayerInfo>(raw.size());
+        List<OnlinePlayerInfo> list = new ArrayList<>(raw.size());
         for (Object aRaw : raw)
         {
             info = new OnlinePlayerInfo((DMTypedHashMap) aRaw);

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/dao/impl/OnlineProfileImplJpa.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/dao/impl/OnlineProfileImplJpa.java
@@ -104,7 +104,7 @@ public class OnlineProfileImplJpa extends JpaBaseDao<OnlineProfile, Long> implem
         query.setParameter("email", email);
 
         // get results
-        List<OnlineProfileSummary> list = new ArrayList<OnlineProfileSummary>();
+        List<OnlineProfileSummary> list = new ArrayList<>();
         List<Object[]> results = query.getResultList();
         for (Object[] a : results)
         {
@@ -158,7 +158,7 @@ public class OnlineProfileImplJpa extends JpaBaseDao<OnlineProfile, Long> implem
 
         List<OnlineProfile> list = (List<OnlineProfile>) query.getResultList();
 
-        PagedList<OnlineProfile> pList = new PagedList<OnlineProfile>(list.size());
+        PagedList<OnlineProfile> pList = new PagedList<>(list.size());
         pList.addAll(list);
         pList.setTotalSize(count);
         return pList;
@@ -206,7 +206,7 @@ public class OnlineProfileImplJpa extends JpaBaseDao<OnlineProfile, Long> implem
         List<Object[]> results = query.getResultList();
 
         // create summary list, set size and translate results
-        PagedList<OnlineProfilePurgeSummary> list = new PagedList<OnlineProfilePurgeSummary>(results.size());
+        PagedList<OnlineProfilePurgeSummary> list = new PagedList<>(results.size());
         list.setTotalSize(count);
 
         for (Object[] a : results)

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/ChatServer.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/ChatServer.java
@@ -218,7 +218,7 @@ public class ChatServer implements UDPLinkHandler, UDPManagerMonitor, UDPLinkMon
         if (!aliases.isEmpty())
         {
             OnlinePlayerInfo oalias;
-            DMArrayList<DMTypedHashMap> oaliases = new DMArrayList<DMTypedHashMap>(aliases.size());
+            DMArrayList<DMTypedHashMap> oaliases = new DMArrayList<>(aliases.size());
             for (OnlineProfile alias : aliases)
             {
                 oalias = new OnlinePlayerInfo();
@@ -409,7 +409,7 @@ public class ChatServer implements UDPLinkHandler, UDPManagerMonitor, UDPLinkMon
     {
         synchronized (links_)
         {
-            DMArrayList<DMTypedHashMap> list = new DMArrayList<DMTypedHashMap>(links_.size());
+            DMArrayList<DMTypedHashMap> list = new DMArrayList<>(links_.size());
             for (LinkInfo info : links_)
             {
                 list.add(info.player.getData());

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
@@ -119,7 +119,7 @@ public class OnlineProfilePurger extends BaseCommandLineApp
         service.deleteOnlineProfiles(deleteList);
     }
 
-    private List<OnlineProfile> deleteList = new ArrayList<OnlineProfile>();
+    private List<OnlineProfile> deleteList = new ArrayList<>();
     private OnlineProfilePurgeSummary last;
     private Date days_90;
     private Date days_14;

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/helper/DisallowedManager.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/helper/DisallowedManager.java
@@ -51,8 +51,8 @@ public class DisallowedManager
 {
 
     private static final String DISALLOWED_PATTERN_PREFIX = ":";
-    private static final List<String> disallowedContains = new ArrayList<String>();
-    private static final List<Pattern> disallowedPatterns = new ArrayList<Pattern>();
+    private static final List<String> disallowedContains = new ArrayList<>();
+    private static final List<Pattern> disallowedPatterns = new ArrayList<>();
 
     public DisallowedManager()
     {

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
@@ -96,7 +96,7 @@ public class BanList extends AdminPokerPage
         CompoundPropertyModel<BanData> formData = new CompoundPropertyModel<>(data);
 
         // form
-        Form<BanData> form = new Form<BanData>("form", formData)
+        Form<BanData> form = new Form<>("form", formData)
         {
             private static final long serialVersionUID = 42L;
 
@@ -256,7 +256,7 @@ public class BanList extends AdminPokerPage
             row.add(DateLabel.forDatePattern("createDate", PropertyConfig.getMessage("msg.format.date")));
 
             // unban
-            Form<String> form = new Form<String>("form", new StringModel(ban.getKey()))
+            Form<String> form = new Form<>("form", new StringModel(ban.getKey()))
             {
                 @Override
                 protected void onSubmit()

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
@@ -90,10 +90,10 @@ public class OnlineProfileSearch extends AdminPokerPage
         add(new BoxPagingNavigator("navigator", dataView, new BasicPluralLabelProvider("player", "players")));
 
         // form data
-        CompoundPropertyModel<SearchData> formData = new CompoundPropertyModel<SearchData>(data);
+        CompoundPropertyModel<SearchData> formData = new CompoundPropertyModel<>(data);
 
         // form
-        Form<SearchData> form = new Form<SearchData>("form", formData)
+        Form<SearchData> form = new Form<>("form", formData)
         {
             private static final long serialVersionUID = 42L;
 
@@ -106,7 +106,7 @@ public class OnlineProfileSearch extends AdminPokerPage
         };
         add(form);
 
-        TextField<String> nameText = new TextField<String>("name");
+        TextField<String> nameText = new TextField<>("name");
         nameText.add(new DefaultFocus());
 
         form.add(nameText);

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
@@ -97,7 +97,7 @@ public class RegistrationSearch extends AdminPokerPage
         CompoundPropertyModel<SearchData> formData = new CompoundPropertyModel<>(data);
 
         // form
-        Form<SearchData> form = new Form<SearchData>("form", formData)
+        Form<SearchData> form = new Form<>("form", formData)
         {
             private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/ForgotPassword.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/ForgotPassword.java
@@ -75,7 +75,7 @@ public class ForgotPassword extends OnlinePokerPage
         CompoundPropertyModel<ForgotPassword> formData = new CompoundPropertyModel<>(this);
 
         // change password form
-        Form<ForgotPassword> pwform = new Form<ForgotPassword>("form", formData)
+        Form<ForgotPassword> pwform = new Form<>("form", formData)
         {
             private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
@@ -159,10 +159,10 @@ public class MyProfile extends OnlinePokerPage
             add(createLabel("name2", user.getDisplayName()));
 
             // form data
-            CompoundPropertyModel<ChangePasswordData> formData = new CompoundPropertyModel<ChangePasswordData>(new ChangePasswordData());
+            CompoundPropertyModel<ChangePasswordData> formData = new CompoundPropertyModel<>(new ChangePasswordData());
 
             // change password form
-            Form<ChangePasswordData> pwform = new Form<ChangePasswordData>("form", formData)
+            Form<ChangePasswordData> pwform = new Form<>("form", formData)
             {
                 private static final long serialVersionUID = 42L;
 
@@ -229,7 +229,7 @@ public class MyProfile extends OnlinePokerPage
 
                     // retire
                     // unban
-                    Form<String> form = new Form<String>("form", new StringModel(p.getName()))
+                    Form<String> form = new Form<>("form", new StringModel(p.getName()))
                     {
                         @Override
                         protected void onSubmit()
@@ -270,7 +270,7 @@ public class MyProfile extends OnlinePokerPage
         @Override
         protected List<OnlineProfileSummary> load()
         {
-            if (userinfo == null) return new ArrayList<OnlineProfileSummary>();
+            if (userinfo == null) return new ArrayList<>();
 
             return profileService.getOnlineProfileSummariesForEmail(userinfo.getEmail());
         }

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Aliases.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Aliases.java
@@ -128,7 +128,7 @@ public class Aliases extends VoidPanel
         @Override
         protected List<OnlineProfile> load()
         {
-            if (user == null) return new ArrayList<OnlineProfile>();
+            if (user == null) return new ArrayList<>();
 
             return profileService.getAllOnlineProfilesForEmail(user.getEmail(), user.getName());
         }

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Login.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Login.java
@@ -62,7 +62,7 @@ public class Login extends VoidPanel implements JavascriptHideable
 
         this.visibleToUser = visibleToUser;
 
-        Form<Login> form = new StatelessForm<Login>("login", new CompoundPropertyModel<>(this))
+        Form<Login> form = new StatelessForm<>("login", new CompoundPropertyModel<>(this))
         {
             private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/NameRangeSearchForm.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/NameRangeSearchForm.java
@@ -79,7 +79,7 @@ public class NameRangeSearchForm extends VoidPanel
         data.setName(name);
 
         // form
-        form = new StatelessForm<NameRangeSearch>("form", new CompoundPropertyModel<>(data))
+        form = new StatelessForm<>("form", new CompoundPropertyModel<>(data))
         {
             private static final long serialVersionUID = 42L;
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/TouchTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/TouchTest.java
@@ -50,7 +50,7 @@ public class TouchTest {
     public TouchTest() {
     }
 
-    public static void main(String args[])
+    public static void main(String[] args)
     {
         long last = System.currentTimeMillis();
         System.out.println("Touching " + args[0]);

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
@@ -76,7 +76,7 @@ public class LanClientList
         }
     }
 
-    private Map<String, LanClientInfo> list_ = new HashMap<String, LanClientInfo>();
+    private Map<String, LanClientInfo> list_ = new HashMap<>();
     private LanControllerInterface controller_;
     
     
@@ -237,7 +237,7 @@ public class LanClientList
      */
     public synchronized List<LanClientInfo> getAsList(String sSortKey, boolean bAscending)
     {
-        List<LanClientInfo> list = new ArrayList<LanClientInfo>(list_.values());
+        List<LanClientInfo> list = new ArrayList<>(list_.values());
         Collections.sort(list, new LanSorter(sSortKey, bAscending));
         return list;
     }
@@ -274,7 +274,7 @@ public class LanClientList
     ////
     
     // listener list
-    protected List<LanListener> listenerList = new ArrayList<LanListener>();
+    protected List<LanListener> listenerList = new ArrayList<>();
     
    /**
      * Adds a listener to the list

--- a/code/server/src/main/java/com/donohoedigital/server/BaseServlet.java
+++ b/code/server/src/main/java/com/donohoedigital/server/BaseServlet.java
@@ -61,7 +61,7 @@ public abstract class BaseServlet extends HttpServlet
     private GameServer server;
     
     // used to track current servlet context
-    private static final ThreadLocal<ServletContext> local = new ThreadLocal<ServletContext>();
+    private static final ThreadLocal<ServletContext> local = new ThreadLocal<>();
 
     // settings
     private boolean ddMessageHandler;

--- a/code/server/src/main/java/com/donohoedigital/server/GameServletRequest.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServletRequest.java
@@ -60,7 +60,7 @@ public class GameServletRequest implements HttpServletRequest
     static Logger logger = LogManager.getLogger(GameServletRequest.class);
 
     // needed to handle request
-    Map<String, Object> headers_ = new TreeMap<String, Object>(new CaseInsensitiveCompare());
+    Map<String, Object> headers_ = new TreeMap<>(new CaseInsensitiveCompare());
     int nContentLength_;
     String sUserAgent_;
     InputStream in_;

--- a/code/server/src/main/java/com/donohoedigital/server/ServerSecurityProvider.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ServerSecurityProvider.java
@@ -87,7 +87,7 @@ public class ServerSecurityProvider extends com.donohoedigital.base.SecurityProv
         md.update(ID);
         md.update(Utils.encode(SecurityUtils.class.getName())); // For backward compatibility.
 
-        byte raw[] = md.digest();
+        byte[] raw = md.digest();
         int rawLength = raw.length;
         int lenDiff = (getEncryptionKeyLength() - rawLength);
 

--- a/code/server/src/main/java/com/donohoedigital/server/ServletDebug.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ServletDebug.java
@@ -93,7 +93,7 @@ public class ServletDebug
 
     public static void printCookies(HttpServletRequest httpservletrequest)
     {
-        Cookie acookie[] = httpservletrequest.getCookies();
+        Cookie[] acookie = httpservletrequest.getCookies();
         if (acookie != null)
         {
             for(int i = 0; i < acookie.length; i++)

--- a/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
@@ -50,8 +50,8 @@ public class ThreadPool
     static Logger logger = LogManager.getLogger(ThreadPool.class);
     
     private GameServer server_;
-    private final List<SocketThread> idle_ = new LinkedList<SocketThread>();
-    private final List<SocketThread> workers_ = new ArrayList<SocketThread>();
+    private final List<SocketThread> idle_ = new LinkedList<>();
+    private final List<SocketThread> workers_ = new ArrayList<>();
     private Class<?> socketClass_;
     private BaseServlet servlet_;
 

--- a/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
@@ -59,7 +59,7 @@ public class DDMailer extends BaseCommandLineApp
     private String sKey_;
     private File file_;
     private String sFrom_;
-    private List<Object[]> params_ = new ArrayList<Object[]>();
+    private List<Object[]> params_ = new ArrayList<>();
 
     // debugging/testing - limit number of emails sent
     private int LIMIT = 0;
@@ -156,7 +156,7 @@ public class DDMailer extends BaseCommandLineApp
         {
             String sLine;
             StringTokenizer token;
-            Object o[];
+            Object[] o;
             int nCnt;
             while ((sLine = buf.readLine()) != null)
             {
@@ -182,7 +182,7 @@ public class DDMailer extends BaseCommandLineApp
      */
     private void doEmail()
     {
-        Object o[];
+        Object[] o;
         String sEmail;
         String sProcess;
         boolean bProcess;

--- a/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
@@ -177,7 +177,7 @@ public class LoadGen
     {
         //String urlFile;
         String outFile;
-        List<URLSpec[]> vURLSpecs = new ArrayList<URLSpec[]>();
+        List<URLSpec[]> vURLSpecs = new ArrayList<>();
 
         setupCommandLineOptions();
         CommandLine.parseArgs(args);
@@ -230,7 +230,7 @@ public class LoadGen
         long time1 = System.currentTimeMillis();
 
         // Get ready to start threads
-        URLSpec urlspecs[];
+        URLSpec[] urlspecs;
         String sSessionName;
         int nSessions = vURLSpecs.size();
         UrlRunner[] runners = new UrlRunner[nThreads * nSessions];
@@ -365,7 +365,7 @@ public class LoadGen
      * <p/>
      * TODO: allow specification of sleep time (not implemented yet)
      */
-    private static URLSpec[] readFile(String saArgs[], int index)
+    private static URLSpec[] readFile(String[] saArgs, int index)
     {
         String sFile = saArgs[index];
         File file = new File(sFile);
@@ -375,7 +375,7 @@ public class LoadGen
             System.exit(-1);
         }
 
-        List<String> vURLs = new ArrayList<String>();
+        List<String> vURLs = new ArrayList<>();
 
         try
         {
@@ -407,7 +407,7 @@ public class LoadGen
         }
 
         int nSize = vURLs.size();
-        URLSpec specs[] = new URLSpec[nSize];
+        URLSpec[] specs = new URLSpec[nSize];
         for (int i = 0; i < nSize; i++)
         {
             specs[i] = new URLSpec(vURLs.get(i), 0);
@@ -433,7 +433,7 @@ public class LoadGen
     private static class UrlRunner extends Thread
     {
         String sThreadName;
-        URLSpec urlspecs[];
+        URLSpec[] urlspecs;
         int loop;
         int loopstart;
         int nCount = 0;
@@ -478,7 +478,7 @@ public class LoadGen
             return errors;
         }
 
-        public UrlRunner(String sName, int n, URLSpec urls[], int l)
+        public UrlRunner(String sName, int n, URLSpec[] urls, int l)
         {
             name = sName;
             sThreadName = fString.form(sName + " T" + (n + 1));

--- a/code/udp/src/main/java/com/donohoedigital/udp/AckList.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/AckList.java
@@ -371,7 +371,7 @@ public class AckList
     {
         if (false)
         {
-            int acks[] = { 200, 201, 202, 205, 204, 203, 197, 195, 196, 198, 199, 180, 185, 190, 192,
+            int[] acks = { 200, 201, 202, 205, 204, 203, 197, 195, 196, 198, 199, 180, 185, 190, 192,
                            193, 195, 194, 183, 196, 197, 201, 184, 182, 189, 186, 188, 187, 181, 191, 182 };
 
             for (int i = 0; i < acks.length; i++)
@@ -382,7 +382,7 @@ public class AckList
         }
         else
         {
-            int hits[] = new int[size+1];
+            int[] hits = new int[size+1];
             MersenneTwisterFast random_ = new MersenneTwisterFast();
             for (int i = 0; i < size * iters; i++)
             {

--- a/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
@@ -54,7 +54,7 @@ public class IncomingQueue
     static final int LAST_DISPATCH_CNT = -1;
 
     // members
-    private ArrayList<UDPData> queue_ = new ArrayList<UDPData>();
+    private ArrayList<UDPData> queue_ = new ArrayList<>();
     private int nLastProcessedID_;
     private UDPLink link_;
 
@@ -154,7 +154,7 @@ public class IncomingQueue
     //// DISPATCH
     ////
 
-    private ArrayList<UDPData> process_ = new ArrayList<UDPData>(10);
+    private ArrayList<UDPData> process_ = new ArrayList<>(10);
 
     /**
      * Dispatch messages.  Basically the messages in the queue are sorted

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
@@ -77,7 +77,7 @@ public class UDPLink
     private int POSSIBLE_TIMEOUT_NOTIFICATION_INTERVAL;
 
     // queue to send (synchronized blocks are used around sendQueue_)
-    private LinkedList<UDPData> sendQueue_ = new LinkedList<UDPData>();
+    private LinkedList<UDPData> sendQueue_ = new LinkedList<>();
     private UDPStats stats_ = new UDPStats();
 
     // session related stuff (set in resetSession() or newSession())
@@ -93,7 +93,7 @@ public class UDPLink
     private long lastMessageReceived_;
     private boolean bGoodbyeInProgress_ = false;
     private boolean bDone_ = false;
-    private ArrayList<UDPLinkMonitor> monitors_ = new ArrayList<UDPLinkMonitor>();
+    private ArrayList<UDPLinkMonitor> monitors_ = new ArrayList<>();
     private long start = System.currentTimeMillis();
 
     // data size related stuff
@@ -367,7 +367,7 @@ public class UDPLink
         int minPayload = MIN_MTU - headers;
         int FACTOR = 128;
         int FUDGE = (MAX_MTU - MIN_MTU) % FACTOR;
-        byte data[] = new byte[maxPayload];
+        byte[] data = new byte[maxPayload];
         Arrays.fill(data, (byte) 'd');
         int id = 0;
 

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
@@ -57,8 +57,8 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
     // members
     private UDPServer server_;
     private UDPLinkHandler handler_;
-    private final List<UDPManagerMonitor> monitors_ = new ArrayList<UDPManagerMonitor>();
-    private final LinkedBlockingQueue<Object> queue_ = new LinkedBlockingQueue<Object>();
+    private final List<UDPManagerMonitor> monitors_ = new ArrayList<>();
+    private final LinkedBlockingQueue<Object> queue_ = new LinkedBlockingQueue<>();
     private final List<UDPLink> links_ = Collections.synchronizedList(new ArrayList<UDPLink>());
     private List<UDPLink> linksCopy_ = Collections.synchronizedList(new ArrayList<UDPLink>());
     boolean bDone_ = false;
@@ -612,7 +612,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
 
         synchronized(links_)
         {
-            links = new ArrayList<UDPLink>(links_.size());
+            links = new ArrayList<>(links_.size());
             links.addAll(links_);
         }
 

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPMessage.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPMessage.java
@@ -68,7 +68,7 @@ public class UDPMessage
     private InetSocketAddress srcAddrActual_;
     private InetSocketAddress srcAddrApparent_;
     private InetSocketAddress dstAddr_; // TODO: will this be needed?  In future, could use for UDP tunneling
-    private ArrayList<UDPData> data_ = new ArrayList<UDPData>(5);
+    private ArrayList<UDPData> data_ = new ArrayList<>(5);
 
     // uknown address
     public static final InetSocketAddress ADDRESS_UNKNOWN = new InetSocketAddress("0.0.0.0", 0);

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/common/AliasedPageableServiceProvider.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/common/AliasedPageableServiceProvider.java
@@ -53,6 +53,6 @@ public abstract class AliasedPageableServiceProvider<T> extends PageableServiceP
     @Override
     public IModel<T> model(T object)
     {
-        return new AliasedCompoundPropertyModel<T>(new EntityModel<T>(object));
+        return new AliasedCompoundPropertyModel<>(new EntityModel<T>(object));
     }
 }

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
@@ -90,7 +90,7 @@ public class AliasedCompoundPropertyModel<T> extends CompoundPropertyModel<T>
 	 * aliases to matter.
 	 */
 	@SuppressWarnings({"CollectionDeclaredAsConcreteClass"})
-    private final ArrayList<Alias> aliases = new ArrayList<Alias>(1);
+    private final ArrayList<Alias> aliases = new ArrayList<>(1);
 
 
 	@SuppressWarnings("unchecked")

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -44,13 +44,17 @@ description: >
   NOTE: org.openrewrite.java.RemoveUnusedImports is deliberately NOT here.  It expands
   star imports (import javax.swing.* becomes one line per class), which this code base
   uses on purpose - it would touch ~370 files for no benefit.
+  NOTE: org.openrewrite.staticanalysis.RemoveRedundantTypeCast is also NOT here - see
+  the RedundantCasts recipe below.
+  NOTE: org.openrewrite.staticanalysis.RemoveExtraSemicolons is also NOT here.  It
+  swallows the whitespace following the semicolon, so "};\n\n    /**" collapses to
+  "}/**" (seen in gui/DDButtonUI.java).  Only 7 sites in this code base - not worth
+  hand-patching the recipe's output on every run.
 recipeList:
   - org.openrewrite.staticanalysis.UseDiamondOperator
-  - org.openrewrite.staticanalysis.RemoveRedundantTypeCast
   - org.openrewrite.staticanalysis.UseJavaStyleArrayDeclarations
   - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
   - org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
-  - org.openrewrite.staticanalysis.RemoveExtraSemicolons
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -142,3 +146,18 @@ description: >
   TypeCleanup.
 recipeList:
   - org.openrewrite.staticanalysis.ExplicitInitialization
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.RedundantCasts
+displayName: Redundant type casts
+description: >
+  Drop casts left over from pre-generics code, e.g. (DDOption) options_.get(i) where
+  options_ is already List<DDOption>.
+  REVIEW EVERY CHANGE.  This recipe does not understand overload resolution: it removed
+  the cast from init(sName, (String) null) in gui/DDImageButton.java, where it was
+  disambiguating init(String,Icon) inherited from AbstractButton against the local
+  init(String,String).  That one failed to compile, but a cast whose removal silently
+  selects a different overload would not.  Kept opt-in for that reason.
+recipeList:
+  - org.openrewrite.staticanalysis.RemoveRedundantTypeCast


### PR DESCRIPTION
PR 2 of the modernization series — the first one that touches source.

Applied with `mvn rewrite:run -Drewrite.activeRecipes=com.donohoedigital.TypeCleanup`.

## What changed

| Count | Change |
|------:|--------|
| 152 | `new HashMap<String, Color>()` → `new HashMap<>()` |
| 120 | `float coord[]` → `float[] coord` |

**149 files, +330/−330.** Both changes are purely syntactic and compile-time only —
neither can alter runtime behaviour, which is why there's no smoke test here (that's
reserved for PR 3's Swing listener rewiring).

Spread across 18 modules, concentrated in `poker` (48 files) and `common` (26).

## Three recipes pulled from the group

Each was removed for a concrete failure found by running it, not on principle. Two moved
to opt-in recipes rather than being deleted, so the capability stays available with the
caveat attached.

**`RemoveUnusedImports` — dropped.** It expands star imports: `import javax.swing.*`
becomes one line per class. That was 369 files, 367 of them import-only, undoing a
convention this code base uses on purpose. IntelliJ's own Optimize Imports handles
genuinely unused imports while respecting the star threshold.

**`RemoveExtraSemicolons` — dropped.** It swallows the whitespace *after* the semicolon,
so in `gui/DDButtonUI.java` this:

```java
        };

        /**
```

collapsed to `}/**`. Only 7 sites in the code base — not worth hand-patching the recipe's
output on every run, which would break the "`rewrite:run` output == what's committed"
property the whole workflow depends on.

**`RemoveRedundantTypeCast` — moved to opt-in `com.donohoedigital.RedundantCasts`.** It
doesn't understand overload resolution. It stripped the cast from
`init(sName, (String) null)` in `gui/DDImageButton.java`, where it was disambiguating
`init(String, Icon)` inherited from `AbstractButton` against the local
`init(String, String)`, and the `gui` module stopped compiling.

That failure was loud. The concern is the quiet version — a cast whose removal silently
binds a *different* overload, which compiles fine and has no test coverage in a Swing UI
path. One wrong out of 15 changes is too high an error rate for a recipe running
unattended, so it now requires opting in and reviewing each change.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- Diff is symmetric (+330/−330); `--ignore-all-space` gives the same totals, so there is
  no whitespace churn
- No mangled/glued lines in the output
- **Idempotent** — re-running `rewrite:dryRun` over the result produces no patch at all