### PR TITLE
Replace anonymous functional interfaces with lambdas

### DIFF
--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Activate.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Activate.java
@@ -51,8 +51,6 @@ import com.donohoedigital.gui.*;
 import javax.swing.BorderFactory;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -152,13 +150,8 @@ public class Activate extends BasePhase implements PropertyChangeListener
 
         // finish registerButton setup
         reg_.setDefaultOverride(registerButton_);
-        registerButton_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                activate();
-            }
-        });
+        registerButton_.addActionListener(e ->
+            activate());
         DDPanel actButtonBase = new DDPanel();
         actButtonBase.add(registerButton_, BorderLayout.NORTH);
         actButtonBase.setBorder(BorderFactory.createEmptyBorder(1, 0, 0, 0));
@@ -181,22 +174,13 @@ public class Activate extends BasePhase implements PropertyChangeListener
         DDPanel demoButtonBase = new DDPanel();
         demoButtonBase.setLayout(new GridLayout(2, 1, 0, 5));
         DDButton demoButton = new GlassButton("demo", "Glass");
-        demoButton.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                engine_.setDemoMode();
-            }
-        });
+        demoButton.addActionListener(e ->
+            engine_.setDemoMode());
         DDButton orderButton = new GlassButton("order", "Glass");
-        orderButton.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                engine_.setActivationNeeded(false); // temporary so can show order dialog
-                context_.processPhaseNow("Order", null);
-                engine_.setActivationNeeded(true);
-            }
+        orderButton.addActionListener(e -> {
+            engine_.setActivationNeeded(false); // temporary so can show order dialog
+            context_.processPhaseNow("Order", null);
+            engine_.setActivationNeeded(true);
         });
         demoButtonBase.add(demoButton);
         demoButtonBase.add(orderButton);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DialogPhase.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DialogPhase.java
@@ -53,8 +53,6 @@ import javax.swing.JComponent;
 import javax.swing.event.InternalFrameAdapter;
 import javax.swing.event.InternalFrameEvent;
 import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.List;
 import java.util.prefs.Preferences;
@@ -392,14 +390,10 @@ public abstract class DialogPhase extends BasePhase implements InternalDialog.Di
         if (bNoShowOption_)
         {
             back_.getNoShowCheckBox().addActionListener(
-                    new ActionListener()
-                    {
-                        public void actionPerformed(ActionEvent e)
-                        {
-                            Preferences prefs = Prefs.getUserPrefs(EnginePrefs.NODE_DIALOG_PHASE);
-                            prefs.putBoolean(sNoShowKey_, back_.getNoShowCheckBox().isSelected());
-                        }
-                    });
+                e -> {
+                    Preferences prefs = Prefs.getUserPrefs(EnginePrefs.NODE_DIALOG_PHASE);
+                    prefs.putBoolean(sNoShowKey_, back_.getNoShowCheckBox().isSelected());
+                });
         }
 
         ///

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DisplayTimedMessage.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DisplayTimedMessage.java
@@ -100,11 +100,8 @@ public class DisplayTimedMessage extends DisplayMessage implements CancelablePha
                 nSecondsLeft_--;
                 if (nSecondsLeft_ <= 0)
                 {
-                    SwingUtilities.invokeLater(new Runnable() {
-                        public void run()
-                        {
-                            if (cancelButton_ != null) cancelButton_.doClick();
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        if (cancelButton_ != null) cancelButton_.doClick();
                     });
                     return;
                 }
@@ -142,13 +139,11 @@ public class DisplayTimedMessage extends DisplayMessage implements CancelablePha
      */
     private void updateTimer()
     {
-        GuiUtils.invoke(new Runnable() {
-            public void run() {
-                String sSeconds = PropertyConfig.getMessage(nSecondsLeft_ == 1 ? "msg.seconds.singular" : "msg.seconds.plural",
-                                                            nSecondsLeft_);
+        GuiUtils.invoke(() -> {
+            String sSeconds = PropertyConfig.getMessage(nSecondsLeft_ == 1 ? "msg.seconds.singular" : "msg.seconds.plural",
+                nSecondsLeft_);
 
-                timer_.setText(PropertyConfig.getMessage("msg.dialog.timer", sSeconds));
-            }
+            timer_.setText(PropertyConfig.getMessage("msg.dialog.timer", sSeconds));
         });
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
@@ -165,13 +165,8 @@ public class EngineBasePanel extends JPanel
         // Upon change, change focus to this panel (old focus may have been
         // on widget in removed component)
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        requestFocus();
-                    }
-                }
+            () ->
+                requestFocus()
         );
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -559,18 +559,14 @@ public class EngineUtils
         
         // sleep in sep thread before turning led off
         Thread tWait = new Thread(
-            new Runnable() {
-                public void run() {
-                        Utils.sleepMillis(100);
-                        // need to invoke later so happens from swing thread
-                        SwingUtilities.invokeLater(
-                            new Runnable() {
-                                public void run() {
-                                    if (ledconnect_ != null) ledconnect_.setIcon(ledyellowoff_);
-                                }
-                            }
-                        );
-                }
+            () -> {
+                Utils.sleepMillis(100);
+                // need to invoke later so happens from swing thread
+                SwingUtilities.invokeLater(
+                    () -> {
+                        if (ledconnect_ != null) ledconnect_.setIcon(ledyellowoff_);
+                    }
+                );
             }
         );
         tWait.start();
@@ -665,11 +661,8 @@ public class EngineUtils
         if (cancelables_ == null || cancelables_.size() == 0) return;
 
         // run in swing loop since possible closing dialogs
-        GuiUtils.invoke(new Runnable() {
-            public void run() {
-                EngineUtils.cancel();
-            }
-        });
+        GuiUtils.invoke(() ->
+            EngineUtils.cancel());
     }
 
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
@@ -410,15 +410,11 @@ public class Help extends BasePhase implements ListSelectionListener,
             // not sure - so this hack makes it less "flashy"
             html_.setSkipNextRepaint(true);
             SwingUtilities.invokeLater(
-                    new Runnable()
-                    {
-                        public void run()
-                        {
-                            //logger.debug(selected_.getName() + " scrollRectToVisible: "+ selected_.getScrollPosition());
-                            html_.scrollRectToVisible(selected_.getScrollPosition());
-                            html_.paintImmediately(0, 0, html_.getWidth(), html_.getHeight());
-                        }
-                    }
+                () -> {
+                    //logger.debug(selected_.getName() + " scrollRectToVisible: "+ selected_.getScrollPosition());
+                    html_.scrollRectToVisible(selected_.getScrollPosition());
+                    html_.paintImmediately(0, 0, html_.getWidth(), html_.getHeight());
+                }
             );
 
         }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
@@ -402,12 +402,10 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
         // if no profiles, show msg
         if (bFileMode_ && profilePanels_.size() == 0) {
             SwingUtilities.invokeLater(
-            new Runnable() {
-                public void run() {
-                    String sMsg = PropertyConfig.getMessage("msg.needprofile"+sMsgName_);
-                    EngineUtils.displayInformationDialog(context_, sMsg, "msg.needprofile.title"+sMsgName_, null);
-                }
-            });
+                () -> {
+                    String sMsg = PropertyConfig.getMessage("msg.needprofile" + sMsgName_);
+                    EngineUtils.displayInformationDialog(context_, sMsg, "msg.needprofile.title" + sMsgName_, null);
+                });
         }
     }
     
@@ -468,19 +466,17 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
         
         // request focus
         SwingUtilities.invokeLater(
-        new Runnable() {
-            public void run() {
+            () -> {
                 // request focus
                 requestFocus();
-                
+
                 // scroll to visible (after display so it adjusts for new)
                 if (selectedPanel_ != null) {
                     Point loc = selectedPanel_.getLocation();
                     loc = SwingUtilities.convertPoint(selectedPanel_.getParent(), loc, scroll_.getViewport());
-                    scroll_.getViewport().scrollRectToVisible(new Rectangle(loc,selectedPanel_.getSize()));
+                    scroll_.getViewport().scrollRectToVisible(new Rectangle(loc, selectedPanel_.getSize()));
                 }
-            }
-        });
+            });
         
         // notify
         fireStateChanged();

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
@@ -496,13 +496,11 @@ public class ScrollGameboard extends JViewport implements
         board_.setScrolling(true);
         if (SCROLL_THREAD == null)
         {
-            SCROLL_THREAD = new Thread(new Runnable() {
-                    public void run() {
-                            while (bSCROLL) {
-                                scrollBoardAndWait();
-                            }
-                    }
-                }, "ScrollThread");
+            SCROLL_THREAD = new Thread(() -> {
+                while (bSCROLL) {
+                    scrollBoardAndWait();
+                }
+            }, "ScrollThread");
             SCROLL_THREAD.start();
         }
     }
@@ -545,10 +543,8 @@ public class ScrollGameboard extends JViewport implements
         {
             Utils.sleepMillis(CLICKTOSCROLL ? SCROLL_DELAY_MILLIS : SCROLL_DELAY_MILLIS_AUTO);
             SwingUtilities.invokeLater(
-                new Runnable() {
-                    public void run() {     
-                            if (bSCROLL && (bMOUSEDOWN || !CLICKTOSCROLL)) scrollBoard();
-                    }
+                () -> {
+                    if (bSCROLL && (bMOUSEDOWN || !CLICKTOSCROLL)) scrollBoard();
                 }
             );
         }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
@@ -415,23 +415,14 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
                 // otherwise, message has been received
                 // sleep in sep thread before generating remove dialog event
                 Thread tWait = new Thread(
-                        new Runnable()
-                        {
-                            public void run()
-                            {
-                                Utils.sleepMillis(nSleep_);
-                                // need to invoke later so happens from swing thread
-                                SwingUtilities.invokeLater(
-                                        new Runnable()
-                                        {
-                                            public void run()
-                                            {
-                                                removeDialog();
-                                            }
-                                        }
-                                );
-                            }
-                        }, "SendMessageDialog"
+                    () -> {
+                        Utils.sleepMillis(nSleep_);
+                        // need to invoke later so happens from swing thread
+                        SwingUtilities.invokeLater(
+                            () ->
+                                removeDialog()
+                        );
+                    }, "SendMessageDialog"
                 );
                 tWait.start();
             }
@@ -622,13 +613,8 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
         status_.setText(sText);
 
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        statusScroll_.getViewport().setViewPosition(ptop);
-                    }
-                }
+            () ->
+                statusScroll_.getViewport().setViewPosition(ptop)
         );
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SplashScreen.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SplashScreen.java
@@ -225,13 +225,8 @@ public class SplashScreen extends JFrame implements ActionListener, MouseListene
         }
 
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        engine_.showMainWindow();
-                    }
-                }
+            () ->
+                engine_.showMainWindow()
         );
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/StartMenu.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/StartMenu.java
@@ -41,8 +41,6 @@ package com.donohoedigital.games.engine;
 import com.donohoedigital.gui.*;
 
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * @author Doug Donohoe
@@ -73,13 +71,8 @@ public class StartMenu extends MenuPhase
             // expired message - just exit button
             DDButton exit = new GlassButton("exit", "GlassBig");
             parent.add(GuiUtils.CENTER(exit), BorderLayout.SOUTH);
-            exit.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    System.exit(0);
-                }
-            });
+            exit.addActionListener(e ->
+                System.exit(0));
         }
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
@@ -251,11 +251,8 @@ public class UDPStatus extends BasePhase implements DDTable.TableMenuItems
             Collections.sort(list, LINK_COMPARATOR);
 
             // table changed
-            GuiUtils.invoke(new Runnable() {
-                public void run() {
-                    updateSwing();
-                }
-            });
+            GuiUtils.invoke(() ->
+                updateSwing());
         }
 
         private void updateSwing()

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/BorderChooser.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/BorderChooser.java
@@ -214,9 +214,7 @@ public class BorderChooser extends InternalDialog implements ActionListener
             nIndex_ = nIndex;
             getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             getSelectionModel().addListSelectionListener(
-                    new ListSelectionListener() {
-                        public void valueChanged(ListSelectionEvent e) { myValueChanged(e); }
-                    }
+                e -> myValueChanged(e)
             );
         }
         

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDPagingTable.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDPagingTable.java
@@ -134,15 +134,11 @@ public class DDPagingTable extends DDPanel implements ActionListener
         refreshButton_.setEnabled(false);
 
         // invoke later to allow label to repaint and buttons to disable
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
-            {
-                 // Update the model and panel with the new offset.
-                DDPagingTableModel model = (DDPagingTableModel) table_.getDDTable().getModel();
-                model.refresh(offset_, rowCount_);
-                refreshPagingPanel();
-            }
+        SwingUtilities.invokeLater(() -> {
+            // Update the model and panel with the new offset.
+            DDPagingTableModel model = (DDPagingTableModel) table_.getDDTable().getModel();
+            model.refresh(offset_, rowCount_);
+            refreshPagingPanel();
         });
     }
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDPopupMenu.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDPopupMenu.java
@@ -60,12 +60,8 @@ public class DDPopupMenu extends JPopupMenu
         // so we force a repaint after showing to be sure
         if (Utils.ISMAC)
         {
-            SwingUtilities.invokeLater(new Runnable() {
-                public void run()
-                {
-                    repaint();
-                }
-            });
+            SwingUtilities.invokeLater(() ->
+                repaint());
         }
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/Bet.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/Bet.java
@@ -291,11 +291,8 @@ public class Bet extends ChainPhase implements PlayerActionListener, CancelableP
 
             // do processing
             SwingUtilities.invokeLater(
-                new Runnable() {
-                    public void run() {
-                            doAI();
-                    }
-                }
+                () ->
+                    doAI()
             );
         }
     }
@@ -480,11 +477,8 @@ public class Bet extends ChainPhase implements PlayerActionListener, CancelableP
             else
             {
                  SwingUtilities.invokeLater(
-                            new Runnable() {
-                                public void run() {
-                                    game_.setInputMode(PokerTableInput.MODE_RECHECK, hhand_, player_);
-                                }
-                            }
+                     () ->
+                         game_.setInputMode(PokerTableInput.MODE_RECHECK, hhand_, player_)
                             );
                 return null;
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonDisplay.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonDisplay.java
@@ -124,12 +124,10 @@ public class ButtonDisplay extends ChainPhase implements Runnable
 
         // repaint board
         SwingUtilities.invokeLater(
-            new Runnable() {
-                public void run() {
-                   if (old != null) PokerUtils.getGameboard().repaintTerritory(old, false);
-                    PokerUtils.getGameboard().repaintTerritory(t, false);
+            () -> {
+                if (old != null) PokerUtils.getGameboard().repaintTerritory(old, false);
+                PokerUtils.getGameboard().repaintTerritory(t, false);
 
-                }
             }
         );
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUp.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUp.java
@@ -95,12 +95,8 @@ public class ColorUp extends ChainPhase
             PokerUtils.getPokerGameboard().repaintAll();
 
             // do rest after repaint occurs
-            SwingUtilities.invokeLater(new Runnable() {
-                public void run()
-                {
-                    nextPhase();
-                }
-            });
+            SwingUtilities.invokeLater(() ->
+                nextPhase());
         }
         else
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUpFinish.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUpFinish.java
@@ -163,11 +163,8 @@ public class ColorUpFinish extends ChainPhase implements PlayerActionListener, R
 
             // do processing
             SwingUtilities.invokeLater(
-                new Runnable() {
-                    public void run() {
-                            playerActionPerformed(0,0);
-                    }
-                }
+                () ->
+                    playerActionPerformed(0, 0)
             );
         }
     }
@@ -252,11 +249,8 @@ public class ColorUpFinish extends ChainPhase implements PlayerActionListener, R
     {
         final Territory t = PokerUtils.getTerritoryForTableSeat(table_, player.getSeat());
         GuiUtils.invokeAndWait(
-            new Runnable() {
-                public void run() {
-                    PokerUtils.getGameboard().repaintTerritory(t, true);
-                }
-            }
+            () ->
+                PokerUtils.getGameboard().repaintTerritory(t, true)
         );
     }
     

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DealCommunity.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DealCommunity.java
@@ -203,11 +203,8 @@ public class DealCommunity extends ChainPhase implements PlayerActionListener
 
             // do processing
             SwingUtilities.invokeLater(
-                new Runnable() {
-                    public void run() {
-                            displayCards();
-                    }
-                }
+                () ->
+                    displayCards()
             );
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DealDisplay.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DealDisplay.java
@@ -354,17 +354,13 @@ public class DealDisplay extends ChainPhase implements Runnable
         {
             final Territory tParam = t;
             GuiUtils.invokeAndWait(
-                    new Runnable()
+                () -> {
+                    // check null for clearer exit
+                    if (PokerUtils.getGameboard() != null)
                     {
-                        public void run()
-                        {
-                            // check null for clearer exit
-                            if (PokerUtils.getGameboard() != null)
-                            {
-                                PokerUtils.getGameboard().repaintTerritory(tParam, true);
-                            }
-                        }
+                        PokerUtils.getGameboard().repaintTerritory(tParam, true);
                     }
+                }
             );
 
             // sleep

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GameOver.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GameOver.java
@@ -53,8 +53,6 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * @author Doug Donohoe
@@ -135,13 +133,8 @@ public class GameOver extends DialogPhase
                                                bOnline_ ? PokerUtils.DEMO_LIMIT_ONLINE : PokerUtils.DEMO_LIMIT);
 
             GlassButton order = new GlassButton("order", "Glass");
-            order.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    context_.processPhase("Order");
-                }
-            });
+            order.addActionListener(e ->
+                context_.processPhase("Order"));
             back_.getButtonBox().addButton(order);
             removeMatchingButton("yesWatch");
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -58,8 +58,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -297,24 +295,16 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             fxvolume.setEditable(true);
             fx = OptionMenu.add(new OptionBoolean(NODE, EngineConstants.PREF_FX, OSTYLE, map_, true, fxvolume), audiobase);
 
-            fx.addChangeListener(new ChangeListener()
-            {
-                public void stateChanged(ChangeEvent e)
-                {
-                    DDCheckBox box = ((OptionBoolean) e.getSource()).getCheckBox();
-                    AudioConfig.setMuteFX(!box.isSelected());
-                    playFX();
-                }
+            fx.addChangeListener(e -> {
+                DDCheckBox box = ((OptionBoolean) e.getSource()).getCheckBox();
+                AudioConfig.setMuteFX(!box.isSelected());
+                playFX();
             });
 
-            fxvolume.getSpinner().addChangeListener(new ChangeListener()
-            {
-                public void stateChanged(ChangeEvent e)
-                {
-                    DDNumberSpinner spinner = (DDNumberSpinner) e.getSource();
-                    AudioConfig.setFXGain(spinner.getValue());
-                    playFX();
-                }
+            fxvolume.getSpinner().addChangeListener(e -> {
+                DDNumberSpinner spinner = (DDNumberSpinner) e.getSource();
+                AudioConfig.setFXGain(spinner.getValue());
+                playFX();
             });
 
             // background music
@@ -323,23 +313,15 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             muvolume.setEditable(true);
             music = OptionMenu.add(new OptionBoolean(NODE, EngineConstants.PREF_BGMUSIC, OSTYLE, map_, true, muvolume), audiobase);
 
-            music.addChangeListener(new ChangeListener()
-            {
-                public void stateChanged(ChangeEvent e)
-                {
-                    DDCheckBox box = ((OptionBoolean) e.getSource()).getCheckBox();
-                    AudioConfig.setMuteBGMusic(!box.isSelected());
-                }
+            music.addChangeListener(e -> {
+                DDCheckBox box = ((OptionBoolean) e.getSource()).getCheckBox();
+                AudioConfig.setMuteBGMusic(!box.isSelected());
             });
 
-            muvolume.getSpinner().addChangeListener(new ChangeListener()
-            {
-                public void stateChanged(ChangeEvent e)
-                {
+            muvolume.getSpinner().addChangeListener(e -> {
 
-                    DDNumberSpinner spinner = (DDNumberSpinner) e.getSource();
-                    AudioConfig.setBGMusicGain(spinner.getValue());
-                }
+                DDNumberSpinner spinner = (DDNumberSpinner) e.getSource();
+                AudioConfig.setBGMusicGain(spinner.getValue());
             });
 
             // size fx, music to same

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupDialog.java
@@ -45,8 +45,6 @@ import javax.swing.JComponent;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -99,13 +97,8 @@ public class HandGroupDialog extends OptionMenuDialog implements PropertyChangeL
         desc_ = new GlassButton("description", "Glass");
         desc_.setPreferredSize(new Dimension(80, 24));
         desc_.setBorderGap(0, 0, 0, 0);
-        desc_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setDescription();
-            }
-        });
+        desc_.addActionListener(e ->
+            setDescription());
         topformat.add(desc_, BorderLayout.EAST);
 
         base_.add(top, BorderLayout.NORTH);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
@@ -45,14 +45,10 @@ import com.donohoedigital.gui.*;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JScrollPane;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -128,13 +124,8 @@ public class HandHistoryPanel extends DDPanel
         summaryHtmlArea_.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
         handsList_ = new ListPanel(HandListItemPanel.class, sStyle);
-        handsList_.addListSelectionListener(new ListSelectionListener()
-        {
-            public void valueChanged(ListSelectionEvent e)
-            {
-                setHandIndex(handsList_.getSelectedIndex());
-            }
-        });
+        handsList_.addListSelectionListener(e ->
+            setHandIndex(handsList_.getSelectedIndex()));
         handsList_.setOpaque(false);
         handsList_.setBorder(BorderFactory.createEmptyBorder(4, 0, 4, 0));
         Insets insets = handsList_.getInsets();
@@ -160,36 +151,23 @@ public class HandHistoryPanel extends DDPanel
         pagingLabel_.setBorder(BorderFactory.createEmptyBorder(1, 0, 1, 0));
         pageDownButton_ = new GlassButton("pagedown", "Glass");
         pageDownButton_.addActionListener(
-                new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        handFirst_ -= pageSize_;
-                        setHands();
-                    }
-                }
+            e -> {
+                handFirst_ -= pageSize_;
+                setHands();
+            }
         );
         pageUpButton_ = new GlassButton("pageup", "Glass");
         pageUpButton_.addActionListener(
-                new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        handFirst_ += pageSize_;
-                        setHands();
-                    }
-                }
+            e -> {
+                handFirst_ += pageSize_;
+                setHands();
+            }
         );
 
         exportButton_ = new GlassButton("export", "Glass");
         exportButton_.addActionListener(
-                new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        export();
-                    }
-                }
+            e ->
+                export()
         );
 
         pagingButtonPanel.setLayout(new GridLayout(1, 3, 8, 0));
@@ -243,21 +221,12 @@ public class HandHistoryPanel extends DDPanel
 
         showAllCheckbox_.setSelected(PokerUtils.isCheatOn(context_, PokerConstants.OPTION_CHEAT_AIFACEUP));
 
-        showAllCheckbox_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                showReasonCheckbox_.setEnabled(showAllCheckbox_.isSelected());
-                setHistoryText();
-            }
+        showAllCheckbox_.addActionListener(e -> {
+            showReasonCheckbox_.setEnabled(showAllCheckbox_.isSelected());
+            setHistoryText();
         });
-        showReasonCheckbox_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setHistoryText();
-            }
-        });
+        showReasonCheckbox_.addActionListener(e ->
+            setHistoryText());
 
         tabs_ = new DDTabbedPane(sStyle, null, DDTabbedPane.TOP);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HistoryExportDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HistoryExportDialog.java
@@ -53,7 +53,6 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileWriter;
@@ -159,53 +158,44 @@ public class HistoryExportDialog extends FileChooserDialog
         base_.remove(choose_);
         base_.add(wait, BorderLayout.CENTER);
 
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
+        SwingUtilities.invokeLater(() -> {
+            Integer handID = (Integer) gamephase_.getObject(PARAM_HAND_ID);
+
+            if (handID != null)
             {
-                Integer handID = (Integer)gamephase_.getObject(PARAM_HAND_ID);
-
-                if (handID != null)
-                {
-                    exp_ = new PokerDatabase.ExportSummary();
-                    exp_.handIDs = new ArrayList();
-                    exp_.handIDs.add(handID);
-                    exp_.tournamentCount = 1;
-                }
-                else
-                {
-                    String where = (String)gamephase_.getObject("where");
-                    BindArray bindArray = (BindArray)gamephase_.getObject("bindArray");
-
-                    exp_ = PokerDatabase.getExportSummary(where, bindArray);
-                }
-
-                ActionListener actionListener = new ActionListener()
-                    {
-                        public void actionPerformed(ActionEvent e)
-                        {
-                            checkButtons();
-                        }
-                    };
-
-                cbxHands_.setText(PropertyConfig.getMessage(
-                                    "msg.handtranscriptcount" + (exp_.handIDs.size() != 1 ? ".plural" : ".singular"),
-                                    exp_.handIDs.size()));
-                cbxHands_.setSelected(true);
-
-                cbxHands_.addActionListener(actionListener);
-
-                cbxTournaments_.setText(PropertyConfig.getMessage(
-                                    "msg.tourneysummarycount" + (exp_.tournamentCount != 1 ? ".plural" : ".singular"),
-                                    exp_.tournamentCount));
-
-                cbxTournaments_.addActionListener(actionListener);
-
-                base_.remove(wait);
-                base_.add(choose_, BorderLayout.CENTER);
-
-                checkButtons();
+                exp_ = new PokerDatabase.ExportSummary();
+                exp_.handIDs = new ArrayList();
+                exp_.handIDs.add(handID);
+                exp_.tournamentCount = 1;
             }
+            else
+            {
+                String where = (String) gamephase_.getObject("where");
+                BindArray bindArray = (BindArray) gamephase_.getObject("bindArray");
+
+                exp_ = PokerDatabase.getExportSummary(where, bindArray);
+            }
+
+            ActionListener actionListener = e ->
+                checkButtons();
+
+            cbxHands_.setText(PropertyConfig.getMessage(
+                "msg.handtranscriptcount" + (exp_.handIDs.size() != 1 ? ".plural" : ".singular"),
+                exp_.handIDs.size()));
+            cbxHands_.setSelected(true);
+
+            cbxHands_.addActionListener(actionListener);
+
+            cbxTournaments_.setText(PropertyConfig.getMessage(
+                "msg.tourneysummarycount" + (exp_.tournamentCount != 1 ? ".plural" : ".singular"),
+                exp_.tournamentCount));
+
+            cbxTournaments_.addActionListener(actionListener);
+
+            base_.remove(wait);
+            base_.add(choose_, BorderLayout.CENTER);
+
+            checkButtons();
         });
 
         return base_;
@@ -305,13 +295,8 @@ public class HistoryExportDialog extends FileChooserDialog
                     }
                     finally
                     {
-                        SwingUtilities.invokeLater(new Runnable()
-                        {
-                            public void run()
-                            {
-                                removeDialog();
-                            }
-                        });
+                        SwingUtilities.invokeLater(() ->
+                            removeDialog());
                     }
                 }
             }.start();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerListDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerListDialog.java
@@ -53,8 +53,6 @@ import javax.swing.table.DefaultTableModel;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -118,27 +116,21 @@ public class PlayerListDialog extends DialogPhase implements PropertyChangeListe
         // buttons
         add_ = new GlassButton("add", "Glass");
         text_.setDefaultOverride(add_);
-        add_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
-            {
-                list_.add(getName(true), null, false);
-                model_.fireTableDataChanged();
-                propertyChange(null); // force selection of new row
-                updateTextFromList();
-                text_.selectAll(); // allow quick adds
-            }
+        add_.addActionListener(e -> {
+            list_.add(getName(true), null, false);
+            model_.fireTableDataChanged();
+            propertyChange(null); // force selection of new row
+            updateTextFromList();
+            text_.selectAll(); // allow quick adds
         });
         add_.setBorderGap(2,5,2,6);
 
         delete_ = new GlassButton("delete", "Glass");
-        delete_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
-            {
-                list_.remove(getName(true), false);
-                model_.fireTableDataChanged();
-                if (model_.getRowCount() > 0) table_.getSelectionModel().setSelectionInterval(0,0); // allow quick deletes
-                updateTextFromList();
-            }
+        delete_.addActionListener(e -> {
+            list_.remove(getName(true), false);
+            model_.fireTableDataChanged();
+            if (model_.getRowCount() > 0) table_.getSelectionModel().setSelectionInterval(0, 0); // allow quick deletes
+            updateTextFromList();
         });
         delete_.setBorderGap(2,5,2,6);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileDialog.java
@@ -57,7 +57,6 @@ import javax.swing.ButtonGroup;
 import javax.swing.JComponent;
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -199,84 +198,44 @@ public class PlayerProfileDialog extends DialogPhase implements PropertyChangeLi
 
         if (profile_.isOnline())
         {
-            emailButton_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    doButton(e);
-                }
-            });
+            emailButton_.addActionListener(e ->
+                doButton(e));
 
             if (passwordButton_ != null)
             {
-                passwordButton_.addActionListener(new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        doButton(e);
-                    }
-                });
+                passwordButton_.addActionListener(e ->
+                    doButton(e));
             }
 
             if (sendButton_ != null)
             {
-                sendButton_.addActionListener(new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        doButton(e);
-                    }
-                });
+                sendButton_.addActionListener(e ->
+                    doButton(e));
             }
 
             if (resetButton_ != null)
             {
-                resetButton_.addActionListener(new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        doButton(e);
-                    }
-                });
+                resetButton_.addActionListener(e ->
+                    doButton(e));
             }
 
             if (syncButton_ != null)
             {
-                syncButton_.addActionListener(new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        doButton(e);
-                    }
-                });
+                syncButton_.addActionListener(e ->
+                    doButton(e));
             }
         }
 
         if (noRadio_ != null)
         {
-            noRadio_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    doRadio();
-                }
-            });
+            noRadio_.addActionListener(e ->
+                doRadio());
 
-            newRadio_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    doRadio();
-                }
-            });
+            newRadio_.addActionListener(e ->
+                doRadio());
 
-            existRadio_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    doRadio();
-                }
-            });
+            existRadio_.addActionListener(e ->
+                doRadio());
         }
 
         checkButtons();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
@@ -50,7 +50,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.*;
@@ -310,13 +309,7 @@ public class PokerDatabase
 
         final String databaseName = getActualDatabaseName(profile);
 
-        File[] files = databaseDir.listFiles(new FilenameFilter()
-        {
-            public boolean accept(File dir, String name)
-            {
-                return name.startsWith(databaseName + ".");
-            }
-        });
+        File[] files = databaseDir.listFiles((dir, name) -> name.startsWith(databaseName + "."));
 
         for (int i = 0; i < files.length; ++i)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerNight.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerNight.java
@@ -205,16 +205,12 @@ public class PokerNight extends BasePhase implements GameClockListener
 
                     // show message
                     SwingUtilities.invokeLater(
-                            new Runnable()
-                            {
-                                public void run()
-                                {
-                                    AudioConfig.playFX("attention");
-                                    TypedHashMap params = new TypedHashMap();
-                                    params.setString(DisplayMessage.PARAM_MESSAGE, sMsg);
-                                    context_.processPhaseNow("PokerNightMessage", params);
-                                }
-                            });
+                        () -> {
+                            AudioConfig.playFX("attention");
+                            TypedHashMap params = new TypedHashMap();
+                            params.setString(DisplayMessage.PARAM_MESSAGE, sMsg);
+                            context_.processPhaseNow("PokerNightMessage", params);
+                        });
                 }
                 else
                 {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
@@ -55,7 +55,6 @@ import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -126,14 +125,10 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
         TypedHashMap dummy = new TypedHashMap();
         numOpponents_ = new OptionInteger(null, "numopp", STYLE, dummy, null, 1, 9, -1, true);
         numOpponents_.addChangeListener(this);
-        numOpponents_.addChangeListener(new ChangeListener()
-        {
-            public void stateChanged(ChangeEvent e)
+        numOpponents_.addChangeListener(e -> {
+            if (numOpponents_.getSpinner().isValidData())
             {
-                if (numOpponents_.getSpinner().isValidData())
-                {
-                    updateNumOpponents();
-                }
+                updateNumOpponents();
             }
         });
         controlbase.add(numOpponents_);
@@ -150,13 +145,8 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
         group.add(simcombo_);
         simbase.add(simcombo_, BorderLayout.WEST);
         // listener to control # sims
-        ActionListener comboListener = new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                numSims_.setEnabled(simcombo_.isSelected());
-            }
-        };
+        ActionListener comboListener = e ->
+            numSims_.setEnabled(simcombo_.isSelected());
 
         allcombo_ = new DDRadioButton("allcombos", STYLE);
         group.add(allcombo_);
@@ -193,42 +183,33 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
         pb.setBorderLayoutGap(0, 5);
 
         run_ = new GlassButton("run", "Glass");
-        run_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        run_.addActionListener(e -> {
+            sim_.bSimRunning_ = true;
+            bStopRequested_ = false;
+            clearResults();
+            run_.setEnabled(false);
+            numSims_.setEnabled(false);
+            numOpponents_.setEnabled(false);
+            allcombo_.setEnabled(false);
+            simcombo_.setEnabled(false);
+            stop_.setEnabled(true);
+            if (simcombo_.isSelected())
             {
-                sim_.bSimRunning_ = true;
-                bStopRequested_ = false;
-                clearResults();
-                run_.setEnabled(false);
-                numSims_.setEnabled(false);
-                numOpponents_.setEnabled(false);
-                allcombo_.setEnabled(false);
-                simcombo_.setEnabled(false);
-                stop_.setEnabled(true);
-                if (simcombo_.isSelected())
+                if (bDemo_)
                 {
-                    if (bDemo_)
-                    {
-                        EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.showdown.demo"));
-                    }
-                    runSimulator();
+                    EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.showdown.demo"));
                 }
-                else
-                {
-                    runIterator();
-                }
+                runSimulator();
+            }
+            else
+            {
+                runIterator();
             }
         });
         stop_ = new GlassButton("stop", "Glass");
         stop_.setEnabled(false);
-        stop_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setStopRequested();
-            }
-        });
+        stop_.addActionListener(e ->
+            setStopRequested());
 
         pb.add(run_, BorderLayout.WEST);
         pb.add(progress_, BorderLayout.CENTER);
@@ -470,17 +451,13 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
 
         final StatResult[] stats = (StatResult[]) oResult;
 
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
+        SwingUtilities.invokeLater(() -> {
+            StatResult stat;
+            for (int i = 0;i < stats.length;i++)
             {
-                StatResult stat;
-                for (int i = 0; i < stats.length; i++)
-                {
-                    stat = stats[i];
-                    if (stat == null) continue;
-                    setResults(i, stat.toHTML("msg.showdown.results"));
-                }
+                stat = stats[i];
+                if (stat == null) continue;
+                setResults(i, stat.toHTML("msg.showdown.results"));
             }
         });
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
@@ -42,8 +42,6 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class PokerSimulatorPanel extends DDTabPanel implements DDProgressFeedback
 {
@@ -89,21 +87,13 @@ public class PokerSimulatorPanel extends DDTabPanel implements DDProgressFeedbac
         pb.add(progress_, BorderLayout.CENTER);
 
         run_ = new GlassButton("run", "Glass");
-        run_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
-            {
-                updateStats();
-            }
-        });
+        run_.addActionListener(e ->
+            updateStats());
 
         stop_ = new GlassButton("stop", "Glass");
         stop_.setEnabled(false);
-        stop_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
-            {
-                setStopRequested();
-            }
-        });
+        stop_.addActionListener(e ->
+            setStopRequested());
 
         pb.add(GuiUtils.NORTH(run_), BorderLayout.WEST);
         pb.add(progress_, BorderLayout.CENTER);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
@@ -345,14 +345,10 @@ public class PokerStartMenu extends StartMenu
             {
                 bCheck = false;
                 SwingUtilities.invokeLater(
-                        new Runnable()
-                        {
-                            public void run()
-                            {
-                                licenseCheck();
-                                profileCheck();
-                            }
-                        }
+                    () -> {
+                        licenseCheck();
+                        profileCheck();
+                    }
                 );
             }
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
@@ -49,8 +49,6 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -156,40 +154,20 @@ public class ShowPokerNightTable extends ShowPokerTable implements PropertyChang
         labelDetails_ = new DisplayLabel(430 / NF3, 120 / NF3, 790 / W, 790 / H, 430f / W, LEFT, TOP);
 
         // listeners/borders
-        buttonRewind_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                rewind();
-            }
-        });
+        buttonRewind_.addActionListener(e ->
+            rewind());
         buttonRewind_.setBorderGap(0, 0, 0, 0);
 
         buttonStartPause_.addActionListener(
-                new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        game_.getGameClock().toggle();
-                    }
-                });
+            e ->
+                game_.getGameClock().toggle());
 
-        buttonForward_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                forward();
-            }
-        });
+        buttonForward_.addActionListener(e ->
+            forward());
         buttonForward_.setBorderGap(0, 0, 0, 0);
 
-        buttonEdit_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                edit();
-            }
-        });
+        buttonEdit_.addActionListener(e ->
+            edit());
 
         // customizations
         customizeLabel(labelTime_, 10);
@@ -513,13 +491,9 @@ public class ShowPokerNightTable extends ShowPokerTable implements PropertyChang
     }
 
     // runnable for in swing thread
-    private Runnable update_ = new Runnable()
-    {
-        public void run()
-        {
-            updateLevel();
-            checkButtons();
-        }
+    private Runnable update_ = () -> {
+        updateLevel();
+        checkButtons();
     };
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerTable.java
@@ -557,13 +557,8 @@ public abstract class ShowPokerTable extends ChainPhase implements
 
         // start bg music
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        EngineUtils.startBackgroundMusic(gamephase_);
-                    }
-                }
+            () ->
+                EngineUtils.startBackgroundMusic(gamephase_)
         );
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -309,26 +309,16 @@ public class ShowTournamentTable extends ShowPokerTable implements
         {
             buttonRebuy_ = new PokerGlassButton(getGameButton("rebuy"));
             buttonbase_.add(buttonRebuy_);
-            buttonRebuy_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    NewLevelActions.rebuy(game_, REBUY_BUTTON, game_.getHumanPlayer().getTable().getLevel());
-                }
-            });
+            buttonRebuy_.addActionListener(e ->
+                NewLevelActions.rebuy(game_, REBUY_BUTTON, game_.getHumanPlayer().getTable().getLevel()));
         }
 
         if (TESTING(PokerConstants.TESTING_TEST_CASE))
         {
             buttonTestCase_ = new GlassButton("testcase", "GlassBig");
             buttonbase_.add(buttonTestCase_);
-            buttonTestCase_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    createTestCase();
-                }
-            });
+            buttonTestCase_.addActionListener(e ->
+                createTestCase());
         }
 
         DDPanel controlbase = buttonbase_;
@@ -665,13 +655,8 @@ public class ShowTournamentTable extends ShowPokerTable implements
 
         // do remaining start a bit later to allow for
         // UI to draw
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
-            {
-                poststart();
-            }
-        });
+        SwingUtilities.invokeLater(() ->
+            poststart());
     }
 
     /**
@@ -691,14 +676,8 @@ public class ShowTournamentTable extends ShowPokerTable implements
         if (TESTING(PokerConstants.TESTING_AUTOPILOT_INIT) && !TESTING(PokerConstants.TESTING_AUTOPILOT))
         {
             SwingUtilities.invokeLater(
-                    new Runnable()
-                    {
-                        public void run()
-                        {
-                            EngineUtils.displayInformationDialog(context_, "Autopilot is enabled, but currently paused (F5 or F9).");
-
-                        }
-                    }
+                () ->
+                    EngineUtils.displayInformationDialog(context_, "Autopilot is enabled, but currently paused (F5 or F9).")
             );
         }
     }
@@ -1246,21 +1225,17 @@ public class ShowTournamentTable extends ShowPokerTable implements
             if (bAllowContinueLower)
             {
                 SwingUtilities.invokeLater(
-                        new Runnable()
+                    () -> {
+                        // in case not yet enabled, wait a bit
+                        // this seems like a hack, but in some cases
+                        // the request focus doesn't occur, and this
+                        // seems to fix it.  Doh.
+                        if (!buttonContinueMiddle_.isEnabled())
                         {
-                            public void run()
-                            {
-                                // in case not yet enabled, wait a bit
-                                // this seems like a hack, but in some cases
-                                // the request focus doesn't occur, and this
-                                // seems to fix it.  Doh.
-                                if (!buttonContinueMiddle_.isEnabled())
-                                {
-                                    Utils.sleepMillis(100);
-                                }
-                                buttonContinueLower_.requestFocus();
-                            }
+                            Utils.sleepMillis(100);
                         }
+                        buttonContinueLower_.requestFocus();
+                    }
                 );
             }
 
@@ -1269,19 +1244,15 @@ public class ShowTournamentTable extends ShowPokerTable implements
             if (bAllowContinue)
             {
                 SwingUtilities.invokeLater(
-                        new Runnable()
+                    () -> {
+                        // see note above
+                        if (!buttonContinueMiddle_.isEnabled())
                         {
-                            public void run()
-                            {
-                                // see note above
-                                if (!buttonContinueMiddle_.isEnabled())
-                                {
-                                    Utils.sleepMillis(100);
-                                }
-
-                                buttonContinueMiddle_.requestFocus();
-                            }
+                            Utils.sleepMillis(100);
                         }
+
+                        buttonContinueMiddle_.requestFocus();
+                    }
                 );
             }
 
@@ -1308,13 +1279,8 @@ public class ShowTournamentTable extends ShowPokerTable implements
                 // run later so focus transfers smoothly
                 // otherwise focus will flash to scrollbar
                 // when we set disabled
-                SwingUtilities.invokeLater(new Runnable()
-                {
-                    public void run()
-                    {
-                        amountPanel_.setEnabled(false);
-                    }
-                });
+                SwingUtilities.invokeLater(() ->
+                    amountPanel_.setEnabled(false));
             }
         }
     }
@@ -1424,15 +1390,11 @@ public class ShowTournamentTable extends ShowPokerTable implements
         {
             // run later (like set false) so ordering is correct in case of
             // rapid, multiple calls to this
-            SwingUtilities.invokeLater(new Runnable()
-            {
-                public void run()
+            SwingUtilities.invokeLater(() -> {
+                amountPanel_.setEnabled(true);
+                if (amountPanel_.isVisible())
                 {
-                    amountPanel_.setEnabled(true);
-                    if (amountPanel_.isVisible())
-                    {
-                        if (!isFocusInChat()) amount_.requestFocus();
-                    }
+                    if (!isFocusInChat()) amount_.requestFocus();
                 }
             });
         }
@@ -1441,13 +1403,8 @@ public class ShowTournamentTable extends ShowPokerTable implements
             // run later so focus transfers smoothly
             // otherwise focus will flash to scrollbar
             // when we set disabled
-            SwingUtilities.invokeLater(new Runnable()
-            {
-                public void run()
-                {
-                    amountPanel_.setEnabled(false);
-                }
-            });
+            SwingUtilities.invokeLater(() ->
+                amountPanel_.setEnabled(false));
         }
     }
 
@@ -2097,13 +2054,9 @@ public class ShowTournamentTable extends ShowPokerTable implements
         // after popup goes away, send focus back to
         // board (need to invoke later because at this
         // time popup is still visible)
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
-            {
-                // don't request if 2nd popup displayed
-                if (menu_ != null) board_.requestFocus();
-            }
+        SwingUtilities.invokeLater(() -> {
+            // don't request if 2nd popup displayed
+            if (menu_ != null) board_.requestFocus();
         });
     }
 
@@ -2430,104 +2383,100 @@ public class ShowTournamentTable extends ShowPokerTable implements
 
         CardSelectorPanel cardSelector = new CardSelectorPanel(cardPiece.getCard(), false);
 
-        cardSelector.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        cardSelector.addActionListener(e -> {
+            CardSelectorPanel cs = (CardSelectorPanel) e.getSource();
+            Card selectedCard = cs.getSelectedCard();
+
+            if (selectedCard != null && !selectedCard.equals(cardPiece.getCard()) &&
+                !selectedCard.equals(Card.BLANK))
             {
-                CardSelectorPanel cs = (CardSelectorPanel) e.getSource();
-                Card selectedCard = cs.getSelectedCard();
+                HoldemHand hhand = table_.getHoldemHand();
+                Hand community = hhand.getCommunity();
+                Deck deck = hhand.getDeck();
 
-                if (selectedCard != null && !selectedCard.equals(cardPiece.getCard()) &&
-                    !selectedCard.equals(Card.BLANK))
+                Hand hand = null;
+                Territory t = null;
+
+                // figure out if the selected card is already in play
+
+                int cardIndex = community.indexOf(selectedCard);
+
+                if (cardIndex >= 0)
                 {
-                    HoldemHand hhand = table_.getHoldemHand();
-                    Hand community = hhand.getCommunity();
-                    Deck deck = hhand.getDeck();
+                    hand = community;
+                    t = PokerUtils.getFlop();
+                }
+                else
+                {
+                    Hand muck = hhand.getMuck();
 
-                    Hand hand = null;
-                    Territory t = null;
-
-                    // figure out if the selected card is already in play
-
-                    int cardIndex = community.indexOf(selectedCard);
+                    cardIndex = muck.indexOf(selectedCard);
 
                     if (cardIndex >= 0)
                     {
-                        hand = community;
-                        t = PokerUtils.getFlop();
+                        hand = muck;
                     }
                     else
                     {
-                        Hand muck = hhand.getMuck();
-
-                        cardIndex = muck.indexOf(selectedCard);
-
-                        if (cardIndex >= 0)
+                        for (int seat = 0;seat < 10;++seat)
                         {
-                            hand = muck;
-                        }
-                        else
-                        {
-                            for (int seat = 0; seat < 10; ++seat)
+                            PokerPlayer pp = table_.getPlayer(seat);
+
+                            if (pp != null)
                             {
-                                PokerPlayer pp = table_.getPlayer(seat);
-
-                                if (pp != null)
+                                if (pp.getHand() != null)
                                 {
-                                    if (pp.getHand() != null)
-                                    {
-                                        cardIndex = pp.getHand().indexOf(selectedCard);
+                                    cardIndex = pp.getHand().indexOf(selectedCard);
 
-                                        if (cardIndex >= 0)
-                                        {
-                                            hand = pp.getHand();
-                                            t = PokerUtils.getTerritoryForTableSeat(table_, pp.getSeat());
-                                            break;
-                                        }
+                                    if (cardIndex >= 0)
+                                    {
+                                        hand = pp.getHand();
+                                        t = PokerUtils.getTerritoryForTableSeat(table_, pp.getSeat());
+                                        break;
                                     }
                                 }
                             }
                         }
                     }
-
-                    // if the selected card is in play, replace it with a new card from the deck
-                    if ((hand != null) && (cardIndex >= 0))
-                    {
-                        hand.setCard(cardIndex, deck.nextCard());
-                        board_.repaintTerritory(t);
-                    }
-                    // card not in play, in the deck, so remove it from the deck (yeah, sam, think of this case?)
-                    else
-                    {
-                        deck.removeCard(selectedCard);
-                    }
-
-                    cardIndex = cardPiece.getCardIndex();
-
-                    hand = (player == null) ? community : player.getHand();
-
-                    // put the card we're replacing back in the deck
-                    deck.addRandom(hand.getCard(cardIndex));
-
-                    // set the new cards
-                    hand.setCard(cardIndex, selectedCard);
-
-                    if (hhand != null && hhand.isAllInShowdown())
-                    {
-                        // if we are changing a card after all have been displayed (when pause after
-                        // deal is on, need to do showdown based on actual comm cards)
-                        int n = EngineUtils.getMatchingPiecesCount(PokerUtils.getFlop(), PokerConstants.PIECE_CARD);
-                        Showdown.displayAllin(hhand, n == 5);
-                    }
                 }
 
-                menu_.setVisible(false);
-                board_.repaintTerritory(cardPiece.getTerritory());
+                // if the selected card is in play, replace it with a new card from the deck
+                if ((hand != null) && (cardIndex >= 0))
+                {
+                    hand.setCard(cardIndex, deck.nextCard());
+                    board_.repaintTerritory(t);
+                }
+                // card not in play, in the deck, so remove it from the deck (yeah, sam, think of this case?)
+                else
+                {
+                    deck.removeCard(selectedCard);
+                }
 
-                table_.firePokerTableEvent(new PokerTableEvent(
-                        PokerTableEvent.TYPE_CARD_CHANGED, table_, player,
-                        (player != null) ? player.getSeat() : PokerTableEvent.NOT_DEFINED));
+                cardIndex = cardPiece.getCardIndex();
+
+                hand = (player == null) ? community : player.getHand();
+
+                // put the card we're replacing back in the deck
+                deck.addRandom(hand.getCard(cardIndex));
+
+                // set the new cards
+                hand.setCard(cardIndex, selectedCard);
+
+                if (hhand != null && hhand.isAllInShowdown())
+                {
+                    // if we are changing a card after all have been displayed (when pause after
+                    // deal is on, need to do showdown based on actual comm cards)
+                    int n = EngineUtils.getMatchingPiecesCount(PokerUtils.getFlop(), PokerConstants.PIECE_CARD);
+                    Showdown.displayAllin(hhand, n == 5);
+                }
             }
+
+            menu_.setVisible(false);
+            board_.repaintTerritory(cardPiece.getTerritory());
+
+            table_.firePokerTableEvent(new PokerTableEvent(
+                PokerTableEvent.TYPE_CARD_CHANGED, table_, player,
+                (player != null) ? player.getSeat() : PokerTableEvent.NOT_DEFINED));
         });
 
         menu.add(GuiUtils.CENTER(cardSelector));

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/StatisticsViewer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/StatisticsViewer.java
@@ -42,7 +42,7 @@ import com.donohoedigital.games.poker.model.TournamentHistory;
 import com.donohoedigital.gui.*;
 
 import javax.swing.*;
-import javax.swing.event.*;
+import javax.swing.event.AncestorEvent;
 import javax.swing.table.DefaultTableModel;
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -113,13 +113,8 @@ public class StatisticsViewer extends BasePhase implements ActionListener
 
         GlassButton change = new GlassButton("changeprofile", "Glass");
         topinfo.add(change, BorderLayout.EAST);
-        change.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                context_.processPhase("PlayerProfileOptions");
-            }
-        });
+        change.addActionListener(e ->
+            context_.processPhase("PlayerProfileOptions"));
 
         DDScrollTable scrollOut = new DDScrollTable
                 (GuiManager.DEFAULT, "PokerPrefsPlayerList", "BrushedMetal", RESULTS_NAMES, RESULTS_WIDTHS);
@@ -152,13 +147,8 @@ public class StatisticsViewer extends BasePhase implements ActionListener
 
         tabs_ = new DDTabbedPane(style, "BrushedMetal", JTabbedPane.TOP);
         tabs_.setOpaque(false);
-        tabs_.addChangeListener(new ChangeListener()
-        {
-            public void stateChanged(ChangeEvent e)
-            {
-                checkDetailsButton();
-            }
-        });
+        tabs_.addChangeListener(e ->
+            checkDetailsButton());
 
         base.add(GuiUtils.CENTER(top), BorderLayout.NORTH);
         DDPanel overlay = new DDPanel();
@@ -187,25 +177,21 @@ public class StatisticsViewer extends BasePhase implements ActionListener
         tabs_.addTab(PropertyConfig.getMessage("msg.handhistory.turn"), ic, new ByRoundPanel(HoldemHand.ROUND_TURN), null);
         tabs_.addTab(PropertyConfig.getMessage("msg.handhistory.river"), ic, new ByRoundPanel(HoldemHand.ROUND_RIVER), null);
 
-        finishTable_.getSelectionModel().addListSelectionListener(new ListSelectionListener()
-        {
-            public void valueChanged(ListSelectionEvent e)
+        finishTable_.getSelectionModel().addListSelectionListener(e -> {
+            if (e.getValueIsAdjusting()) return;
+
+            if (finishTable_.getSelectedRow() < 0)
             {
-                if (e.getValueIsAdjusting()) return;
+                finishTable_.setRowSelectionInterval(0, 0);
+                finishTable_.repaint();
+            }
+            else
+            {
+                Component c = tabs_.getSelectedComponent();
 
-                if (finishTable_.getSelectedRow() < 0)
-                {
-                    finishTable_.setRowSelectionInterval(0, 0);
-                    finishTable_.repaint();
-                }
-                else
-                {
-                    Component c = tabs_.getSelectedComponent();
-
-                    if (c instanceof OverallPanel) ((OverallPanel)c).refresh();
-                    if (c instanceof ByHandPanel) ((ByHandPanel)c).refresh();
-                    if (c instanceof ByRoundPanel) ((ByRoundPanel)c).refresh();
-                }
+                if (c instanceof OverallPanel) ((OverallPanel) c).refresh();
+                if (c instanceof ByHandPanel) ((ByHandPanel) c).refresh();
+                if (c instanceof ByRoundPanel) ((ByRoundPanel) c).refresh();
             }
         });
     }
@@ -685,13 +671,8 @@ public class StatisticsViewer extends BasePhase implements ActionListener
 
             table_ = scrollTable.getDDTable();
 
-            table_.getSelectionModel().addListSelectionListener(new ListSelectionListener()
-            {
-                public void valueChanged(ListSelectionEvent e)
-                {
-                    checkDetailsButton();
-                }
-            });
+            table_.getSelectionModel().addListSelectionListener(e ->
+                checkDetailsButton());
             table_.addMouseListener(new MouseListener()
             {
                 public void mouseClicked(MouseEvent e)
@@ -978,13 +959,8 @@ public class StatisticsViewer extends BasePhase implements ActionListener
 
             table_ = scrollTable.getDDTable();
 
-            table_.getSelectionModel().addListSelectionListener(new ListSelectionListener()
-            {
-                public void valueChanged(ListSelectionEvent e)
-                {
-                    checkDetailsButton();
-                }
-            });
+            table_.getSelectionModel().addListSelectionListener(e ->
+                checkDetailsButton());
             table_.addMouseListener(new MouseListener()
             {
                 public void mouseClicked(MouseEvent e)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TableDesignDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TableDesignDialog.java
@@ -53,8 +53,6 @@ import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
@@ -112,17 +110,13 @@ public class TableDesignDialog extends DialogPhase implements ChangeListener, Pr
         JComponent swapcenter = GuiUtils.CENTER(swap);
         swapcenter.setBorder(BorderFactory.createEmptyBorder(5,0,0,0));
         colors.add(swapcenter, BorderLayout.CENTER);
-        swap.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                Color old = profile_.getColorBottom();
-                profile_.setColorBottom(profile_.getColorTop());
-                profile_.setColorTop(old);
-                faux.updateColors(profile_.getColorTop(), profile_.getColorBottom());
-                bottomChooser_.setColor(profile_.getColorBottom());
-                topChooser_.setColor(profile_.getColorTop());
-            }
+        swap.addActionListener(e -> {
+            Color old = profile_.getColorBottom();
+            profile_.setColorBottom(profile_.getColorTop());
+            profile_.setColorTop(old);
+            faux.updateColors(profile_.getColorTop(), profile_.getColorBottom());
+            bottomChooser_.setColor(profile_.getColorBottom());
+            topChooser_.setColor(profile_.getColorTop());
         });
         DDLabelBorder bottom = new DDLabelBorder("bottom", STYLE);
         bottomChooser_ = new ColorChooserPanel(STYLE, profile_.getColorBottom(), "engine.basepanel");

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
@@ -306,14 +306,10 @@ public class TournamentProfileDialog extends OptionMenuDialog implements Propert
             GlassButton invitees = new GlassButton("invitees", "Glass");
             invitees.setBorderGap(2, 4, 2, 4);
             invitees.setPreferredSize(new Dimension(75, 15));
-            invitees.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    TypedHashMap params = new TypedHashMap();
-                    params.setObject(PlayerListDialog.PARAM_PLAYER_LIST, profile_.getInvitees());
-                    context_.processPhaseNow("InvitedPlayerList", params);
-                }
+            invitees.addActionListener(e -> {
+                TypedHashMap params = new TypedHashMap();
+                params.setObject(PlayerListDialog.PARAM_PLAYER_LIST, profile_.getInvitees());
+                context_.processPhaseNow("InvitedPlayerList", params);
             });
 
             OptionBoolean obs = new OptionBoolean(null, TournamentProfile.PARAM_INVITE_OBS, STYLE, dummy_, true);
@@ -1102,13 +1098,8 @@ public class TournamentProfileDialog extends OptionMenuDialog implements Propert
         // clear button
         clear_ = new GlassButton("clear", "Glass");
         left.add(GuiUtils.NORTH(GuiUtils.CENTER(clear_)), BorderLayout.CENTER);
-        clear_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                clearSpots();
-            }
-        });
+        clear_.addActionListener(e ->
+            clearSpots());
 
         // amount fields
         DDPanel center = new DDPanel();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AITest.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AITest.java
@@ -50,12 +50,12 @@ import com.donohoedigital.gui.GuiManager;
 import javax.swing.JDialog;
 import javax.swing.JScrollPane;
 import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.Arrays;
 
 public class AITest
@@ -107,35 +107,31 @@ public class AITest
 
             htmlArea = new DDHtmlArea();
 
-            htmlArea.addHyperlinkListener(new HyperlinkListener()
-            {
-                public void hyperlinkUpdate(HyperlinkEvent e)
+            htmlArea.addHyperlinkListener(e -> {
+                if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED)
                 {
-                    if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED)
-                    {
-                        File file = new File(e.getDescription());
-                        GameState gameState = GameStateFactory.createGameState(file, false);
+                    File file = new File(e.getDescription());
+                    GameState gameState = GameStateFactory.createGameState(file, false);
 
-                        //PokerGame game = (PokerGame)engine.createGame(gameState);
-                        context_.setGameManager(null);
-                        LoadSavedGame.loadGame(context_, gameState);
-                        PokerGame game = (PokerGame)context_.getGame();
-                        /*
-                        if (game == null)
-                        {
-                            LoadSavedGame.loadGame(engine, gameState);
-                            game = (PokerGame)engine.getGame();
-                        }
-                        else
-                        {
-                            game.loadGame(gameState, true);
-                        }
-                        */
-                        PokerTable table = game.getCurrentTable();
-                        HoldemHand hhand = table.getHoldemHand();
-                        PokerPlayer player = hhand.getCurrentPlayer();
-                        player.setPlayerType(playerType_);
+                    //PokerGame game = (PokerGame)engine.createGame(gameState);
+                    context_.setGameManager(null);
+                    LoadSavedGame.loadGame(context_, gameState);
+                    PokerGame game = (PokerGame) context_.getGame();
+                    /*
+                    if (game == null)
+                    {
+                        LoadSavedGame.loadGame(engine, gameState);
+                        game = (PokerGame)engine.getGame();
                     }
+                    else
+                    {
+                        game.loadGame(gameState, true);
+                    }
+                    */
+                    PokerTable table = game.getCurrentTable();
+                    HoldemHand hhand = table.getHoldemHand();
+                    PokerPlayer player = hhand.getCurrentPlayer();
+                    player.setPlayerType(playerType_);
                 }
             });
 
@@ -146,13 +142,8 @@ public class AITest
 
             GlassButton refreshButton = new GlassButton(GuiManager.DEFAULT,  "BrushedMetal");
             refreshButton.setText("Refresh");
-            refreshButton.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    refresh();
-                }
-            });
+            refreshButton.addActionListener(e ->
+                refresh());
             buttons.add(refreshButton);
 
             getContentPane().add(scroll, BorderLayout.CENTER);
@@ -209,13 +200,7 @@ public class AITest
 
             File fDir = getTestCaseDir();
 
-            File[] files = fDir.listFiles(new FilenameFilter()
-            {
-                public boolean accept(File dir, String name)
-                {
-                    return (name.endsWith(".ddpokersave"));
-                }
-            });
+            File[] files = fDir.listFiles((dir, name) -> (name.endsWith(".ddpokersave")));
 
             Arrays.sort(files);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
@@ -673,56 +673,35 @@ public class PocketWeights
                 return;
             case HandAction.ACTION_FOLD:
             case HandAction.ACTION_CHECK:
-                func = new PostFlopWeightFunction()
-                {
-                    public float adjustWeight(float weight, float rhs, float ppot, float npot)
-                    {
-                        //return (rhs < .75f) ? (weight+1f)/2f : weight/2f;
-                        //return ((float)(Math.pow((.8f-rhs)/.8f,2d))+weight)/2f;
-                        //return (rhs < .8f) ? ((float)(Math.pow((.8f-rhs)/.8f,2d))+weight)/2f : 0f;
-                        return (float) (0.75d + Math.sin(1.25d * Math.PI * (rhs - npot) + Math.PI / 2.0d) / 4.0d) * weight;
-                        //return (1.0f-rhs)*weight;
-                    }
-                };
+                func = (weight, rhs, ppot, npot) ->
+                    //return (rhs < .75f) ? (weight+1f)/2f : weight/2f;
+                    //return ((float)(Math.pow((.8f-rhs)/.8f,2d))+weight)/2f;
+                    //return (rhs < .8f) ? ((float)(Math.pow((.8f-rhs)/.8f,2d))+weight)/2f : 0f;
+                    (float) (0.75d + Math.sin(1.25d * Math.PI * (rhs - npot) + Math.PI / 2.0d) / 4.0d) * weight;
                 break;
             case HandAction.ACTION_CALL:
                 //bias = ((float)amount) / ((float)potSize);
                 // asymptotically approaches zero with higher pot odds
                 bias = 1.0f / ((((float) potSize_) / ((float) amount)) + 1.0f);
-                func = new PostFlopWeightFunction()
-                {
-                    public float adjustWeight(float weight, float rhs, float ppot, float npot)
-                    {
-                        //return (rhs > .75f) ? (weight+1f)/2f : weight/2f;
-                        //return (rhs > .6f) ? ((float)(Math.pow((rhs-.6f)/.4f,2d))+weight)/2f : 0f;
-                        return (float) (0.35d + Math.sin(1.5d * Math.PI * ((rhs + ppot - npot) + 1.0d)) / 4.0d) * weight;
-                    }
-                };
+                func = (weight, rhs, ppot, npot) ->
+                    //return (rhs > .75f) ? (weight+1f)/2f : weight/2f;
+                    //return (rhs > .6f) ? ((float)(Math.pow((rhs-.6f)/.4f,2d))+weight)/2f : 0f;
+                    (float) (0.35d + Math.sin(1.5d * Math.PI * ((rhs + ppot - npot) + 1.0d)) / 4.0d) * weight;
                 break;
             case HandAction.ACTION_BET:
                 bias = ((float) amount) / ((float) potSize_);
-                func = new PostFlopWeightFunction()
-                {
-                    public float adjustWeight(float weight, float rhs, float ppot, float npot)
-                    {
-                        //return (rhs > .85f) ? (weight+1f)/2f : weight/2f;
-                        //return Math.min(weight+rhs*rhs, 1f);
-                        //return (rhs > .85f) ? ((float)(Math.pow((rhs-.85f)/.15f,2d))+weight)/2f : 0f;
-                        return (float) (Math.pow(0.9d * (rhs + npot), 2.0d) + 0.1d) * weight;
-                    }
-                };
+                func = (weight, rhs, ppot, npot) ->
+                    //return (rhs > .85f) ? (weight+1f)/2f : weight/2f;
+                    //return Math.min(weight+rhs*rhs, 1f);
+                    //return (rhs > .85f) ? ((float)(Math.pow((rhs-.85f)/.15f,2d))+weight)/2f : 0f;
+                    (float) (Math.pow(0.9d * (rhs + npot), 2.0d) + 0.1d) * weight;
                 break;
             case HandAction.ACTION_RAISE:
-                func = new PostFlopWeightFunction()
-                {
-                    public float adjustWeight(float weight, float rhs, float ppot, float npot)
-                    {
-                        //return (rhs > .9f) ? ((float)(Math.pow((rhs-.9f)/.1f,2d))+weight)/2f : 0f;
-                        //return (rhs > .95f) ? (weight+1f)/2f : weight/2f;
-                        return (float) (0.35d + Math.sin(1.5d * Math.PI * ((rhs + ppot - npot) + 1.0d)) / 4.0d) *
-                               (float) (Math.pow(0.9d * (rhs + npot + ppot), 20.0d) + 0.1d) * weight;
-                    }
-                };
+                func = (weight, rhs, ppot, npot) ->
+                    //return (rhs > .9f) ? ((float)(Math.pow((rhs-.9f)/.1f,2d))+weight)/2f : 0f;
+                    //return (rhs > .95f) ? (weight+1f)/2f : weight/2f;
+                    (float) (0.35d + Math.sin(1.5d * Math.PI * ((rhs + ppot - npot) + 1.0d)) / 4.0d) *
+                        (float) (Math.pow(0.9d * (rhs + npot + ppot), 20.0d) + 0.1d) * weight;
                 break;
             default:
                 throw new ApplicationError("Unhandled action type " + actionType);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
@@ -473,35 +473,21 @@ public class AdvisorInfoDialog extends DialogPhase
                     }
                 }
 
-                GuiUtils.invoke(new Runnable()
-                {
-                    public void run()
-                    {
-                        grid_.repaint();
-                    }
-                });
+                GuiUtils.invoke(() ->
+                    grid_.repaint());
             }
             else
             {
                 grid_.clear();
 
-                GuiUtils.invoke(new Runnable()
-                {
-                    public void run()
-                    {
-                        grid_.repaint();
-                    }
-                });
+                GuiUtils.invoke(() ->
+                    grid_.repaint());
 
                 progressBar_.setPercentDone(0);
 
-                GuiUtils.invoke(new Runnable()
-                {
-                    public void run()
-                    {
-                        progressPanel_ = GuiUtils.CENTER(progressBar_);
-                        grid_.add(progressPanel_, BorderLayout.CENTER);
-                    }
+                GuiUtils.invoke(() -> {
+                    progressPanel_ = GuiUtils.CENTER(progressBar_);
+                    grid_.add(progressPanel_, BorderLayout.CENTER);
                 });
 
                 Hand community = ai.getCommunity();
@@ -595,13 +581,8 @@ public class AdvisorInfoDialog extends DialogPhase
 
                         ++count;
 
-                        GuiUtils.invoke(new Runnable()
-                        {
-                            public void run()
-                            {
-                                grid_.repaint(500);
-                            }
-                        });
+                        GuiUtils.invoke(() ->
+                            grid_.repaint(500));
 
                         progressBar_.setPercentDone((count*100)/total);
                     }
@@ -614,13 +595,9 @@ public class AdvisorInfoDialog extends DialogPhase
                 //ai.noPotential = false;
                 //RuleEngine.matrix = false;
 
-                GuiUtils.invoke(new Runnable()
-                {
-                    public void run()
-                    {
-                        grid_.remove(progressPanel_);
-                        grid_.repaint();
-                    }
+                GuiUtils.invoke(() -> {
+                    grid_.remove(progressPanel_);
+                    grid_.repaint();
                 });
             }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionDialog.java
@@ -52,8 +52,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyChangeEvent;
@@ -119,13 +117,8 @@ public class HandSelectionDialog extends OptionMenuDialog
         DDButton desc = new GlassButton("description", "Glass");
         desc.setPreferredSize(new Dimension(80, 24));
         desc.setBorderGap(0, 0, 0, 0);
-        desc.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setDescription();
-            }
-        });
+        desc.addActionListener(e ->
+            setDescription());
 
         topButtons.setLayout(new GridLayout(1, 2, 4, 0));
         topButtons.add(desc);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionPanel.java
@@ -43,8 +43,6 @@ import com.donohoedigital.gui.DDPanel;
 import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class HandSelectionPanel extends DDPanel
 {
@@ -75,44 +73,32 @@ public class HandSelectionPanel extends DDPanel
         handSelectionHup_ = new DDComboBox(handSelectionElement, sStyle);
 
 
-        handSelectionFull_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
+        handSelectionFull_.addActionListener(e -> {
+            profile_.setHandSelectionFull((HandSelectionScheme) handSelectionFull_.getSelectedItem());
+            if (changeListener != null)
             {
-                profile_.setHandSelectionFull((HandSelectionScheme)handSelectionFull_.getSelectedItem());
-                if (changeListener != null)
-                {
-                    changeListener.stateChanged(null);
-                }
+                changeListener.stateChanged(null);
             }
         });
-        handSelectionShort_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
+        handSelectionShort_.addActionListener(e -> {
+            profile_.setHandSelectionShort((HandSelectionScheme) handSelectionShort_.getSelectedItem());
+            if (changeListener != null)
             {
-                profile_.setHandSelectionShort((HandSelectionScheme)handSelectionShort_.getSelectedItem());
-                if (changeListener != null)
-                {
-                    changeListener.stateChanged(null);
-                }
+                changeListener.stateChanged(null);
             }
         });
-        handSelectionVeryShort_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
+        handSelectionVeryShort_.addActionListener(e -> {
+            profile_.setHandSelectionVeryShort((HandSelectionScheme) handSelectionVeryShort_.getSelectedItem());
+            if (changeListener != null)
             {
-                profile_.setHandSelectionVeryShort((HandSelectionScheme)handSelectionVeryShort_.getSelectedItem());
-                if (changeListener != null)
-                {
-                    changeListener.stateChanged(null);
-                }
+                changeListener.stateChanged(null);
             }
         });
-        handSelectionHup_.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
+        handSelectionHup_.addActionListener(e -> {
+            profile_.setHandSelectionHup((HandSelectionScheme) handSelectionHup_.getSelectedItem());
+            if (changeListener != null)
             {
-                profile_.setHandSelectionHup((HandSelectionScheme)handSelectionHup_.getSelectedItem());
-                if (changeListener != null)
-                {
-                    changeListener.stateChanged(null);
-                }
+                changeListener.stateChanged(null);
             }
         });
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
@@ -38,8 +38,6 @@ import com.donohoedigital.games.poker.ai.PlayerType;
 import com.donohoedigital.gui.*;
 
 import javax.swing.BorderFactory;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.util.ArrayList;
@@ -130,13 +128,8 @@ public class OpponentMixPanel extends DDTabPanel
             fPercent_.setBigStep(10);
             addMouseListeners(fPercent_); // add manually since not in hierarchy when panel created
             fPercent_.addChangeListener(
-                new ChangeListener()
-                {
-                    public void stateChanged(ChangeEvent e)
-                    {
-                        percentValueChanged();
-                    }
-                }
+                e ->
+                    percentValueChanged()
             );
 
             addMouseWheelListener(fPercent_.getTextField());

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeDialog.java
@@ -51,8 +51,6 @@ import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyChangeEvent;
@@ -135,13 +133,8 @@ public class PlayerTypeDialog extends OptionMenuDialog implements PropertyChange
         desc_ = new GlassButton("description", "Glass");
         desc_.setPreferredSize(new Dimension(80, 24));
         desc_.setBorderGap(0, 0, 0, 0);
-        desc_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setDescription();
-            }
-        });
+        desc_.addActionListener(e ->
+            setDescription());
 
         topButtons.setLayout(new GridLayout(1, 2, 4, 0));
         topButtons.add(desc_);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeManager.java
@@ -43,8 +43,6 @@ import com.donohoedigital.gui.GuiUtils;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class PlayerTypeManager extends ProfileManagerPanel
 {
@@ -60,13 +58,8 @@ public class PlayerTypeManager extends ProfileManagerPanel
         roster_ = new GlassButton("roster", "Glass");
         roster_.setPreferredSize(new Dimension(80, 24));
         roster_.setBorderGap(0, 0, 0, 0);
-        roster_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                setRoster();
-            }
-        });
+        roster_.addActionListener(e ->
+            setRoster());
 
         summaryBorder_.add(GuiUtils.EAST(roster_), BorderLayout.SOUTH);
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
@@ -43,7 +43,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 
@@ -92,13 +91,8 @@ public class PlayerTypeSlidersPanel extends DDPanel
 
             pill_ = new MyPillPanel("DashboardHeader", itemx.getLabel());
             pill_.setExpanded(itemx.isExpanded());
-            pill_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    pillClicked();
-                }
-            });
+            pill_.addActionListener(e ->
+                pillClicked());
 
             value_ = new DDLabel(GuiManager.DEFAULT, sStyle);
             value_.setPreferredWidth(30);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/phase/CreateTestCase.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/phase/CreateTestCase.java
@@ -62,8 +62,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -108,13 +106,8 @@ public class CreateTestCase extends DialogPhase
         base.setPreferredSize(new Dimension(200, 200));
 
         this.getMatchingButton("results").addActionListener(
-                new ActionListener()
-                {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        AITest.test(context_);
-                    }
-                }
+            e ->
+                AITest.test(context_)
         );
 
         return base;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardAdvisor.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardAdvisor.java
@@ -53,8 +53,6 @@ import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class DashboardAdvisor extends DashboardItem
 {
@@ -97,27 +95,18 @@ public class DashboardAdvisor extends DashboardItem
         DDPanel base = new DDPanel();
 
         DDButton actButton_ = new GlassButton("aidoit", "Glass");
-        actButton_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                Phase phase = context_.getCurrentPhase();
+        actButton_.addActionListener(e -> {
+            Phase phase = context_.getCurrentPhase();
 
-                if (phase instanceof Bet)
-                {
-                    ((Bet) phase).doAI();
-                }
+            if (phase instanceof Bet)
+            {
+                ((Bet) phase).doAI();
             }
         });
 
         DDButton whyButton_ = new GlassButton("tellmewhy", "Glass");
-        whyButton_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                context_.processPhaseNow("AdvisorInfoDialog", null);
-            }
-        });
+        whyButton_.addActionListener(e ->
+            context_.processPhaseNow("AdvisorInfoDialog", null));
 
         /*
         ExplicitLayout layout = new ExplicitLayout();
@@ -190,15 +179,11 @@ public class DashboardAdvisor extends DashboardItem
         }
 
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        setTitle(getTitle());
-                        htmlAdvice_.setText(advice_);
-                        buttons_.setVisible(!NOADVICE.equals(advice_));
-                    }
-                });
+            () -> {
+                setTitle(getTitle());
+                htmlAdvice_.setText(advice_);
+                buttons_.setVisible(!NOADVICE.equals(advice_));
+            });
     }
 
     @Override

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
@@ -226,11 +226,6 @@ public class DashboardClock extends DashboardItem implements GameClockListener
     }
 
     // runnable for invoking clock ticked event in swing thread
-    private Runnable updateTimeRunner_ = new Runnable()
-                        {
-                            public void run()
-                            {
-                                updateTime();
-                            }
-                        };
+    private Runnable updateTimeRunner_ = () ->
+        updateTime();
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
@@ -53,8 +53,6 @@ import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.TimerTask;
@@ -217,21 +215,11 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
             header_ = new DashboardHeader("DashboardHeader", false);
             header_.setText(getTitle());
             header_.addAncestorListener(this);
-            header_.check_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    setOpen(header_.check_.isSelected());
-                }
-            });
+            header_.check_.addActionListener(e ->
+                setOpen(header_.check_.isSelected()));
 
-            header_.delete_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    setInDashboard(header_.delete_.isSelected());
-                }
-            });
+            header_.delete_.addActionListener(e ->
+                setInDashboard(header_.delete_.isSelected()));
         }
 
         if (body_ == null)
@@ -459,13 +447,8 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
     }
 
     // runnable for invoking table changed event in swing thread
-    private Runnable tableChangedRunner_ = new Runnable()
-    {
-        public void run()
-        {
-            tableChanged(game_.getCurrentTable());
-        }
-    };
+    private Runnable tableChangedRunner_ = () ->
+        tableChanged(game_.getCurrentTable());
 
     /**
      * Game property changed - we track current table

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardPanel.java
@@ -45,8 +45,6 @@ import javax.swing.border.Border;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * Created by IntelliJ IDEA.
@@ -192,16 +190,12 @@ public class DashboardPanel extends DDPanel
                              edit,
                              ContainerEF.right(dashBG).subtract(ComponentEF.preferredWidth(edit)),
                              ContainerEF.top(dashBG).add(5)));
-        edit.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                TypedHashMap params = new TypedHashMap();
-                params.setObject(DashboardEditorDialog.PARAM_DASHMGR, mgr_);
-                mgr_.getGame().getGameContext().processPhaseNow("DashboardEditorDialog", params);
-                sync();
-                mgr_.stateChanged();
-            }
+        edit.addActionListener(e -> {
+            TypedHashMap params = new TypedHashMap();
+            params.setObject(DashboardEditorDialog.PARAM_DASHMGR, mgr_);
+            mgr_.getGame().getGameContext().processPhaseNow("DashboardEditorDialog", params);
+            sync();
+            mgr_.stateChanged();
         });
 
         return dashBG;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/MyHand.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/MyHand.java
@@ -148,12 +148,8 @@ public class MyHand extends DashboardItem
     {
         if (impl_ != null && impl_.isDisplayed() && !table.isZipMode())
         {
-            GuiUtils.invoke(new Runnable() {
-                public void run()
-                {
-                    impl_.updateAll();
-                }
-            });
+            GuiUtils.invoke(() ->
+                impl_.updateAll());
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
@@ -86,13 +86,8 @@ public class ObserversDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = new Runnable()
-                        {
-                            public void run()
-                            {
-                                updateAll();
-                            }
-                        };
+    private Runnable updateRunner_ = () ->
+        updateAll();
 
     /**
      * update observer list

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
@@ -47,8 +47,6 @@ import com.donohoedigital.gui.GuiUtils;
 
 import javax.swing.JComponent;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 
 /**
@@ -114,42 +112,30 @@ public class OnlineDash extends DashboardItem
         else
         {
             sitout_ = new DDCheckBox("sitout", STYLE);
-            sitout_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
+            sitout_.addActionListener(e -> {
+                if (PokerUtils.isDemoOver(context_, player_, true) && !sitout_.isSelected())
                 {
-                    if (PokerUtils.isDemoOver(context_, player_, true) && !sitout_.isSelected())
-                    {
-                        EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.onlinedone.demo"));
-                        sitout_.setSelected(true);
-                        return;
-                    }
-
-                    player_.setSittingOut(sitout_.isSelected());
-                    getTD().playerUpdate(player_, player_.getOnlineSettings());
+                    EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.onlinedone.demo"));
+                    sitout_.setSelected(true);
+                    return;
                 }
+
+                player_.setSittingOut(sitout_.isSelected());
+                getTD().playerUpdate(player_, player_.getOnlineSettings());
             });
             base_.add(sitout_);
 
             mucklose_ = new DDCheckBox("mucklose", STYLE);
-            mucklose_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    player_.setAskShowLosing(!mucklose_.isSelected());
-                    getTD().playerUpdate(player_, player_.getOnlineSettings());
-                }
+            mucklose_.addActionListener(e -> {
+                player_.setAskShowLosing(!mucklose_.isSelected());
+                getTD().playerUpdate(player_, player_.getOnlineSettings());
             });
             base_.add(mucklose_);
 
             muckwin_ = new DDCheckBox("muckwin", STYLE);
-            muckwin_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    player_.setAskShowWinning(!muckwin_.isSelected());
-                    getTD().playerUpdate(player_, player_.getOnlineSettings());
-                }
+            muckwin_.addActionListener(e -> {
+                player_.setAskShowWinning(!muckwin_.isSelected());
+                getTD().playerUpdate(player_, player_.getOnlineSettings());
             });
             base_.add(muckwin_);
         }
@@ -217,13 +203,8 @@ public class OnlineDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = new Runnable()
-                        {
-                            public void run()
-                            {
-                                updateAll();
-                            }
-                        };
+    private Runnable updateRunner_ = () ->
+        updateAll();
 
     ///
     /// display logic

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/PlayerInfo.java
@@ -126,16 +126,12 @@ public class PlayerInfo extends DashboardItem implements TerritorySelectionListe
 
     // these arrive on the game's thread, not the swing one - unlike the table events,
     // which the superclass already delivers in swing.  We set label text directly.
-    private final Runnable updateInfoRunner_ = new Runnable()
-    {
-        public void run()
-        {
-            // invoke() is invokeLater from the game's thread, so the game can be torn
-            // down before we run: finish() clears players_ and the rank lookup then
-            // throws.  isDisplayed() is no help - bUiCreated_ is never reset - so this
-            // is the same guard updateAll() uses, for the same reason.
-            if (!game_.isFinished()) updateInfo();
-        }
+    private final Runnable updateInfoRunner_ = () -> {
+        // invoke() is invokeLater from the game's thread, so the game can be torn
+        // down before we run: finish() clears players_ and the rank lookup then
+        // throws.  isDisplayed() is no help - bUiCreated_ is never reset - so this
+        // is the same guard updateAll() uses, for the same reason.
+        if (!game_.isFinished()) updateInfo();
     };
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
@@ -243,13 +243,9 @@ public class Rank extends DashboardItem
     private String sRank_;
 
     // runnable for setting label text in swing thread
-    private Runnable setLabelRunner_ = new Runnable()
-    {
-        public void run()
-        {
-            labelInfo_.setText(sTextToUpdate_);
-            setTitle(getTitle());
-        }
+    private Runnable setLabelRunner_ = () -> {
+        labelInfo_.setText(sTextToUpdate_);
+        setTitle(getTitle());
     };
 
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
@@ -57,8 +57,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
@@ -201,19 +199,16 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
 
         // clear button
         GlassButton clear = new GlassButton("chat.clear", "Glass");
-        clear.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
+        clear.addActionListener(e -> {
+            if (center_ == tab_)
             {
-                if (center_ == tab_)
-                {
-                    ChatTab tab = (ChatTab) tab_.getSelectedComponent();
-                    tab.chatList.removeAllItems();
-                }
-                else
-                {
-                    chatList_[0].removeAllItems();
-                    if (chatList_[1] != null) chatList_[1].removeAllItems();
-                }
+                ChatTab tab = (ChatTab) tab_.getSelectedComponent();
+                tab.chatList.removeAllItems();
+            }
+            else
+            {
+                chatList_[0].removeAllItems();
+                if (chatList_[1] != null) chatList_[1].removeAllItems();
             }
         });
 
@@ -238,14 +233,11 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
 
             // send button
             GlassButton send = new GlassButton("chat.send", "Glass");
-            send.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e)
+            send.addActionListener(e -> {
+                // make sure we have something to send
+                if (msg_.isValidData())
                 {
-                    // make sure we have something to send
-                    if (msg_.isValidData())
-                    {
-                        sendChat();
-                    }
+                    sendChat();
                 }
             });
             msg_.setDefaultOverride(send);
@@ -258,14 +250,11 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
                 {
                     // send button
                     GlassButton sendall = new GlassButton("chat.sendall", "Glass");
-                    sendall.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e)
+                    sendall.addActionListener(e -> {
+                        // make sure we have something to send
+                        if (msg_.isValidData())
                         {
-                            // make sure we have something to send
-                            if (msg_.isValidData())
-                            {
-                                sendChatAll();
-                            }
+                            sendChatAll();
                         }
                     });
                     buttonbase.add(sendall);
@@ -274,14 +263,11 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
                 {
                     // send button
                     GlassButton sendhost = new GlassButton("chat.sendhost", "Glass");
-                    sendhost.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e)
+                    sendhost.addActionListener(e -> {
+                        // make sure we have something to send
+                        if (msg_.isValidData())
                         {
-                            // make sure we have something to send
-                            if (msg_.isValidData())
-                            {
-                                sendChatPrivate(PokerPlayer.HOST_ID);
-                            }
+                            sendChatPrivate(PokerPlayer.HOST_ID);
                         }
                     });
                     buttonbase.add(sendhost);
@@ -300,37 +286,27 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
                 startTest_ = new GlassButton(GuiManager.DEFAULT, "Glass");
                 startTest_.setText("Start");
                 buttonbase.add(startTest_);
-                startTest_.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        startTest_.setEnabled(false);
-                        stopTest_.setEnabled(true);
-                        startTest();
-                    }
+                startTest_.addActionListener(e -> {
+                    startTest_.setEnabled(false);
+                    stopTest_.setEnabled(true);
+                    startTest();
                 });
 
                 stopTest_ = new GlassButton(GuiManager.DEFAULT, "Glass");
                 stopTest_.setText("Stop");
                 stopTest_.setEnabled(false);
                 buttonbase.add(stopTest_);
-                stopTest_.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        startTest_.setEnabled(true);
-                        stopTest_.setEnabled(false);
-                        stopTest();
-                    }
+                stopTest_.addActionListener(e -> {
+                    startTest_.setEnabled(true);
+                    stopTest_.setEnabled(false);
+                    stopTest();
                 });
 
                 GlassButton dump = new GlassButton(GuiManager.DEFAULT, "Glass");
                 dump.setText("Dump");
                 buttonbase.add(dump);
-                dump.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        logger.debug("Thread dump:\n" + Utils.getAllStacktraces());
-                    }
-                });
+                dump.addActionListener(e ->
+                    logger.debug("Thread dump:\n" + Utils.getAllStacktraces()));
             }
         }
         else
@@ -356,15 +332,12 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
         if (!profile.isActivated()) return;
 
         GlassButton lobby = new GlassButton("chat.lobby", "Glass");
-        lobby.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e)
-                {
-                    if (OnlineLobby.showLobby(GameEngine.getGameEngine(), context_, PlayerProfileOptions.getDefaultProfile()))
-                    {
-                        context_.processPhase("OnlineLobby");
-                    }
-                }
-            });
+        lobby.addActionListener(e -> {
+            if (OnlineLobby.showLobby(GameEngine.getGameEngine(), context_, PlayerProfileOptions.getDefaultProfile()))
+            {
+                context_.processPhase("OnlineLobby");
+            }
+        });
         buttonbase.add(lobby);
     }
 
@@ -457,12 +430,8 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
 
         // close button
         GlassButton close = new GlassButton("close", "Glass");
-        close.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e)
-            {
-                context.close();
-            }
-        });
+        close.addActionListener(e ->
+            context.close());
 
         add(GuiUtils.CENTER(close), BorderLayout.SOUTH);
         revalidate();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostPauseDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostPauseDialog.java
@@ -74,12 +74,8 @@ public class HostPauseDialog extends DialogPhase
     {
         if (impl_ != null && impl_.bAutoClose_)
         {
-            GuiUtils.invoke(new Runnable() {
-                public void run()
-                {
-                    impl_.removeDialog();
-                }
-            });
+            GuiUtils.invoke(() ->
+                impl_.removeDialog());
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
@@ -53,8 +53,6 @@ import org.apache.logging.log4j.Logger;
 
 import javax.swing.ImageIcon;
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * Created by IntelliJ IDEA.
@@ -107,16 +105,12 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
         base.add(status_, BorderLayout.CENTER);
 
         details_ = new DDCheckBox("showdetails2", STYLE);
-        details_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        details_.addActionListener(e -> {
+            if (!details_.isSelected())
             {
-                if (!details_.isSelected())
+                if (error_ != null)
                 {
-                    if (error_ != null)
-                    {
-                        error_.removeDialog();
-                    }
+                    error_.removeDialog();
                 }
             }
         });
@@ -143,13 +137,10 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
     {
         if (PokerUtils.getPokerGameboard() != null)
         {
-            GuiUtils.invoke(new Runnable() {
-                public void run()
-                {
-                    game_.setInputMode(PokerTableInput.MODE_QUITSAVE);
-                    PokerUtils.clearCards(true);
-                    PokerUtils.clearResults(game_.getGameContext(), true);
-                }
+            GuiUtils.invoke(() -> {
+                game_.setInputMode(PokerTableInput.MODE_QUITSAVE);
+                PokerUtils.clearCards(true);
+                PokerUtils.clearResults(game_.getGameContext(), true);
             });
         }
     }
@@ -159,12 +150,8 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
      */
     private void updateStatusInSwing()
     {
-        GuiUtils.invoke(new Runnable() {
-            public void run()
-            {
-                updateStatus(false);
-            }
-        });
+        GuiUtils.invoke(() ->
+            updateStatus(false));
     }
 
     /**
@@ -233,15 +220,12 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
         {
             if (nAttempts_ == 0)
             {
-                GuiUtils.invokeAndWait(new Runnable() {
-                    public void run()
-                    {
-                        DDMessage init = new DDMessage();
-                        init.setStatus(DDMessageListener.STATUS_APPL_ERROR);
-                        init.setApplicationErrorMessage(PropertyConfig.getMessage(
-                                bInGame_ ? "msg.msgerror.disconnect.p2p.game" : "msg.msgerror.disconnect.p2p.lobby"));
-                        handleError(init, false);
-                    }
+                GuiUtils.invokeAndWait(() -> {
+                    DDMessage init = new DDMessage();
+                    init.setStatus(DDMessageListener.STATUS_APPL_ERROR);
+                    init.setApplicationErrorMessage(PropertyConfig.getMessage(
+                        bInGame_ ? "msg.msgerror.disconnect.p2p.game" : "msg.msgerror.disconnect.p2p.lobby"));
+                    handleError(init, false);
                 });
             }
             Utils.sleepMillis(nAttempts_ == 0 ? 1000 : 5000);
@@ -252,28 +236,25 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
             // if aborting, continue
             if (bAbort_) continue;
 
-            GuiUtils.invokeAndWait(new Runnable() {
-                public void run()
-                {
-                    if (game_.getOnlineMode() == PokerGame.MODE_CANCELLED) bAbort_ = true;
+            GuiUtils.invokeAndWait(() -> {
+                if (game_.getOnlineMode() == PokerGame.MODE_CANCELLED) bAbort_ = true;
 
-                    if (bAbort_) return;
-                    status_.setIcon(YELLOWLED);
-                    logger.debug("Attempting to reconnect...");
-                    Object o = mgr_.joinGame(local_.isObserver(), true, false);
-                    nAttempts_++;
-                    if (o == Boolean.TRUE)
-                    {
-                        DDMessage reconnect = new DDMessage();
-                        reconnect.setStatus(DDMessageListener.STATUS_OK);
-                        handleError(reconnect, false);
-                        bReconnected_ = true;
-                    }
-                    else
-                    {
-                        status_.setIcon(REDLED);
-                        if (o instanceof DDMessage) handleError((DDMessage) o, true);
-                    }
+                if (bAbort_) return;
+                status_.setIcon(YELLOWLED);
+                logger.debug("Attempting to reconnect...");
+                Object o = mgr_.joinGame(local_.isObserver(), true, false);
+                nAttempts_++;
+                if (o == Boolean.TRUE)
+                {
+                    DDMessage reconnect = new DDMessage();
+                    reconnect.setStatus(DDMessageListener.STATUS_OK);
+                    handleError(reconnect, false);
+                    bReconnected_ = true;
+                }
+                else
+                {
+                    status_.setIcon(REDLED);
+                    if (o instanceof DDMessage) handleError((DDMessage) o, true);
                 }
             });
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/JoinGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/JoinGame.java
@@ -56,8 +56,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.util.List;
 
@@ -96,18 +94,14 @@ public class JoinGame extends ListGames
         pub.add(inside, BorderLayout.CENTER);
 
         GlassButton find = new GlassButton("okayfind", "Glass");
-        find.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        find.addActionListener(e -> {
+            if (engine_.isDemo())
             {
-                if (engine_.isDemo())
-                {
-                    EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.playerprofile.demo2"));
-                }
-                else
-                {
-                    context_.processPhase("FindGames");
-                }
+                EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.playerprofile.demo2"));
+            }
+            else
+            {
+                context_.processPhase("FindGames");
             }
         });
         inside.add(find, BorderLayout.WEST);
@@ -453,13 +447,11 @@ public class JoinGame extends ListGames
 
             // run in swing thread
             SwingUtilities.invokeLater(
-                new Runnable() {
-                    public void run() {
-                        String sKey = getSelectedRowKey();
-                        getClientList();
-                        fireTableDataChanged();
-                        selectRow(sKey);
-                    }
+                () -> {
+                    String sKey = getSelectedRowKey();
+                    getClientList();
+                    fireTableDataChanged();
+                    selectRow(sKey);
                 }
             );
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
@@ -144,25 +144,21 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
         connectText_.addPropertyChangeListener("value", this);
         connectLabel_ = w.label;
         pubPaste_ = w.button;
-        pubPaste_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        pubPaste_.addActionListener(e -> {
+            Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
+            Transferable value = clip.getContents(null);
+            if (value.isDataFlavorSupported(DataFlavor.stringFlavor))
             {
-                Clipboard clip = Toolkit.getDefaultToolkit().getSystemClipboard();
-                Transferable value = clip.getContents(null);
-                if (value.isDataFlavorSupported(DataFlavor.stringFlavor))
+                try
                 {
-                    try
+                    String s = (String) value.getTransferData(DataFlavor.stringFlavor);
+                    if (s != null)
                     {
-                        String s = (String) value.getTransferData(DataFlavor.stringFlavor);
-                        if (s != null)
-                        {
-                            connectText_.setText(s);
-                        }
+                        connectText_.setText(s);
                     }
-                    catch (Throwable ignored)
-                    {
-                    }
+                }
+                catch (Throwable ignored)
+                {
                 }
             }
         });
@@ -295,13 +291,9 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
         public void run()
         {
             Utils.sleepMillis(500);
-            SwingUtilities.invokeLater(new Runnable()
-            {
-                public void run()
-                {
-                    button.setEnabled(true);
-                    button.doClick();
-                }
+            SwingUtilities.invokeLater(() -> {
+                button.setEnabled(true);
+                button.doClick();
             });
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
@@ -534,13 +534,8 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
      */
     public void propertyChange(PropertyChangeEvent evt)
     {
-        SwingUtilities.invokeLater(new Runnable()
-        {
-            public void run()
-            {
-                updateProfileData();
-            }
-        });
+        SwingUtilities.invokeLater(() ->
+            updateProfileData());
     }
 
     /**
@@ -867,11 +862,8 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
                 }
 
                 // table changed
-                GuiUtils.invoke(new Runnable() {
-                    public void run() {
-                        fireTableDataChanged();
-                    }
-                });
+                GuiUtils.invoke(() ->
+                    fireTableDataChanged());
             }
         }
     }
@@ -961,11 +953,8 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
                 {
                     AudioConfig.playFX("observerjoin");
                 }
-                GuiUtils.invoke(new Runnable() {
-                    public void run() {
-                        fireTableDataChanged();
-                    }
-                });
+                GuiUtils.invoke(() ->
+                    fireTableDataChanged());
             }
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineConfiguration.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineConfiguration.java
@@ -56,8 +56,6 @@ import org.apache.logging.log4j.Logger;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
@@ -171,22 +169,13 @@ public class OnlineConfiguration extends BasePhase implements PropertyChangeList
         ippub.add(pbox, BorderLayout.NORTH);
         configurePublic_ = new DDCheckBox("publicgame", STYLE);
         configurePublic_.setSelected(false);
-        configurePublic_.addChangeListener(new ChangeListener()
-        {
-            public void stateChanged(ChangeEvent e)
+        configurePublic_.addChangeListener(e ->
+            doCheckBox());
+        configurePublic_.addActionListener(e -> {
+            if (configurePublic_.isSelected())
             {
-                doCheckBox();
-            }
-        });
-        configurePublic_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                if (configurePublic_.isSelected())
-                {
-                    String sMsg = PropertyConfig.getMessage("msg.publicip.notice", "" + game_.getPort());
-                    EngineUtils.displayInformationDialog(context_, sMsg, "PublicIP");
-                }
+                String sMsg = PropertyConfig.getMessage("msg.publicip.notice", "" + game_.getPort());
+                EngineUtils.displayInformationDialog(context_, sMsg, "PublicIP");
             }
         });
         pbox.add(configurePublic_, BorderLayout.WEST);
@@ -213,13 +202,8 @@ public class OnlineConfiguration extends BasePhase implements PropertyChangeList
 
         test_ = new GlassButton("testip", "Glass");
         pubbuttons.add(test_);
-        test_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
-                testConnection();
-            }
-        });
+        test_.addActionListener(e ->
+            testConnection());
 
         ////// BOTTOM
         DDPanel bottom = new DDPanel();
@@ -266,15 +250,11 @@ public class OnlineConfiguration extends BasePhase implements PropertyChangeList
         listPublic_.setSelected(false);
 
         // shouldn't happen unless player copies a player profile file over
-        listPublic_.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
+        listPublic_.addActionListener(e -> {
+            if (listPublic_.isSelected() && engine_.isDemo())
             {
-                if (listPublic_.isSelected() && engine_.isDemo())
-                {
-                    EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.playerprofile.demo"));
-                    listPublic_.setSelected(false);
-                }
+                EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.playerprofile.demo"));
+                listPublic_.setSelected(false);
             }
         });
         gbox.add(listPublic_, BorderLayout.SOUTH);
@@ -352,13 +332,8 @@ public class OnlineConfiguration extends BasePhase implements PropertyChangeList
         {
             DDButton copy = new GlassButton("publicip", "Glass");
             panel.add(GuiUtils.CENTER(copy), BorderLayout.EAST);
-            copy.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    getPublicIP();
-                }
-            });
+            copy.addActionListener(e ->
+                getPublicIP());
             w.button = copy;
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
@@ -277,12 +277,8 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
                 case PokerConstants.CHAT_ADMIN_ERROR:
                     // alter chat window
                     SwingUtilities.invokeLater(
-                        new Runnable() {
-                            public void run()
-                            {
-                                chat_.removeBottomControls(context_);
-                            }
-                        }
+                        () ->
+                            chat_.removeBottomControls(context_)
                     );
                     break;
             }
@@ -382,11 +378,8 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
             Collections.sort(list);
 
             // table changed
-            GuiUtils.invoke(new Runnable() {
-                public void run() {
-                    fireTableDataChanged();
-                }
-            });
+            GuiUtils.invoke(() ->
+                fireTableDataChanged());
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
@@ -1076,20 +1076,16 @@ public class OnlineManager implements ChatManager
 
         // need to update from Swing thread
         SwingUtilities.invokeLater(
-                new Runnable()
-                {
-                    public void run()
-                    {
-                        String sKey = bBan ? "msg.cancel.client.ban" :
-                                      game_.isInProgress() ? "msg.cancel.client.play" :
-                                      "msg.cancel.client.reg";
+            () -> {
+                String sKey = bBan ? "msg.cancel.client.ban" :
+                    game_.isInProgress() ? "msg.cancel.client.play" :
+                        "msg.cancel.client.reg";
 
-                        PokerPlayer host = getHost();
-                        EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage(sKey,
-                                                                                                 Utils.encodeHTML(host.getName())));
-                        context_.restart();
-                    }
-                }
+                PokerPlayer host = getHost();
+                EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage(sKey,
+                    Utils.encodeHTML(host.getName())));
+                context_.restart();
+            }
         );
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
@@ -348,15 +348,11 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
 
                 // show error dialog to user and restart
                 SwingUtilities.invokeLater(
-                        new Runnable()
-                        {
-                            public void run()
-                            {
-                                EngineUtils.displayInformationDialog(context_, Utils.fixHtmlTextFor15(
-                                        PropertyConfig.getMessage("msg.tderror")));
-                                context_.restart();
-                            }
-                        }
+                    () -> {
+                        EngineUtils.displayInformationDialog(context_, Utils.fixHtmlTextFor15(
+                            PropertyConfig.getMessage("msg.tderror")));
+                        context_.restart();
+                    }
                 );
             }
 

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -78,12 +78,13 @@ type: specs.openrewrite.org/v1beta/recipe
 name: com.donohoedigital.Lambdas
 displayName: Lambdas and method references
 description: >
-  Replace anonymous implementations of functional interfaces with lambdas, and lambdas
-  that merely delegate with method references. Mostly Swing listeners in gui/ and poker/.
-  Anonymous classes that hold state or reference the enclosing instance are left alone.
+  Replace anonymous implementations of functional interfaces with lambdas.  Mostly Swing
+  listeners and Runnables in poker/ and gameengine/.  Anonymous classes that hold state or
+  refer to the enclosing instance via a bare "this" are left alone - "this" means the
+  anonymous instance inside an anonymous class but the enclosing one inside a lambda.
+  NOTE: ReplaceLambdaWithMethodReference is NOT here - see MethodReferences below.
 recipeList:
   - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
-  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
   - org.openrewrite.staticanalysis.LambdaBlockToExpression
 
 ---
@@ -200,3 +201,18 @@ styleConfigs:
         - import all other imports
         - <blank line>
         - import static all other imports
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: com.donohoedigital.MethodReferences
+displayName: Method references
+description: >
+  Replace lambdas that merely delegate with method references, e.g. () -> updateAll()
+  becomes this::updateAll.
+  REVIEW EVERY CHANGE.  This recipe confuses a superclass with an enclosing class.  In
+  gameengine/SendMessageDialog.java, which extends DialogPhase, it emitted
+  "DialogPhase.this::removeDialog" - illegal, because DialogPhase is a supertype rather
+  than an enclosing instance, and the gameengine module stopped compiling.  Kept opt-in
+  for that reason.
+recipeList:
+  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference


### PR DESCRIPTION
PR 4 of the modernization series.

Applied with `mvn rewrite:run -Drewrite.activeRecipes=com.donohoedigital.Lambdas`.

**68 files, +684/−1393** — net 700 fewer lines. 123 conversions, mostly Swing
`ActionListener`s and `Runnable`s passed to `SwingUtilities.invokeLater`, in `poker` (53
files), `gameengine` (12), `gui` (2), `gametools` (1).

```diff
-registerButton_.addActionListener(new ActionListener()
-{
-    public void actionPerformed(ActionEvent e)
-    {
-        activate();
-    }
-});
+registerButton_.addActionListener(e -> activate());
```

## The `this` hazard

Inside an anonymous class, a **bare** `this` is the anonymous instance. Inside a lambda it is
the *enclosing* instance. Converting a body that uses bare `this` silently changes what it
refers to — it still compiles, and nothing in the test suite would catch it. That is the real
hazard, and I verified **no converted body references `this` in either form**.

A **qualified** `Foo.this` is not a hazard: it means the enclosing instance in both
constructions, so those sites are safe to convert. 55 sites in the code base use that form and
the recipe skipped them anyway — conservatively, not because they were dangerous.

| | anonymous class | lambda |
|---|---|---|
| `this` | the listener instance | the enclosing instance |
| `Foo.this` | the enclosing instance | the enclosing instance |

One such skipped site is the `DDTable` export listener
(`gui/DDTable.java:199`, the Export entry in a table's right-click menu, which passes
`DDTable.this` to `DDTable.Exporter`). Its actual blocker is unrelated to `this`: the
anonymous `actionPerformed(ActionEvent e)` **shadows** the enclosing
`mouseReleased(MouseEvent e)`. An anonymous class body opens a new scope so that is legal, but
a lambda shares the enclosing scope, so `e -> ...` would not compile. OpenRewrite will not
invent a replacement parameter name, so it skips. IntelliJ offers the same fix with the
parameter renamed to `e1`.

Roughly 41 anonymous implementations remain for that reason. They are being handled separately
as a hand-applied PR, since no recipe covers them.

## `ReplaceLambdaWithMethodReference` pulled from this group

It confuses a superclass with an enclosing class. In `gameengine/SendMessageDialog.java`,
which `extends DialogPhase`, it emitted `DialogPhase.this::removeDialog` — illegal, because
`DialogPhase` is a supertype, not an enclosing instance. The `gameengine` module stopped
compiling.

Moved to an opt-in `com.donohoedigital.MethodReferences` recipe with the failure documented.
That costs 14 method references and keeps all 123 lambda conversions.

## Imports

62 removed, 5 added — all legitimate. `ActionListener`/`ActionEvent` become unused precisely
*because* their anonymous classes are gone. Two files drop a star import because a conversion
took their usage count below the 5-class collapse threshold.

Worth noting this is PR #236 paying off: before import normalization, this same change carried
**+376 import lines across 65 of 68 files**. Now the diff is the lambda work and nothing else.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- **Idempotent** — re-running produces no patch
- No converted body references `this`
- **Smoke test:** `poker` launches clean — ran 45s, **zero exceptions**, database loaded,
  multicast up, clean shutdown. This exercises UI construction, where all 123 listener
  attachments execute, so a broken lambda would throw at startup.

**Smoke test scope:** startup only. I can't drive the UI, so the interactive paths — dealing a
hand, the options dialog, right-clicking a table — are unverified. Worth a manual pass before
merging, as you did for PR #235.
