### PR TITLE
Modernize string and collection API usage

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/Base64.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Base64.java
@@ -1,5 +1,7 @@
 package com.donohoedigital.base;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Encodes and decodes to and from Base64 notation.
  *
@@ -765,7 +767,7 @@ public class Base64
         }   // end try
         catch( java.io.UnsupportedEncodingException uee )
         {
-            bytes = s.getBytes();
+            bytes = s.getBytes(StandardCharsets.UTF_8);
         }   // end catch
 		//</change>
         
@@ -1341,7 +1343,7 @@ public class Base64
     
     public static void main(String[] s)
     {
-        System.out.println(s[0] +" equals " + Base64.encodeBytes(s[0].getBytes()));
+        System.out.println(s[0] +" equals " + Base64.encodeBytes(s[0].getBytes(StandardCharsets.UTF_8)));
     }
     
 }   // end class Base64

--- a/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
+++ b/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
@@ -18,6 +18,7 @@
  */
 package com.donohoedigital.base;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -178,7 +179,7 @@ public class RandomGUID extends Object
             sbValueBeforeMD5.append(Long.toString(rand));
 
             valueBeforeMD5 = sbValueBeforeMD5.toString();
-            md5.update(valueBeforeMD5.getBytes());
+            md5.update(valueBeforeMD5.getBytes(StandardCharsets.UTF_8));
 
             byte[] array = md5.digest();
             StringBuilder sb = new StringBuilder();

--- a/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
@@ -38,6 +38,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -337,6 +338,6 @@ public class SecurityUtils
      */
     public static String getMD5Hash(String s, byte[] key)
     {
-        return hash(s.getBytes(), key, "MD5");
+        return hash(s.getBytes(StandardCharsets.UTF_8), key, "MD5");
     }
 }

--- a/code/common/src/main/java/com/donohoedigital/comms/DDHttpClient.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDHttpClient.java
@@ -51,6 +51,7 @@ import java.io.OutputStream;
 import java.net.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -290,7 +291,7 @@ public class DDHttpClient
             if (options_.sUsername != null && options_.sPassword != null)
             {
                 String sEncode = options_.sUsername + ':' + options_.sPassword;
-                sEncode = Base64.encodeBytes(sEncode.getBytes());
+                sEncode = Base64.encodeBytes(sEncode.getBytes(StandardCharsets.UTF_8));
                 sb.append("Authorization: Basic ").append(sEncode).append(CRLF);
             }
 

--- a/code/common/src/main/java/com/donohoedigital/comms/TokenizedList.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/TokenizedList.java
@@ -103,7 +103,7 @@ public class TokenizedList implements DataMarshal
      */
     private Object nextToken(Class<?> cExpected)
     {
-        ApplicationError.assertTrue(tokens_.size() > 0, "No tokens left");
+        ApplicationError.assertTrue(!tokens_.isEmpty(), "No tokens left");
         Object o = tokens_.remove(0);
         if (o == null) return null;
         ApplicationError.assertTrue(cExpected.isAssignableFrom(o.getClass()), "Next token wrong type", o.getClass().getName());
@@ -115,7 +115,7 @@ public class TokenizedList implements DataMarshal
      */
     public Object peekToken()
     {
-        ApplicationError.assertTrue(tokens_.size() > 0, "No tokens left");
+        ApplicationError.assertTrue(!tokens_.isEmpty(), "No tokens left");
         return tokens_.get(0);
     }
     
@@ -124,7 +124,7 @@ public class TokenizedList implements DataMarshal
      */
     public boolean hasMoreTokens()
     {
-        return(tokens_.size() > 0);
+        return(!tokens_.isEmpty());
     }
     
     /**

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/BorderPoint.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/BorderPoint.java
@@ -212,7 +212,7 @@ public class BorderPoint extends MapPoint
     public Border getCurrentBorder()
     {
         // if no border set, but we have borders, return 1st border
-        if (bCurrentBorder_ == null && myBorders_.size() > 0)
+        if (bCurrentBorder_ == null && !myBorders_.isEmpty())
         {
             bCurrentBorder_ = myBorders_.getBorder(0);
         }

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
@@ -181,7 +181,7 @@ public class Borders extends TreeSet<Border> {
         {
             border = iter.next();
             // don't bother writing out if not 1 point in the border
-            if (border.getBorderPoints().size() > 0)
+            if (!border.getBorderPoints().isEmpty())
             {
                 //sName = border.getTerritory1().getName() + "." + border.getTerritory2().getName() + ".xml";
                 //sName = sName.replace(' ', '_');

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
@@ -262,7 +262,7 @@ public class GameState extends MsgState implements SaveFile
      */
     public void resetAfterRead(boolean bCheckEmpty)
     {
-        if (bCheckEmpty && entries_.size() > 0)
+        if (bCheckEmpty && !entries_.isEmpty())
         {
             logger.warn("GameState resetAfterRead: " + sName_ + ": has " + entries_.size() + " entries left.");
             for (int i = 0; i < entries_.size(); i++)
@@ -551,7 +551,7 @@ public class GameState extends MsgState implements SaveFile
      */
     public GameStateEntry removeEntry()
     {
-        ApplicationError.assertTrue(entries_.size() > 0, "No more entries");
+        ApplicationError.assertTrue(!entries_.isEmpty(), "No more entries");
         return entries_.remove(0);
     }
     
@@ -560,7 +560,7 @@ public class GameState extends MsgState implements SaveFile
      */
     public GameStateEntry peekEntry()
     {
-        if (entries_.size() == 0) return null;
+        if (entries_.isEmpty()) return null;
         return entries_.get(0);
     }
     

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Territory.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Territory.java
@@ -601,7 +601,7 @@ public class Territory implements GamePieceContainer, ObjectID, Comparable
 
         
         // points
-        if (myPoints_ != null && myPoints_.size() > 0)
+        if (myPoints_ != null && !myPoints_.isEmpty())
         {
             writer.printElementCloseLine();
             int nSize = myPoints_.size();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Token.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Token.java
@@ -123,7 +123,7 @@ public class Token
      */
     public TokenAction getLastAction()
     {
-        if (actionHistory_.size() == 0) return null;
+        if (actionHistory_.isEmpty()) return null;
         
         return (TokenAction) actionHistory_.get(actionHistory_.size() - 1);
     }
@@ -151,7 +151,7 @@ public class Token
      */
     public TokenAction removeLastAction()
     {
-        if (actionHistory_.size() == 0) return null;
+        if (actionHistory_.isEmpty()) return null;
         
         TokenAction action = getLastAction();
         if (action != null)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -658,7 +658,7 @@ public class EngineUtils
      */
     public synchronized static void cancelCancelables()
     {
-        if (cancelables_ == null || cancelables_.size() == 0) return;
+        if (cancelables_ == null || cancelables_.isEmpty()) return;
 
         // run in swing loop since possible closing dialogs
         GuiUtils.invoke(() ->

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -1088,7 +1088,7 @@ public abstract class GameEngine extends BaseApp
         boolean remove(GameContext context)
         {
             ApplicationError.assertTrue(contexts.remove(context), "Window not found in list", context.getWindow().getName());
-            return contexts.size() == 0;
+            return contexts.isEmpty();
         }
 
         // GameContext 1st window

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/PlayersDieRoll6x2.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/PlayersDieRoll6x2.java
@@ -138,7 +138,7 @@ public class PlayersDieRoll6x2 implements DataMarshal
         for (int i = 0; i < dieRolls.length; i++)
         {
             if (isPlayerEliminated(i)) continue;
-            if ((dieRolls[i].size() == 0) || (
+            if ((dieRolls[i].isEmpty()) || (
                         (dieRolls[i].size() >= nMinRolls) &&
                         ((DieRoll6x2)dieRolls[i].get(dieRolls[i].size() -1)).getSum() == nMax))
             {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ProfileList.java
@@ -400,7 +400,7 @@ public abstract class ProfileList extends DDPanel implements AWTEventListener, F
         checkButtons();
         
         // if no profiles, show msg
-        if (bFileMode_ && profilePanels_.size() == 0) {
+        if (bFileMode_ && profilePanels_.isEmpty()) {
             SwingUtilities.invokeLater(
                 () -> {
                     String sMsg = PropertyConfig.getMessage("msg.needprofile" + sMsgName_);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ScrollGameboard.java
@@ -1028,7 +1028,7 @@ public class ScrollGameboard extends JViewport implements
         panel.removeMouseWheelListener(handler_);
         handler_.init();
         topPanels_.pop();
-        if (topPanels_.size() > 0)
+        if (!topPanels_.isEmpty())
         {
             topPanel_ = topPanels_.peek();
         }
@@ -1042,7 +1042,7 @@ public class ScrollGameboard extends JViewport implements
      */
     public boolean isModalMode()
     {
-        return topPanels_.size() > 0;
+        return !topPanels_.isEmpty();
     }
     
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
@@ -241,7 +241,7 @@ public class UDPStatus extends BasePhase implements DDTable.TableMenuItems
         private void update()
         {
             // skip repaint if nothing changed
-            if (udp_ == null && list.size() == 0) return;
+            if (udp_ == null && list.isEmpty()) return;
 
             // get list
             list.clear();

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
@@ -146,7 +146,7 @@ public class PlayerQueue extends ServerDataFile
         // keep getting head of list (earlier messages are first)
         // remove from head of list as long as timestamp is less
         // than or equal to the given timestamp
-        while (!bDone && msgList_.size() > 0)
+        while (!bDone && !msgList_.isEmpty())
         {
             msg = (EngineMessage) msgList_.get(0);
             if (msg.getCreateTimeStamp() <= timestamp)

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
@@ -358,7 +358,7 @@ public class ServerSideGame extends ServerDataFile implements GameInfo
      */
     public ActionItem getLastActionItem()
     {
-        if (actionList_.size() == 0) return null;
+        if (actionList_.isEmpty()) return null;
         return (ActionItem) actionList_.get(actionList_.size() - 1);
     }
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/UpgradedKeyImplJpa.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/dao/impl/UpgradedKeyImplJpa.java
@@ -61,7 +61,7 @@ public class UpgradedKeyImplJpa extends JpaBaseDao<UpgradedKey, Long> implements
         query.setParameter("key", sKey);
 
         List<UpgradedKey> list = (List<UpgradedKey>) query.getResultList();
-        if (list.size() == 0) return null;
+        if (list.isEmpty()) return null;
         return list.get(0);
     }
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDComboBox.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDComboBox.java
@@ -244,7 +244,7 @@ public class DDComboBox extends JComboBox implements
 
         List<?> values = elem.getListValues();
 
-        if (values == null || values.size() == 0)
+        if (values == null || values.isEmpty())
         {
             logger.warn("DataElement " + elem.getName() + " has no list values");
             return;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipLeaderPanel.java
@@ -144,7 +144,7 @@ public class ChipLeaderPanel extends DDTabPanel
         setBorderLayoutGap(10,0);
 
         // current players
-        if (current.size() > 0)
+        if (!current.isEmpty())
         {
             DDPanel top = new DDPanel();
             top.setBorderLayoutGap(5, 10);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUpFinish.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ColorUpFinish.java
@@ -217,7 +217,7 @@ public class ColorUpFinish extends ChainPhase implements PlayerActionListener, R
             if (player == null) continue;
 
             // repaint players with non-empty hands
-            if (player.getHand().size() > 0)
+            if (!player.getHand().isEmpty())
             {
                 repaint(player);
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
@@ -591,9 +591,9 @@ public String getFileName() {
     {
         String sBreak = "<BR><BR>";
         String sDesc = Utils.encodeHTML(getDescription());
-        return (sDesc != null ? sDesc.replaceAll("\n", "<BR>\n") + sBreak : "") +
+        return (sDesc != null ? sDesc.replace("\n", "<BR>\n") + sBreak : "") +
                 "<DIV>" +
-                "<DDHANDGROUP CARDS=\"" + getSummary().replaceAll(" ", "") + "\">" +
+                "<DDHANDGROUP CARDS=\"" + getSummary().replace(" ", "") + "\">" +
                 "</DIV>";
     }
 
@@ -740,7 +740,7 @@ public String getFileName() {
 
         if (getClassCount() > 0)
         {
-            map_.setString("hands", getSummary().replaceAll(" ", "") + "|" + Integer.toString(getStrength()));
+            map_.setString("hands", getSummary().replace(" ", "") + "|" + Integer.toString(getStrength()));
         }
         else
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
@@ -270,7 +270,7 @@ public class HandHistoryPanel extends DDPanel
 
         handsList_.setItems(hands_);
 
-        if (hands_.size() == 0)
+        if (hands_.isEmpty())
         {
             titleLabel_.setText(PropertyConfig.getMessage("msg.nohistory"));
             pagingLabel_.setText("");
@@ -393,7 +393,7 @@ public class HandHistoryPanel extends DDPanel
             {
                 handHTML = hand.toHTML();
 
-                if (community.size() > 0)
+                if (!community.isEmpty())
                 {
                     info.getScore(hand, community);
                     handShown = "&nbsp;-&nbsp;" + info.toString(", ", false);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandInfo.java
@@ -1019,15 +1019,14 @@ public class HandInfo implements Comparable<HandInfo>
     {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("\n--- "+player_.getName()+" ---- " + all_ +"\n");
+        sb.append("\n--- ").append(player_.getName()).append(" ---- ").append(all_).append("\n");
 
         // normal to string
         sb.append(this);
         sb.append("\n");
 
         // suits
-        sb.append("Spades: " + nSpades_ + "  Hearts: " + nHearts_ +
-                "  Diamonds: " + nDiamonds_ + "  Clubs: " + nClubs_ + "\n");
+        sb.append("Spades: ").append(nSpades_).append("  Hearts: ").append(nHearts_).append("  Diamonds: ").append(nDiamonds_).append("  Clubs: ").append(nClubs_).append("\n");
 
         // ranks
         String sValue;
@@ -1047,18 +1046,18 @@ public class HandInfo implements Comparable<HandInfo>
         for (int i = 0; i < seq_.size(); i++)
         {
             seq = seq_.get(i);
-            sb.append("Seq " + (i+1) +": "+seq+"\n");
+            sb.append("Seq ").append(i + 1).append(": ").append(seq).append("\n");
         }
 
         // straight flush seq
         for (int i = 0; i < seqFlush_.size(); i++)
         {
             seq = seqFlush_.get(i);
-            sb.append("SeqFlush " + (i+1) +": "+seq+"\n");
+            sb.append("SeqFlush ").append(i + 1).append(": ").append(seq).append("\n");
         }
 
         // pairs, quads, trips
-        sb.append("Pairs: " + nPairs_ + "  Trips: " + nTrips_ + "  Quads: " + nQuads_);
+        sb.append("Pairs: ").append(nPairs_).append("  Trips: ").append(nTrips_).append("  Quads: ").append(nQuads_);
         return sb.toString();
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
@@ -231,7 +231,7 @@ public class HandLadder
         if (getHandRank() > 1)
         {
             buf.append("<tr>");
-            buf.append("<td><font color=\"white\"><b>Stronger Hands - " + PokerConstants.formatPercent(strongerPercent) + "%</b></font></td>");
+            buf.append("<td><font color=\"white\"><b>Stronger Hands - ").append(PokerConstants.formatPercent(strongerPercent)).append("%</b></font></td>");
             buf.append("<td align=\"right\"><font color=\"white\"><b>Count</b></font></td>");
             buf.append("<td align=\"right\"><font color=\"white\"><b>Probability</b></font></td>");
             buf.append("</tr>");
@@ -292,7 +292,7 @@ public class HandLadder
         if (getHandRank() < totalCount_)
         {
             buf.append("<tr>");
-            buf.append("<td><font color=\"white\"><b>Equal or Weaker Hands - " + PokerConstants.formatPercent(lessEqualPercent) + "%</b></font></td>");
+            buf.append("<td><font color=\"white\"><b>Equal or Weaker Hands - ").append(PokerConstants.formatPercent(lessEqualPercent)).append("%</b></font></td>");
             buf.append("<td align=\"right\"><font color=\"white\"><b>Count</b></font></td>");
             buf.append("<td align=\"right\"><font color=\"white\"><b>Probability</b></font></td>");
             buf.append("</tr>");

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfile.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfile.java
@@ -348,7 +348,7 @@ public class PlayerProfile extends BaseProfile
 
         List<TournamentHistory> history = getHistory();
         TournamentHistory hist;
-        if (history.size() == 0)
+        if (history.isEmpty())
         {
             return 0;
         }
@@ -374,7 +374,7 @@ public class PlayerProfile extends BaseProfile
 
         List<TournamentHistory> history = getHistory();
         TournamentHistory hist;
-        if (history.size() == 0)
+        if (history.isEmpty())
         {
             return 0;
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -208,7 +208,7 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
 
         // copy v2 changes
         File userSaveV3 = GameConfigUtils.getSaveDir();
-        File userSaveV2 = new File(userSaveV3.getAbsolutePath().replaceAll("poker3", "poker2"));
+        File userSaveV2 = new File(userSaveV3.getAbsolutePath().replace("poker3", "poker2"));
         if (userSaveV2.exists() && userSaveV2.isDirectory())
         {
             ConfigUtils.copyDir(userSaveV2, userSaveV3, new UpgradeFilter());

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandSelectionScheme.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/HandSelectionScheme.java
@@ -177,7 +177,7 @@ public class HandSelectionScheme extends BaseProfile
             HandGroup group = handgroups_.get(i);
 
             if (group.getClassCount() > 0) {
-                map_.setString("hands" + i, group.getSummary().replaceAll(" ", "") + "|" + Integer.toString(group.getStrength()));
+                map_.setString("hands" + i, group.getSummary().replace(" ", "") + "|" + Integer.toString(group.getStrength()));
             }
         }
 
@@ -251,7 +251,7 @@ public class HandSelectionScheme extends BaseProfile
         String sDesc = getDescription();
         if (sDesc != null)
         {
-            buf.append(Utils.encodeHTML(sDesc).replaceAll("\n", "<BR>\n"));
+            buf.append(Utils.encodeHTML(sDesc).replace("\n", "<BR>\n"));
             buf.append("<BR>");
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PlayerType.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PlayerType.java
@@ -323,7 +323,7 @@ public class PlayerType extends BaseProfile
 
         if (sDesc != null && sDesc.length() > 0)
         {
-            buf.append(Utils.encodeHTML(sDesc).replaceAll("\n", "<BR>\n"));
+            buf.append(Utils.encodeHTML(sDesc).replace("\n", "<BR>\n"));
             buf.append("<BR><BR>");
         }
 
@@ -482,7 +482,7 @@ public class PlayerType extends BaseProfile
         {
             List<BaseProfile> profiles = getProfileListCached(details);
 
-            if (profiles.size() == 0)
+            if (profiles.isEmpty())
             {
                 throw new ApplicationError("No computer player types defined!");
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
@@ -76,7 +76,7 @@ public class PocketScores
         }
 
         // compute fingerprint for flop - change triggers cache flush
-        long fpFlop = (community.size() == 0) ? 0 :
+        long fpFlop = (community.isEmpty()) ? 0 :
                       1L << community.getCard(0).getIndex() |
                       1L << community.getCard(1).getIndex() |
                       1L << community.getCard(2).getIndex();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
@@ -159,7 +159,7 @@ public class PocketWeights
 
         if (community == null) return 0.0f;
 
-        boolean preflop = (community.size() == 0);
+        boolean preflop = (community.isEmpty());
 
         PocketRanks ranks = null;
 
@@ -228,7 +228,7 @@ public class PocketWeights
     {
         Hand community = hhand_.getCommunity();
 
-        if (community.size() == 0)
+        if (community.isEmpty())
         {
             throw new ApplicationError("PocketWeights.getBiasedEffectiveHandStrength() called before the flop.");
         }
@@ -311,7 +311,7 @@ public class PocketWeights
     {
         Hand community = hhand_.getCommunity();
 
-        boolean bPreFlop = community.size() == 0;
+        boolean bPreFlop = community.isEmpty();
 
         PocketRanks ranks = null;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/V2Player.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/V2Player.java
@@ -336,7 +336,7 @@ public class V2Player extends V1Player implements AIConstants
 
         Hand community = new Hand(getCommunity()); // copy because we will be altering
 
-        if (community.size() == 0)
+        if (community.isEmpty())
         {
             return;
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
@@ -376,7 +376,7 @@ public class AdvanceAction extends DashboardItem implements ActionListener
      */
     public static HandAction getAdvanceAction()
     {
-        if (impl_ != null && impl_.buttons_.size() != 0)
+        if (impl_ != null && !impl_.buttons_.isEmpty())
         {
             HandAction action = impl_._getAdvanceAction();
             impl_.clearButtons();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
@@ -395,7 +395,7 @@ public class ImpExpParadise implements ImpExp
 
         buf.append(" | ");
 
-        if (ieHand.community.size() > 0)
+        if (!ieHand.community.isEmpty())
         {
             buf.append("Board: [");
             for (int i = 0; i < ieHand.community.size(); ++i)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpUB.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpUB.java
@@ -268,7 +268,7 @@ public class ImpExpUB implements ImpExp
 
         buf.append(newline);
 
-        if (ieHand.community.size() > 0)
+        if (!ieHand.community.isEmpty())
         {
             if (flop.length() == 0)
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
@@ -421,7 +421,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
     public void mouseReleased(MouseEvent e)
     {
         if (!GuiUtils.isPopupTrigger(e, false)) return;
-        if (getItems().size() == 0) return;
+        if (getItems().isEmpty()) return;
 
         DDPopupMenu menu = new DDPopupMenu();
 
@@ -494,16 +494,16 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
 
         // header
         StringBuilder sb = new StringBuilder("<HTML><HEAD><TITLE>");
-        sb.append("DD Poker Chat Export - " + sDate);
+        sb.append("DD Poker Chat Export - ").append(sDate);
         sb.append("</TITLE><BASE href=\"http://www.ddpoker.com/\"></HEAD><BODY>\n");
 
         // top table
         sb.append("<TABLE CELLSPACING=\"2\" CELLPADDING=\"0\"><TR>\n");
         sb.append("<TD><img src=\"images/pokericon32.jpg\">&nbsp;&nbsp;</TD><TD COLSPAN=2 style=\"font-size: 23px;\">DD Poker Chat Export</TD></TR>\n");
         sb.append("<TR><TD></TD><TD style=\"font-size: 15px;\"><B>Date:&nbsp;&nbsp;</B></TD>");
-        sb.append("<TD style=\"font-size: 15px;\">" + sDate + "</TD></TR>\n");
+        sb.append("<TD style=\"font-size: 15px;\">").append(sDate).append("</TD></TR>\n");
         sb.append("<TR><TD></TD><TD style=\"font-size: 15px;\"><B>Where:&nbsp;&nbsp;</B></TD>");
-        sb.append("<TD style=\"font-size: 15px;\">" + sDetails + "</TD></TR>\n");
+        sb.append("<TD style=\"font-size: 15px;\">").append(sDetails).append("</TD></TR>\n");
         sb.append("</TD></TR></TABLE><BR>");
 
         // chat
@@ -519,7 +519,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
             s = msg.sMsg;//html.getText();
 
             // <ddimg width="12" src="icon-small" yadj="-3" height="12">
-            s = s.replaceAll("ddimg", "img");
+            s = s.replace("ddimg", "img");
 
             // results piece (jpg)
             s = s.replaceAll("src=\"(results-[0-9a-zA-Z\\-]+)\"", "src=\"gamehelp/images/$1.jpg\"");
@@ -542,7 +542,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
 
         // hash
         String sHash = SecurityUtils.getMD5Hash(sb.toString(), PokerConstants.CHAT_BYTES);
-        sb.append("<!-- " + sHash + " -->");
+        sb.append("<!-- ").append(sHash).append(" -->");
 
         return sb.toString();
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManagerQueue.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManagerQueue.java
@@ -144,7 +144,7 @@ public class OnlineManagerQueue implements Runnable
         
         //logger.info("Shutting down OnlineMessageQueue...");
         ArrayList list = getMessageQueue();
-        if (list != null && list.size() > 0)
+        if (list != null && !list.isEmpty())
         {
             logger.warn("Left " + list.size() + " messages to send");
         }
@@ -258,7 +258,7 @@ public class OnlineManagerQueue implements Runnable
      */
     private synchronized ArrayList getMessageQueue()
     {
-        if (msgQ_.size() == 0) return null; // avoid new object if empty
+        if (msgQ_.isEmpty()) return null; // avoid new object if empty
         
         ArrayList list = msgQ_;
         msgQ_ = new ArrayList();
@@ -288,7 +288,7 @@ public class OnlineManagerQueue implements Runnable
 
         Qentry msg;
         int index = 0;
-        while (list.size() > 0)
+        while (!list.isEmpty())
         {
             msg = null;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/TournamentDirector.java
@@ -1654,7 +1654,7 @@ public class TournamentDirector extends BasePhase implements Runnable, GameManag
             OtherTables.consolidateTables(game_, tables);
 
             // safety check - can't have added players in addition to being removed
-            ApplicationError.assertTrue(!(table.getAddedList().size() > 0 && table.isRemoved()),
+            ApplicationError.assertTrue(!(!table.getAddedList().isEmpty() && table.isRemoved()),
                                         "Table removed but has players added", table);
 
             // if table was removed, we need to move observers

--- a/code/poker/src/main/java/com/zookitec/layout/ExplicitConstraints.java
+++ b/code/poker/src/main/java/com/zookitec/layout/ExplicitConstraints.java
@@ -604,7 +604,7 @@ public class ExplicitConstraints implements Serializable, Cloneable {
     }
 
     private String infiniteMsg(String attribute, ExplicitLayout layout) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Component [] components;
         int index;
         components = layout.getContainer().getComponents();

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/Hand.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/Hand.java
@@ -799,7 +799,7 @@ public class Hand extends DMArrayList<Card>
 
     public String toHTML()
     {
-        if (size() == 0) return "";
+        if (isEmpty()) return "";
 
         StringBuilder buf = new StringBuilder();
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/CryptoTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/CryptoTest.java
@@ -39,6 +39,8 @@
 package com.donohoedigital.proto.tests;
 
 
+import java.nio.charset.StandardCharsets;
+
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -64,7 +66,7 @@ public class CryptoTest {
         Cipher cipher = Cipher.getInstance("Blowfish");
         cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
         byte[] encrypted = 
-            cipher.doFinal("This is just an example".getBytes());
+            cipher.doFinal("This is just an example".getBytes(StandardCharsets.UTF_8));
         
         Cipher cipher2 = Cipher.getInstance("Blowfish");
         cipher2.init(Cipher.DECRYPT_MODE, skeySpec);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
@@ -159,7 +159,7 @@ public class Experiments
     public void testEncodeSlash()
     {
         String enc = "><//'>";
-        enc = enc.replaceAll("/", "&#47;");
+        enc = enc.replace("/", "&#47;");
         logger.debug("ENCODE: " + enc);
     }
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastSender.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastSender.java
@@ -36,6 +36,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 
 public class MulticastSender 
@@ -52,7 +53,7 @@ public class MulticastSender
 
 			// create a datagram with a suitable message
 			String str = "Hello from: "+InetAddress.getLocalHost();
-			byte[] data = str.getBytes();
+			byte[] data = str.getBytes(StandardCharsets.UTF_8);
 			DatagramPacket dp = new DatagramPacket(data, data.length, ia, recvPort);
 
 			// create a multicast socket bound to any local port
@@ -69,7 +70,7 @@ public class MulticastSender
             for (int i = 0; i < 1000; i++)
             {
                 sData = "Message " + i + "  stuff stuff asd sdfa asdf asdf as asasdf asdfsaf sadflj asfasasjflj";
-                dp.setData(sData.getBytes());
+                dp.setData(sData.getBytes(StandardCharsets.UTF_8));
                 ms.send(dp);
             }
             ms.setTimeToLive(ttl);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSender.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSender.java
@@ -37,6 +37,7 @@ import com.donohoedigital.base.Utils;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 
 public class UnicastSender 
@@ -53,7 +54,7 @@ public class UnicastSender
 
 			// create a datagram with a suitable message
 			String str = "Hello from: "+InetAddress.getLocalHost();
-			byte[] data = str.getBytes();
+			byte[] data = str.getBytes(StandardCharsets.UTF_8);
 			DatagramPacket dp = new DatagramPacket(data, data.length, ia, recvPort);
 
 			// create a socket bound to any local port
@@ -63,7 +64,7 @@ public class UnicastSender
             for (int i = 0; i < 1000; i++)
             {
                 sData = "Message " + i + "  stuff stuff asd sdfa asdf asdf as asasdf asdfsaf sadflj asfasasjflj";
-                dp.setData(sData.getBytes());
+                dp.setData(sData.getBytes(StandardCharsets.UTF_8));
                 ms.send(dp);
                 if (i % 25 == 0) Utils.sleepMillis(1);
             }

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
@@ -206,7 +206,7 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
                 for (int i = 0; i < nNum; i++)
                 {
                     sb.setLength(0);
-                    sb.append("This is message for the test server to process and handle and stuff " + (i + 1));
+                    sb.append("This is message for the test server to process and handle and stuff ").append(i + 1);
                     if (ADD_EXTRA)
                     {
                         sb.append(" ");

--- a/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
@@ -149,7 +149,7 @@ public class ThreadPool
         SocketThread worker = null;
 
         synchronized (idle_) {
-            if (idle_.size() > 0) {
+            if (!idle_.isEmpty()) {
                 worker = idle_.remove(0);
             }
         }

--- a/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
@@ -140,7 +140,7 @@ public class WorkerPool
         WorkerThread worker = null;
 
         synchronized (idle_) {
-            if (idle_.size() > 0) {
+            if (!idle_.isEmpty()) {
                 worker = (WorkerThread) idle_.remove(0);
             }
         }

--- a/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
@@ -43,6 +43,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -664,8 +665,8 @@ public class LoadGen
                     conn.setRequestMethod("POST");
                     conn.setRequestProperty("content-type", sPostContentType);
                     OutputStream o = conn.getOutputStream();
-                    o.write(sPost.getBytes());
-                    o.write("\n".getBytes()); // for War!
+                    o.write(sPost.getBytes(StandardCharsets.UTF_8));
+                    o.write("\n".getBytes(StandardCharsets.UTF_8)); // for War!
                     o.close();
                 }
 

--- a/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
@@ -51,6 +51,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class is for testing registrations through a proxy.  We configure
@@ -139,7 +140,7 @@ public class ProxySocketThread extends SocketThread implements PostWriter, DDMes
         // we send the entire buffer
         logger.debug("Sending DATA to " + proxy_ + " ->\n========= INPUT =========\n" + sData +
                        "=========  END  =========");
-        writer.write(sData.getBytes());
+        writer.write(sData.getBytes(StandardCharsets.UTF_8));
     }
 
     /** DDMessageListener - output progress **/

--- a/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
@@ -45,26 +45,20 @@ public class SchemaValidate extends DefaultHandler {
     /** Warning. */
     public void warning(SAXParseException ex) {
 
-        result.append("[Warning] "+
-                           getLocationString(ex)+": "+
-                           ex.getMessage() +  " \n");
+        result.append("[Warning] ").append(getLocationString(ex)).append(": ").append(ex.getMessage()).append(" \n");
     }
 
     /** Error. */
     public void error(SAXParseException ex) {
 
-        result.append("[Error] "+
-                           getLocationString(ex)+": "+
-                           ex.getMessage() + " " + "\n");
+        result.append("[Error] ").append(getLocationString(ex)).append(": ").append(ex.getMessage()).append(" " + "\n");
 //                           "\n at " + Utils.formatExceptionText(new Throwable()) + "\n");
     }
 
     /** Fatal error. */
     public void fatalError(SAXParseException ex) throws SAXException {
 
-        result.append("[Fatal Error] "+
-                           getLocationString(ex)+": "+
-                           ex.getMessage() + " \n");
+        result.append("[Fatal Error] ").append(getLocationString(ex)).append(": ").append(ex.getMessage()).append(" \n");
     }
 
     /** Returns a string of the location. */

--- a/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
@@ -102,7 +102,7 @@ public class IncomingQueue
     {
         synchronized(queue_)
         {
-            if (queue_.size() == 0) return false;
+            if (queue_.isEmpty()) return false;
             return (queue_.get(0).getID() - 1 != nLastProcessedID_);
         }
     }
@@ -185,7 +185,7 @@ public class IncomingQueue
             {
                 synchronized (queue_)
                 {
-                    if (queue_.size() == 0) return false;
+                    if (queue_.isEmpty()) return false;
 
                     // first item on queue must be next message in sequence
                     data = queue_.get(0);
@@ -216,7 +216,7 @@ public class IncomingQueue
                 // process data found (outside of sync loop)
                 nLastProcessedID_ += process_.size();
                 data = process_.remove(0);
-                if (process_.size() > 0)
+                if (!process_.isEmpty())
                 {
                     data.combine(process_);
                     process_.clear();

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
@@ -1486,9 +1486,7 @@ public class UDPLink
         public String toString()
         {
             StringBuilder sb = new StringBuilder();
-            sb.append("AVG: "+ getAverage() + ", OUT: " + dataOut +", RE: " + dataresend +
-                      ", IN: "+ dataIn + ", DUP: "+ dataDups +
-                      ", BIN: " + Utils.formatSizeBytes(bytesIn) + ", BOUT: "+ Utils.formatSizeBytes(bytesOut));
+            sb.append("AVG: ").append(getAverage()).append(", OUT: ").append(dataOut).append(", RE: ").append(dataresend).append(", IN: ").append(dataIn).append(", DUP: ").append(dataDups).append(", BIN: ").append(Utils.formatSizeBytes(bytesIn)).append(", BOUT: ").append(Utils.formatSizeBytes(bytesOut));
 
             return sb.toString();
         }

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
@@ -525,7 +525,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
         // cleanup links
         synchronized(links_)
         {
-            while (links_.size() > 0)
+            while (!links_.isEmpty())
             {
                 UDPLink link = links_.remove(0);
                 link.finish(false);

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -92,19 +92,24 @@ type: specs.openrewrite.org/v1beta/recipe
 name: com.donohoedigital.StringsAndCollections
 displayName: String and collection API modernization
 description: >
-  isEmpty() over size() == 0, contains() over indexOf(), constant-first equals(),
-  valueOf() over wrapper constructors, StringBuilder over StringBuffer, and friends.
+  isEmpty() over size() == 0, contains() over indexOf(), valueOf() over wrapper
+  constructors, StringBuilder over StringBuffer, explicit charsets, and friends.
+  NOT here, deliberately:
+  - EqualsAvoidsNull.  It rewrites sName.equals("foo") as "foo".equals(sName), which is
+    not behaviour preserving: a null receiver throws NPE today and would silently return
+    false afterwards.  86 sites across 42 files.  Rejected - we do not want Yoda
+    conditions in this code base, and an NPE on an unexpected null is worth seeing.
+  - UseListSort.  It rewrites Collections.sort(list) as list.sort(null); correct, since
+    null means natural ordering, but it reads worse than what it replaces.
 recipeList:
   - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
   - org.openrewrite.staticanalysis.IndexOfReplaceableByContains
-  - org.openrewrite.staticanalysis.EqualsAvoidsNull
   - org.openrewrite.staticanalysis.StringLiteralEquality
   - org.openrewrite.staticanalysis.NoValueOfOnStringType
   - org.openrewrite.staticanalysis.NoToStringOnStringType
   - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
   - org.openrewrite.staticanalysis.UseStandardCharset
   - org.openrewrite.staticanalysis.ExplicitCharsetOnStringGetBytes
-  - org.openrewrite.staticanalysis.UseListSort
   - org.openrewrite.staticanalysis.UseStringReplace
   - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
   - org.openrewrite.staticanalysis.ReplaceStringBufferWithStringBuilder


### PR DESCRIPTION
PR 5 of the modernization series.

Applied with `mvn rewrite:run -Drewrite.activeRecipes=com.donohoedigital.StringsAndCollections`.

**55 files, +108/−101.** Concentrated in `poker` (20), `gameengine` (6), `proto`/`gamecommon`/
`common` (5 each).

| Count | Change |
|------:|--------|
| 49 | `size() == 0` → `isEmpty()` |
| 22 | `getBytes()` → `getBytes(StandardCharsets.UTF_8)` |
| 9 | `replaceAll(literal)` → `replace(literal)` (no regex involved) |
| 1 | `StringBuffer` → `StringBuilder` |
| — | plus `indexOf`/`contains` and wrapper-constructor → `valueOf` |

## The charset changes are a no-op at runtime

These looked like the risky part — `Base64`, `DDHttpClient` and the UDP senders all put bytes
on the wire — so I checked each of the 22 individually.

`getBytes()` already resolves to UTF-8 here: JEP 400 made UTF-8 the platform default from
Java 18, and `tools/bin/runjava` additionally passes `-Dfile.encoding=UTF-8`. The change makes
that explicit rather than altering it.

Two sites feed MD5 hashing — `SecurityUtils.hash(s.getBytes(), key, "MD5")` and an
`md5.update(valueBeforeMD5.getBytes())`. Those would matter if the encoding actually shifted,
since stored hashes would stop matching. It doesn't, and for ASCII input the bytes are
identical under any legacy default charset anyway.

## Two recipes dropped rather than applied

**`EqualsAvoidsNull`** — rewrites `sName.equals("foo")` as `"foo".equals(sName)`. **Not
behaviour preserving:** a null receiver throws NPE today and would silently evaluate `false`
afterwards. 86 sites across 42 files, which would have been most of this PR.

It cuts both ways — several receivers are Swing APIs that genuinely can return null
(`evt.getPropertyName()`, `button.getName()`), so it would suppress real latent NPEs. But it
would equally mask a null that should have surfaced, and the first pass is meant to be
mechanical. Rejected: we don't want Yoda conditions in this code base.

**`UseListSort`** — rewrites `Collections.sort(list)` as `list.sort(null)`. Correct, since
`null` means natural ordering, but it reads worse than what it replaces. 22 sites.

Both are recorded in `rewrite.yml` with the reasoning, so the decision isn't accidentally
revisited.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- **Idempotent** — re-running produces no patch
- Confirmed neither dropped recipe leaked into the output (no `"lit".equals(...)`, no
  `.sort(null)`)
- All 22 charset sites reviewed individually

No smoke test — these are localized expression rewrites with no event-handling or
initialization involvement. The Swing-sensitive work was PR #237.