### PR TITLE
Use method references where lambdas only delegate

### DIFF
--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
@@ -165,8 +165,7 @@ public class EngineBasePanel extends JPanel
         // Upon change, change focus to this panel (old focus may have been
         // on widget in removed component)
         SwingUtilities.invokeLater(
-            () ->
-                requestFocus()
+            this::requestFocus
         );
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -661,8 +661,7 @@ public class EngineUtils
         if (cancelables_ == null || cancelables_.isEmpty()) return;
 
         // run in swing loop since possible closing dialogs
-        GuiUtils.invoke(() ->
-            EngineUtils.cancel());
+        GuiUtils.invoke(EngineUtils::cancel);
     }
 
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
@@ -419,8 +419,7 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
                         Utils.sleepMillis(nSleep_);
                         // need to invoke later so happens from swing thread
                         SwingUtilities.invokeLater(
-                            () ->
-                                removeDialog()
+                            this::removeDialog
                         );
                     }, "SendMessageDialog"
                 );

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
@@ -251,8 +251,7 @@ public class UDPStatus extends BasePhase implements DDTable.TableMenuItems
             Collections.sort(list, LINK_COMPARATOR);
 
             // table changed
-            GuiUtils.invoke(() ->
-                updateSwing());
+            GuiUtils.invoke(this::updateSwing);
         }
 
         private void updateSwing()

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/BorderChooser.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/BorderChooser.java
@@ -214,7 +214,7 @@ public class BorderChooser extends InternalDialog implements ActionListener
             nIndex_ = nIndex;
             getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             getSelectionModel().addListSelectionListener(
-                e -> myValueChanged(e)
+                this::myValueChanged
             );
         }
         

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/Bet.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/Bet.java
@@ -291,8 +291,7 @@ public class Bet extends ChainPhase implements PlayerActionListener, CancelableP
 
             // do processing
             SwingUtilities.invokeLater(
-                () ->
-                    doAI()
+                Bet.this::doAI
             );
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DealCommunity.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DealCommunity.java
@@ -203,8 +203,7 @@ public class DealCommunity extends ChainPhase implements PlayerActionListener
 
             // do processing
             SwingUtilities.invokeLater(
-                () ->
-                    displayCards()
+                DealCommunity.this::displayCards
             );
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileDialog.java
@@ -198,31 +198,26 @@ public class PlayerProfileDialog extends DialogPhase implements PropertyChangeLi
 
         if (profile_.isOnline())
         {
-            emailButton_.addActionListener(e ->
-                doButton(e));
+            emailButton_.addActionListener(this::doButton);
 
             if (passwordButton_ != null)
             {
-                passwordButton_.addActionListener(e ->
-                    doButton(e));
+                passwordButton_.addActionListener(this::doButton);
             }
 
             if (sendButton_ != null)
             {
-                sendButton_.addActionListener(e ->
-                    doButton(e));
+                sendButton_.addActionListener(this::doButton);
             }
 
             if (resetButton_ != null)
             {
-                resetButton_.addActionListener(e ->
-                    doButton(e));
+                resetButton_.addActionListener(this::doButton);
             }
 
             if (syncButton_ != null)
             {
-                syncButton_.addActionListener(e ->
-                    doButton(e));
+                syncButton_.addActionListener(this::doButton);
             }
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -655,8 +655,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
 
         // do remaining start a bit later to allow for
         // UI to draw
-        SwingUtilities.invokeLater(() ->
-            poststart());
+        SwingUtilities.invokeLater(this::poststart);
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
@@ -226,6 +226,5 @@ public class DashboardClock extends DashboardItem implements GameClockListener
     }
 
     // runnable for invoking clock ticked event in swing thread
-    private Runnable updateTimeRunner_ = () ->
-        updateTime();
+    private Runnable updateTimeRunner_ = this::updateTime;
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
@@ -86,8 +86,7 @@ public class ObserversDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = () ->
-        updateAll();
+    private Runnable updateRunner_ = this::updateAll;
 
     /**
      * update observer list

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
@@ -203,8 +203,7 @@ public class OnlineDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = () ->
-        updateAll();
+    private Runnable updateRunner_ = this::updateAll;
 
     ///
     /// display logic

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
@@ -534,8 +534,7 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
      */
     public void propertyChange(PropertyChangeEvent evt)
     {
-        SwingUtilities.invokeLater(() ->
-            updateProfileData());
+        SwingUtilities.invokeLater(this::updateProfileData);
     }
 
     /**
@@ -862,8 +861,7 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
                 }
 
                 // table changed
-                GuiUtils.invoke(() ->
-                    fireTableDataChanged());
+                GuiUtils.invoke(this::fireTableDataChanged);
             }
         }
     }
@@ -953,8 +951,7 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
                 {
                     AudioConfig.playFX("observerjoin");
                 }
-                GuiUtils.invoke(() ->
-                    fireTableDataChanged());
+                GuiUtils.invoke(this::fireTableDataChanged);
             }
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
@@ -378,8 +378,7 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
             Collections.sort(list);
 
             // table changed
-            GuiUtils.invoke(() ->
-                fireTableDataChanged());
+            GuiUtils.invoke(this::fireTableDataChanged);
         }
     }
 


### PR DESCRIPTION
PR 6 of the modernization series. Added at Doug's request after he hit the first of these in
`Bet.java` once PR #237 merged.

Applied with `mvn rewrite:run -Drewrite.activeRecipes=com.donohoedigital.MethodReferences`,
plus one hand fix described below.

**14 files, +20/−39.** 20 method references.

```diff
-SwingUtilities.invokeLater(() -> doAI());
+SwingUtilities.invokeLater(Bet.this::doAI);

-emailButton_.addActionListener(e -> doButton(e));
+emailButton_.addActionListener(this::doButton);
```

These sites didn't exist before PR #237 — they were anonymous classes, so the suggestion
couldn't apply. That's why this is sequenced after the lambda work rather than folded into it.

## Every qualified `X.this::` was checked

This recipe confuses a **superclass** with an **enclosing class**, which is why it was pulled
from PR #237 after breaking the `gameengine` build. So each qualifier was verified against
whether `X` encloses the class or is a supertype:

| Qualifier | File | Verdict |
|---|---|---|
| `DialogPhase.this::removeDialog` | `SendMessageDialog.java` | **illegal** — `class SendMessageDialog extends DialogPhase` |
| `Bet.this::doAI` | `Bet.java` | legal — `AIWait` (line 278) is an inner class of `Bet` |
| `DealCommunity.this::displayCards` | `DealCommunity.java` | legal — `DealWait` (line 190) is an inner class |

The illegal one is hand-fixed to `this::removeDialog`. It sits in a lambda nested inside
another lambda, so `this` already refers to the enclosing `SendMessageDialog`;
`removeDialog()` is merely *inherited* from `DialogPhase`, which is what misled the recipe into
qualifying with the declaring class.

**The hand fix doesn't cost reproducibility.** The recipe only rewrites lambdas, and that site
is now a method reference — a re-run has nothing left to do there. Confirmed by the idempotency
check. That's the distinction from `RemoveExtraSemicolons` in PR #235, where a hand fix would
have been undone on every run, so the recipe was dropped instead.

## Receivers

The other 17 are `this::` or the static `EngineUtils::cancel`. None binds a mutable field,
which matters because a method reference evaluates its receiver **once at creation** rather
than per call — `x -> foo.bar(x)` and `foo::bar` differ if `foo` is reassigned.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- **Idempotent** — re-running produces no patch, including at the hand-fixed site
- All 3 qualified `X.this::` verified against the class's enclosing chain vs its `extends` chain
- All 20 receivers checked for eager-evaluation exposure