### PR TITLE
Convert the remaining anonymous listeners to lambdas

### DIFF
--- a/code/gui/src/main/java/com/donohoedigital/gui/DDTable.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDTable.java
@@ -196,12 +196,7 @@ public class DDTable extends JTable implements DDTextVisibleComponent, MouseList
             DDMenuItem item = new DDMenuItem(GuiManager.DEFAULT, "PopupMenu");
             item.setText(PropertyConfig.getMessage("menuitem.table.export"));
             item.setIcon(exportIcon_);
-            item.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent e)
-                {
-                    exporter_.exportRequested(DDTable.this);
-                }
-            });
+            item.addActionListener(ae -> exporter_.exportRequested(DDTable.this));
             menu.add(item);
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -515,23 +515,11 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
 
             // buttons
             DDButton bannedplayers = new GlassButton("bannedplayers", "Glass");
-            bannedplayers.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    context_.processPhaseNow("BannedPlayerList", null);
-                }
-            });
+            bannedplayers.addActionListener(e -> context_.processPhaseNow("BannedPlayerList", null));
             bannedplayers.setBorderGap(2, 5, 2, 6);
 
             DDButton mutedplayers = new GlassButton("mutedplayers", "Glass");
-            mutedplayers.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    context_.processPhaseNow("MutedPlayerList", null);
-                }
-            });
+            mutedplayers.addActionListener(e -> context_.processPhaseNow("MutedPlayerList", null));
             mutedplayers.setBorderGap(2, 5, 2, 6);
 
             DDPanel buttonbase = new DDPanel();
@@ -600,13 +588,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             // test button
             test_ = new GlassButton("testonline", "Glass");
             serverBorder.add(GuiUtils.CENTER(test_), BorderLayout.EAST);
-            test_.addActionListener(new ActionListener()
-            {
-                public void actionPerformed(ActionEvent e)
-                {
-                    testConnection();
-                }
-            });
+            test_.addActionListener(e -> testConnection());
 
             // update text fields based on pref
             doOnlineEnabled();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
@@ -119,26 +119,24 @@ public class PlayerTypeSlidersPanel extends DDPanel
             {
                 slider_.setValue(itemx.getValue());
                 slider_.setVisible(!itemx.isExpanded());
-                slider_.addChangeListener(new ChangeListener()
-                {
-                    public void stateChanged(ChangeEvent e)
-                    {
-                        AIStrategyNode item = (AIStrategyNode)getItem();
+                slider_.addChangeListener(e -> {
+                        // renamed from 'item' - a lambda shares the enclosing scope, where the
+                        // SliderItemPanel constructor already has 'item' and 'itemx'
+                        AIStrategyNode node = (AIStrategyNode)getItem();
 
                         value_.setText(Integer.toString(slider_.getValue()));
 
                         //if (!bUpdating_ && !((DDSlider)e.getSource()).getValueIsAdjusting())
                         if (!bUpdating_)
                         {
-                            item.setValue(slider_.getValue());
-                            item.propagateValueChange();
+                            node.setValue(slider_.getValue());
+                            node.propagateValueChange();
                             if (PlayerTypeSlidersPanel.changeListener != null)
                             {
                                 PlayerTypeSlidersPanel.changeListener.stateChanged(e);    
                             }
                         }
 
-                    }
                 });
 
                 borderPanel_.add(slider_, BorderLayout.EAST);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
@@ -475,14 +475,9 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
      * invoke in timer thread (to get out of any locks held by
      * callers like TournamentDirector).
      */
-    private PokerTableListener listener_ = new PokerTableListener()
-    {
-        public void tableEventOccurred(final PokerTableEvent event)
-        {
+    private PokerTableListener listener_ = event ->
             // run immediately
             timer.schedule(new TableEventTask(event), 0);
-        }
-    };
 
     /**
      * Task for particular poker table event.  When invoked, runs immediately

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
@@ -433,10 +433,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
         DDMenuItem item = new DDMenuItem(GuiManager.DEFAULT, "PopupMenu");
         item.setText(PropertyConfig.getMessage("menuitem.chat.export"));
         item.setIcon(exportIcon_);
-        item.addActionListener(new ActionListener()
-        {
-            public void actionPerformed(ActionEvent e)
-            {
+        item.addActionListener(ae -> {
                 TypedHashMap params = new TypedHashMap();
                 params.setString(FileChooserDialog.PARAM_SUGGESTED_NAME, "chat");
                 Phase choose = context_.processPhaseNow("ExportChat", params);
@@ -447,7 +444,6 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
                     logger.info("Exporting chat to " + file.getAbsolutePath());
                     ConfigUtils.writeFile((File) oResult, toHtml(), false);
                 }
-            }
         });
         menu.add(item);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
@@ -328,15 +328,7 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
 
         DDButton paste = new GlassButton("pasteurl", "Glass");
         buttons.add(paste, BorderLayout.CENTER);
-        paste.addActionListener(new ActionListener()
-        {
-            DDTextField _text = text;
-
-            public void actionPerformed(ActionEvent e)
-            {
-                GuiUtils.copyToClipboard(text.getText());
-            }
-        });
+        paste.addActionListener(e -> GuiUtils.copyToClipboard(text.getText()));
 
         if (bUseLastButton)
         {
@@ -345,16 +337,7 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
             buttons.add(uselast, BorderLayout.EAST);
             if (sLast != null && sLast.length() > 0)
             {
-                uselast.addActionListener(new ActionListener()
-                {
-                    DDTextField _text = text;
-                    String _sLast = sLast;
-
-                    public void actionPerformed(ActionEvent e)
-                    {
-                        text.setText(sLast);
-                    }
-                });
+                uselast.addActionListener(e -> text.setText(sLast));
             }
             else
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineConfiguration.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineConfiguration.java
@@ -294,15 +294,7 @@ public class OnlineConfiguration extends BasePhase implements PropertyChangeList
         panel.add(text, BorderLayout.CENTER);
         DDButton copy = new GlassButton("copyurl", "Glass");
         panel.add(GuiUtils.CENTER(copy), BorderLayout.EAST);
-        copy.addActionListener(new ActionListener()
-        {
-            DDTextField _text = text;
-
-            public void actionPerformed(ActionEvent e)
-            {
-                GuiUtils.copyToClipboard(text.getText());
-            }
-        });
+        copy.addActionListener(e -> GuiUtils.copyToClipboard(text.getText()));
 
         w.label = label;
         w.text = text;


### PR DESCRIPTION
PR 7 of the modernization series. **Hand-applied — no recipe covers these.**

OpenRewrite can't convert them: doing so requires renaming a variable, and the recipe won't
invent names. IntelliJ will, which is why it's still flagging them.

**7 files, +15/−74.** 10 conversions, after which **no convertible anonymous
functional-interface implementation remains in the tree**.

## Correction: 10 sites, not the ~41 I estimated

I gave you ~41 earlier from a grep. That was wrong twice over:

- **Adapters can never be lambdas.** `MouseAdapter`, `WindowAdapter`, `FocusAdapter`,
  `ComponentAdapter`, `InternalFrameAdapter`, `MouseMotionAdapter` — 10 sites — are *abstract
  classes*, not interfaces. They exist precisely to let you override one method of a
  multi-method interface. A lambda needs a functional interface. That's a language rule, not a
  tool gap, and those sites stay as they are permanently.
- **One was commented out** — a `ListSelectionListener` inside a `/* ... */` block in
  `StatisticsViewer.java` that my raw-source scan counted as live code.

## Dead fields

Three sites declared a field that is never read, which alone blocks conversion since a lambda
can't declare fields:

```diff
-paste.addActionListener(new ActionListener()
-{
-    DDTextField _text = text;          // assigned, never used
-    public void actionPerformed(ActionEvent e)
-    { GuiUtils.copyToClipboard(text.getText()); }
-});
+paste.addActionListener(e -> GuiUtils.copyToClipboard(text.getText()));
```

Each was confirmed unreferenced (`_text` in `ListGames` ×2 and `OnlineConfiguration`, `_sLast`
in `ListGames`). Dropping them is part of the conversion, not separate dead-code work.

## Renames

An anonymous class body opens its own scope; a lambda shares the enclosing one. Three sites
needed a rename:

| Site | Rename | Reason |
|---|---|---|
| `DDTable` | param `e` → `ae` | encloses `mouseReleased(MouseEvent e)` |
| `ChatListPanel` | param `e` → `ae` | enclosing method uses `e` *after* the listener |
| `PlayerTypeSlidersPanel` | local `item` → `node` | body's local collides with the constructor's `item` |

The last one is worth noting: **the clash was a local variable, not a parameter**, and I didn't
predict it — the compiler did. My shadowing heuristic was unreliable (it matched `if (...)`
lines as method signatures), so I used the build as the oracle instead, which is exact. That
file already carried `itemx` from an earlier workaround for the same collision, so a third name
was needed; the rename carries a comment explaining why.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- Re-scanned the tree (comments stripped, adapters excluded): **0 convertible sites remain**
- **Smoke test:** `poker` ran 45s, zero exceptions, database loaded, multicast up

**Smoke test scope:** startup only, as before. `DDTable`'s export item and `ChatListPanel`'s
export item are right-click menu actions, and `GamePrefsPanel`'s three buttons are in Options —
worth exercising those specifically, since they're the handlers this PR rewires.