### PR TITLE
Mark private fields final and tidy modifiers

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/Base64.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Base64.java
@@ -47,53 +47,53 @@ import java.nio.charset.StandardCharsets;
  * @author rob@iharder.net
  * @version 2.0
  */
-public class Base64
+public final class Base64
 {
     
 /* ********  P U B L I C   F I E L D S  ******** */   
     
     
     /** No options specified. Value is zero. */
-    public final static int NO_OPTIONS = 0;
+    public static final int NO_OPTIONS = 0;
     
     /** Specify encoding. */
-    public final static int ENCODE = 1;
+    public static final int ENCODE = 1;
     
     
     /** Specify decoding. */
-    public final static int DECODE = 0;
+    public static final int DECODE = 0;
     
     
     /** Specify that data should be gzip-compressed. */
-    public final static int GZIP = 2;
+    public static final int GZIP = 2;
     
     
     /** Don't break lines when encoding (violates strict Base64 specification) */
-    public final static int DONT_BREAK_LINES = 8;
+    public static final int DONT_BREAK_LINES = 8;
     
     
 /* ********  P R I V A T E   F I E L D S  ******** */  
     
     
     /** Maximum line length (76) of Base64 output. */
-    private final static int MAX_LINE_LENGTH = 76;
+    private static final int MAX_LINE_LENGTH = 76;
     
     
     /** The equals sign (=) as a byte. */
-    private final static byte EQUALS_SIGN = (byte)'=';
+    private static final byte EQUALS_SIGN = (byte)'=';
     
     
     /** The new line character (\n) as a byte. */
-    private final static byte NEW_LINE = (byte)'\n';
+    private static final byte NEW_LINE = (byte)'\n';
     
     
     /** Preferred encoding. */
-    private final static String PREFERRED_ENCODING = "UTF-8";
+    private static final String PREFERRED_ENCODING = "UTF-8";
     
     
     /** The 64 valid Base64 values. */
-    private final static byte[] ALPHABET;
-    private final static byte[] _NATIVE_ALPHABET = /* May be something funny like EBCDIC */
+    private static final byte[] ALPHABET;
+    private static final byte[] _NATIVE_ALPHABET = /* May be something funny like EBCDIC */
     {
         (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F', (byte)'G',
         (byte)'H', (byte)'I', (byte)'J', (byte)'K', (byte)'L', (byte)'M', (byte)'N',
@@ -127,7 +127,7 @@ public class Base64
      * Translates a Base64 value to either its 6-bit reconstruction value
      * or a negative number indicating some other meaning.
      **/
-    private final static byte[] DECODABET =
+    private static final byte[] DECODABET =
     {   
         -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
         -5,-5,                                      // Whitespace: Tab and Linefeed
@@ -162,9 +162,9 @@ public class Base64
         -9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9,-9         // Decimal 244 - 255 */
     };
     
-    private final static byte BAD_ENCODING    = -9; // Indicates error in encoding
-    private final static byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
-    private final static byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
+    private static final byte BAD_ENCODING    = -9; // Indicates error in encoding
+    private static final byte WHITE_SPACE_ENC = -5; // Indicates white space in encoding
+    private static final byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
     
     /** Defeats instantiation. */

--- a/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
+++ b/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
@@ -259,7 +259,7 @@ public abstract class ManagedQueue<T>
     /**
      * Thread which pulls items off the queue
      */
-    private class QueueThread extends Thread
+    private final class QueueThread extends Thread
     {
         private QueueThread()
         {

--- a/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
+++ b/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
@@ -261,7 +261,7 @@ public class MersenneTwisterFast implements Serializable, Cloneable
      * only uses the first 32 bits for its seed).   
      */
 
-    synchronized public void setSeed(final long seed)
+    public synchronized void setSeed(final long seed)
         {
         // Due to a bug in java.util.Random clear up to 1.2, we're
         // doing our own Gaussian variable.
@@ -295,7 +295,7 @@ public class MersenneTwisterFast implements Serializable, Cloneable
      * integers are repeatedly used in a wrap-around fashion.
      */
 
-    synchronized public void setSeed(final int[] array)
+    public synchronized void setSeed(final int[] array)
         {
         if (array.length == 0)
             throw new IllegalArgumentException("Array length must be greater than zero");

--- a/code/common/src/main/java/com/donohoedigital/base/MovingAverage.java
+++ b/code/common/src/main/java/com/donohoedigital/base/MovingAverage.java
@@ -45,7 +45,7 @@ public class MovingAverage
     private int idx_;
     private int sum_;
 
-    private long[] entries_;
+    private final long[] entries_;
     private long peak_;
 
     /**

--- a/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/SecurityUtils.java
@@ -317,7 +317,7 @@ public class SecurityUtils
     /**
      * Get secure random object
      */
-    public synchronized static SecureRandom getSecureRandom()
+    public static synchronized SecureRandom getSecureRandom()
     {
         if (random == null)
         {

--- a/code/common/src/main/java/com/donohoedigital/base/Utils.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Utils.java
@@ -946,7 +946,7 @@ public class Utils
     /**
      * Filter by extension
      */
-    private static class UtilFileFilter implements FilenameFilter
+    private static final class UtilFileFilter implements FilenameFilter
     {
         String sExt;
         String sBeginsWith = null;

--- a/code/common/src/main/java/com/donohoedigital/comms/DDHttpClient.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDHttpClient.java
@@ -469,12 +469,12 @@ public class DDHttpClient
     {
         sc_.close();
     }
-    
+
     /**
      * Class to look up a host in a thread so
      * we can timeout if takes too long
      */
-    private static class LookupHost implements Runnable
+    private static final class LookupHost implements Runnable
     {
         String host;
         InetAddress addr = null;

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
@@ -143,9 +143,9 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
 
     // transient data only
     private int nStatus_ = DDMessageListener.STATUS_NONE;
-    
+
     // class to represent data chunks
-    private class MessageData
+    private final class MessageData
     {
         private byte[] bytedata_;
         private File filedata_;

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessenger.java
@@ -388,12 +388,12 @@ public class DDMessenger
             catch (Exception ignore) {}
         }
     }
-    
+
     /**
      * Class to represent return data from getURL
      */
     @SuppressWarnings({"PublicInnerClass"})
-    public static class ReturnData
+    public static final class ReturnData
     {
         private DDByteArrayOutputStream headers;
         private DDByteArrayOutputStream out;

--- a/code/common/src/main/java/com/donohoedigital/comms/MsgState.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/MsgState.java
@@ -56,14 +56,14 @@ public class MsgState
     private static final int NEXT_ID_NOTSET = -1;
     
     // ids
-    private Map<Object, Integer> ids_ = new HashMap<>();
-    private Map<Integer, Object> reverseids_ = new HashMap<>();
+    private final Map<Object, Integer> ids_ = new HashMap<>();
+    private final Map<Integer, Object> reverseids_ = new HashMap<>();
     private int nextid_ = NEXT_ID_NOTSET;
     
     // class info
     private TokenizedList classNames_;
-    private Map<String, Integer> classids_ = new HashMap<>();
-    private Map<Integer, String> reverseclassids_ = new HashMap<>();
+    private final Map<String, Integer> classids_ = new HashMap<>();
+    private final Map<Integer, String> reverseclassids_ = new HashMap<>();
     private int nextclassid_ = 0;
     
     /**

--- a/code/common/src/main/java/com/donohoedigital/config/Activation.java
+++ b/code/common/src/main/java/com/donohoedigital/config/Activation.java
@@ -124,8 +124,8 @@ public class Activation
      * Return a hash of the given id
      */
     private static MessageDigest md_ = null;
-    private static byte[] foo = new byte[25];
-    private static StringBuilder sb_ = new StringBuilder(20);
+    private static final byte[] foo = new byte[25];
+    private static final StringBuilder sb_ = new StringBuilder(20);
 
     /**
      * init message digest

--- a/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
@@ -60,13 +60,13 @@ import java.util.Map;
  */
 public class AudioConfig extends XMLConfigFileLoader
 {
-    private static Logger aLogger = LogManager.getLogger(AudioConfig.class);
+    private static final Logger aLogger = LogManager.getLogger(AudioConfig.class);
 
     private static final String AUDIO_CONFIG = "audio.xml";
 
     private static AudioConfig audioConfig = null;
 
-    private Map<String, AudioDef> audios_ = new HashMap<>();
+    private final Map<String, AudioDef> audios_ = new HashMap<>();
 
     private static boolean bMuteFX_ = false;
     private static float fFXGain_ = .8f;

--- a/code/common/src/main/java/com/donohoedigital/config/CachedEntityResolver.java
+++ b/code/common/src/main/java/com/donohoedigital/config/CachedEntityResolver.java
@@ -49,13 +49,13 @@ import java.util.Map;
  * Time: 3:30:38 PM
  * To change this template use File | Settings | File Templates.
  */
-public class CachedEntityResolver implements EntityResolver
+public final class CachedEntityResolver implements EntityResolver
 {
     private final Map<String, URL> matches = new HashMap<>();
 
     private static CachedEntityResolver resolver = null;
 
-    public synchronized static CachedEntityResolver instance()
+    public static synchronized CachedEntityResolver instance()
     {
         if (resolver == null)
         {

--- a/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
@@ -47,7 +47,7 @@ import java.util.Map;
  */
 public class DebugConfig
 {
-    private static Logger logger = LogManager.getLogger(DebugConfig.class);
+    private static final Logger logger = LogManager.getLogger(DebugConfig.class);
     private static Boolean TESTING_ENABLED = null;
     private static final Map<String, Boolean> cache = new HashMap<>();
 

--- a/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
@@ -58,14 +58,14 @@ import java.util.Map;
  */
 public class HelpConfig extends XMLConfigFileLoader
 {
-    private static Logger hLogger = LogManager.getLogger(HelpConfig.class);
+    private static final Logger hLogger = LogManager.getLogger(HelpConfig.class);
     
     private String HELP_CONFIG = "help.xml";
 
     private static HelpConfig helpConfig = null;
     
-    private Map<String, HelpTopic> helps_ = new HashMap<>();
-    private List<HelpTopic> helparray_ = new ArrayList<>();
+    private final Map<String, HelpTopic> helps_ = new HashMap<>();
+    private final List<HelpTopic> helparray_ = new ArrayList<>();
     
     /** 
      * Creates a new instance of HelpConfig from the Appconfig file 

--- a/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
@@ -63,13 +63,13 @@ import java.net.URL;
  */
 public class ImageConfig extends XMLConfigFileLoader
 {
-    private static Logger iLogger = LogManager.getLogger(ImageConfig.class);
+    private static final Logger iLogger = LogManager.getLogger(ImageConfig.class);
     
     private static final String IMAGE_CONFIG = "images.xml";
 
     private static ImageConfig imageConfig = null;
     
-    private Map<String, ImageDef> images_ = new HashMap<>();
+    private final Map<String, ImageDef> images_ = new HashMap<>();
     
     /** 
      * Creates a new instance of ImageConfig from the Appconfig file 

--- a/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
@@ -64,15 +64,15 @@ public class ImageDef
 {
     static Logger logger = LogManager.getLogger(ImageDef.class);
 
-    private static boolean DEBUG = false;
+    private static final boolean DEBUG = false;
 
-    private String sName_;
-    private URL url_;
+    private final String sName_;
+    private final URL url_;
     private ImageIcon icon_;
     private AnimatedImageIcon anim_;
     private BufferedImage bimage_;
-    private boolean bCache_;
-    private boolean bComposite_;
+    private final boolean bCache_;
+    private final boolean bComposite_;
     private String[] saComponents_;
     private int x_ = 0;
     private int y_ = 0;

--- a/code/common/src/main/java/com/donohoedigital/config/Perf.java
+++ b/code/common/src/main/java/com/donohoedigital/config/Perf.java
@@ -50,12 +50,12 @@ import java.util.TreeMap;
  */
 public class Perf 
 {
-    private static boolean JPROFILER = true;
+    private static final boolean JPROFILER = true;
 
     private static boolean ON = false;
-    private static boolean MEM = false;
+    private static final boolean MEM = false;
     private static boolean bRunning = true;
-    private static Map count_ = new TreeMap();
+    private static final Map count_ = new TreeMap();
 
     /**
      * turn on performance features (called from EngineInit)

--- a/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
@@ -58,7 +58,7 @@ import java.util.*;
  */
 public class PropertyConfig extends Properties
 {
-    private static Logger logger = LogManager.getLogger(PropertyConfig.class);
+    private static final Logger logger = LogManager.getLogger(PropertyConfig.class);
 
     // config file names
     private static final String PROPS_CONFIG_COMMON = "common.properties";
@@ -70,7 +70,7 @@ public class PropertyConfig extends Properties
     private static PropertyConfig propConfig = null;
 
     // testing - don't throw missing exceptions
-    private static boolean testing = false;
+    private static final boolean testing = false;
 
     /**
      * Creates a new instance of PropertyConfig from the Appconfig file

--- a/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
@@ -47,7 +47,7 @@ import java.util.List;
  * Time: 4:30:42 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ShutdownManager implements Thread.UncaughtExceptionHandler
+public final class ShutdownManager implements Thread.UncaughtExceptionHandler
 {
     private static final Logger logger = LogManager.getLogger(ShutdownManager.class);
 
@@ -75,7 +75,7 @@ public class ShutdownManager implements Thread.UncaughtExceptionHandler
     /**
      * Install our own shutdown manager.
      */
-    public synchronized static void install()
+    public static synchronized void install()
     {
         if (manager == null) {
             manager = new ShutdownManager();
@@ -100,7 +100,7 @@ public class ShutdownManager implements Thread.UncaughtExceptionHandler
      *
      * @param shutdownListener listener which will be called on shutdown
      */
-    public synchronized static void addShutdownListener(final ShutdownListener shutdownListener)
+    public static synchronized void addShutdownListener(final ShutdownListener shutdownListener)
     {
         install(); // make sure we have a shutdown manager
         manager.listeners.add(shutdownListener);
@@ -111,7 +111,7 @@ public class ShutdownManager implements Thread.UncaughtExceptionHandler
      *
      * @param details
      */
-    public synchronized static void exitAbnormal(String details)
+    public static synchronized void exitAbnormal(String details)
     {
         install(); // make sure we have a shutdown manager
         manager.exitAbnormal(ABNORMAL_BY_USER, details);

--- a/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/StylesConfig.java
@@ -62,16 +62,16 @@ import java.util.Map;
  */
 public class StylesConfig extends XMLConfigFileLoader
 {
-    private static Logger sLogger = LogManager.getLogger(StylesConfig.class);
+    private static final Logger sLogger = LogManager.getLogger(StylesConfig.class);
 
     private static final String STYLE_CONFIG = "styles.xml";
     private static final boolean DEBUG_FONT = false;
 
     private static StylesConfig stylesConfig = null;
 
-    private Map<String, Color> colors_ = new HashMap<>();
-    private Map<String, Font> fonts_ = new HashMap<>();
-    private Map<String, Font> fontdefs_ = new HashMap<>();
+    private final Map<String, Color> colors_ = new HashMap<>();
+    private final Map<String, Font> fonts_ = new HashMap<>();
+    private final Map<String, Font> fontdefs_ = new HashMap<>();
 
     /**
      * Creates a new instance of StylesConfig from the Appconfig file

--- a/code/common/src/main/java/com/donohoedigital/html/Table.java
+++ b/code/common/src/main/java/com/donohoedigital/html/Table.java
@@ -43,10 +43,10 @@ import java.util.ArrayList;
  */
 public class Table
 {
-    private ArrayList<TableColumn> cols_ = new ArrayList<>();
-    private ArrayList<TableRow> rows_ = new ArrayList<>();
+    private final ArrayList<TableColumn> cols_ = new ArrayList<>();
+    private final ArrayList<TableRow> rows_ = new ArrayList<>();
 
-    private int CELLPADDING, CELLSPACING;
+    private final int CELLPADDING, CELLSPACING;
 
     public Table(int CELLSPACING, int CELLPADDING)
     {

--- a/code/common/src/main/java/com/donohoedigital/html/TableColumn.java
+++ b/code/common/src/main/java/com/donohoedigital/html/TableColumn.java
@@ -86,9 +86,9 @@ public class TableColumn
     }
 
     // members
-    private VALIGN vAlign_;
-    private HALIGN hAlign_;
-    private TableData header_;
+    private final VALIGN vAlign_;
+    private final HALIGN hAlign_;
+    private final TableData header_;
 
     /**
      * Constructor

--- a/code/common/src/main/java/com/donohoedigital/html/TableRow.java
+++ b/code/common/src/main/java/com/donohoedigital/html/TableRow.java
@@ -43,7 +43,7 @@ import java.util.ArrayList;
  */
 public class TableRow
 {
-    private ArrayList<TableData> data_ = new ArrayList<>();
+    private final ArrayList<TableData> data_ = new ArrayList<>();
 
     public TableRow()
     {

--- a/code/common/src/main/java/com/donohoedigital/xml/EncoderObject.java
+++ b/code/common/src/main/java/com/donohoedigital/xml/EncoderObject.java
@@ -37,8 +37,8 @@ package com.donohoedigital.xml;
  */
 public class EncoderObject
 {
-    private Object object;
-    private String alias;
+    private final Object object;
+    private final String alias;
 
     public EncoderObject(Object object, String alias)
     {

--- a/code/common/src/main/java/com/donohoedigital/xml/SimpleXMLEncoder.java
+++ b/code/common/src/main/java/com/donohoedigital/xml/SimpleXMLEncoder.java
@@ -48,8 +48,8 @@ public class SimpleXMLEncoder
 
     SimpleDateFormat format = Utils.getRFC822();
 
-    private StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    private Stack<EncoderObject> currentObject = new Stack<>();
+    private final StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    private final Stack<EncoderObject> currentObject = new Stack<>();
 
     /**
      * Set current object null and start new tag with name "alias".

--- a/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DataElementConfigTest
 {
-    private static Logger logger = LogManager.getLogger(DataElementConfigTest.class);
+    private static final Logger logger = LogManager.getLogger(DataElementConfigTest.class);
 
     private DataElementConfig load()
     {

--- a/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class HelpConfigTest
 {
-    private static Logger logger = LogManager.getLogger(HelpConfigTest.class);
+    private static final Logger logger = LogManager.getLogger(HelpConfigTest.class);
     @Test
     public void testLoad()
     {

--- a/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
+++ b/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
@@ -51,7 +51,7 @@ import java.util.Map;
  */
 public class DatabaseManager
 {
-    private static Logger logger = LogManager.getLogger(DatabaseManager.class);
+    private static final Logger logger = LogManager.getLogger(DatabaseManager.class);
 
     private static final String PROPERTY_PREFIX = "settings.database.";
 
@@ -66,7 +66,7 @@ public class DatabaseManager
     public static final String PARAM_PASSWORD = "password";
 
     private static boolean initialized_ = false;
-    private static Map<String, Database> hmDatabases_ = new HashMap<>();
+    private static final Map<String, Database> hmDatabases_ = new HashMap<>();
 
     /**
      * Determine if the manager has been initialized.

--- a/code/db/src/main/java/com/donohoedigital/db/ResultMap.java
+++ b/code/db/src/main/java/com/donohoedigital/db/ResultMap.java
@@ -42,11 +42,11 @@ import java.sql.SQLException;
  */
 public class ResultMap extends DMTypedHashMap
 {
-    private DatabaseQuery query_ = null;
-    private ResultSet rs_ = null;
+    private final DatabaseQuery query_ = null;
+    private final ResultSet rs_ = null;
 
-    private int index_ = 0;
-    private int count_ = -1;
+    private final int index_ = 0;
+    private final int count_ = -1;
 
     /**
      * Retrieve the next row and store the results.

--- a/code/db/src/main/java/com/donohoedigital/db/dao/impl/JpaBaseDao.java
+++ b/code/db/src/main/java/com/donohoedigital/db/dao/impl/JpaBaseDao.java
@@ -54,7 +54,7 @@ import java.util.List;
 public abstract class JpaBaseDao<T extends BaseModel<ID>, ID extends Serializable> implements BaseDao<T, ID>
 {
     // the model class we are managing
-    private Class<T> persistentModelClass;
+    private final Class<T> persistentModelClass;
 
     // entity manager provided via Spring
     protected EntityManager entityManager;

--- a/code/ddpoker/src/main/java/com/ddpoker/holdem/PlayerAction.java
+++ b/code/ddpoker/src/main/java/com/ddpoker/holdem/PlayerAction.java
@@ -46,7 +46,7 @@ public class PlayerAction
     private int call_ = 0;
     private int bet_ = 0;
 
-    private int rand_;
+    private final int rand_;
     private int action_;
 
     private String sDebug_;

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
@@ -59,7 +59,7 @@ import java.net.URL;
  */
 public class Borders extends TreeSet<Border> {
     
-    private static Logger logger = LogManager.getLogger(Borders.class);
+    private static final Logger logger = LogManager.getLogger(Borders.class);
     
     private MapPoints allPoints_;
     private static final String BORDER_TAG = "BORDER";

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/DDGeneralPathIterator.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/DDGeneralPathIterator.java
@@ -50,9 +50,9 @@ public class DDGeneralPathIterator implements PathIterator
 {
     //static Logger logger = LogManager.getLogger(DDGeneralPathIterator.class);
     
-    private GeneralPath path_;
+    private final GeneralPath path_;
     private static final int[] curvesize = {2, 2, 4, 6, 0};
-    private ArrayList points_ = new ArrayList();
+    private final ArrayList points_ = new ArrayList();
     float[] current_;
     private int index_ = 0;
     

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameButton.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameButton.java
@@ -53,7 +53,7 @@ public class GameButton extends TypedHashMap
     public static final String PARAM_GENERIC = "generic";
     public static final String DELIM = ":";
     
-    private String sName_; 
+    private final String sName_; 
     private String sGotoPhase_;
     private String sParam_;
 

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameConfigUtils.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameConfigUtils.java
@@ -66,7 +66,7 @@ public class GameConfigUtils
      * the returned value is cached in the ConfigManager, so there is only
      * one per application (useful for locking)
      */
-    public synchronized static File getSaveDir()
+    public static synchronized File getSaveDir()
     {
         if (saveDir == null)
         {

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameStateEntry.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameStateEntry.java
@@ -103,7 +103,7 @@ public class GameStateEntry extends TokenizedList
     private void initAfterRead(MsgState mstate)
     {
         GameState state = (GameState) mstate;
-        GameStateDelegate delegate = state.getDelegate();
+        GameStateDelegate delegate = GameState.getDelegate();
         if (delegate == null) return;
         id_ = removeIntegerToken();
         Integer classid = removeIntegerToken();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameStateFactory.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameStateFactory.java
@@ -143,7 +143,7 @@ public class GameStateFactory
      * get class
      */
     @SuppressWarnings({"unchecked"})
-    private synchronized static Class<? extends GameState> getClazz()
+    private static synchronized Class<? extends GameState> getClazz()
     {
         if (CLAZZ == null)
         {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/BasePhase.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/BasePhase.java
@@ -101,7 +101,7 @@ public abstract class BasePhase implements Phase
     /**
      * Must declare - logic of phase goes in here
      */
-    abstract public void start();
+    public abstract void start();
     
     /**
      * Called when a phase is removed as the main component (

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DiceRoller.java
@@ -87,7 +87,7 @@ public class DiceRoller {
     /**
      * Roll one die of nSides, return int
      */
-    public synchronized static int rollDieInt(int nSides)
+    public static synchronized int rollDieInt(int nSides)
     {
         return random_.nextInt(nSides) + 1;
     }
@@ -97,7 +97,7 @@ public class DiceRoller {
      * newSeed should be called after the (related) group of calls
      * that start with this one are done.
      */
-    public synchronized static int rollDieInt(int nSides, long seed)
+    public static synchronized int rollDieInt(int nSides, long seed)
     {
         random_.setSeed(seed);
         return random_.nextInt(nSides) + 1;
@@ -106,7 +106,7 @@ public class DiceRoller {
     /**
      * create new seed based on timestamp
      */
-    public synchronized static void newSeed()
+    public static synchronized void newSeed()
     {
         random_.setSeed(Utils.getCurrentTimeStamp());
     }
@@ -114,7 +114,7 @@ public class DiceRoller {
     /**
      * set the seed
      */
-    public synchronized static void setSeed(long seed)
+    public static synchronized void setSeed(long seed)
     {
         random_.setSeed(seed);
     }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/DieImage.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/DieImage.java
@@ -116,8 +116,8 @@ public class DieImage extends JPanel {
         }
     }
         
-    private double PIP = 3.3f/16f;
-    private double PIPSIZE = 3.2f/16f;
+    private final double PIP = 3.3f/16f;
+    private final double PIPSIZE = 3.2f/16f;
     private void drawUpperLeft(Graphics2D g, Dimension size)
     {
         double x = size.width * PIP;

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineBasePanel.java
@@ -197,7 +197,7 @@ public class EngineBasePanel extends JPanel
     boolean bPainting_ = false;
 
     // growbox color
-    private Color growColor_ = new Color(200, 200, 200, 125);
+    private final Color growColor_ = new Color(200, 200, 200, 125);
 
     // JDD 2019
     static boolean PAINT_GROW_BOX = true;

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineDialog.java
@@ -62,11 +62,11 @@ public class EngineDialog extends InternalDialog
 {
     protected static Logger logger = LogManager.getLogger(EngineDialog.class);
 
-    private GameContext context_;
+    private final GameContext context_;
     private DialogBackground base_;
     private Component focus_;
-    private int DESIRED_WIDTH;
-    private int DESIRED_HEIGHT;
+    private final int DESIRED_WIDTH;
+    private final int DESIRED_HEIGHT;
 
     /**
      * Constructor

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePieceButton.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePieceButton.java
@@ -47,7 +47,7 @@ import com.donohoedigital.gui.ButtonPanel;
 public class EngineGamePieceButton extends ButtonPanel
 {
     // info
-    private EngineGamePiece piece_;
+    private final EngineGamePiece piece_;
     
     /**
      * Creates a new instance of EngineGamePieceButton 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineUtils.java
@@ -68,9 +68,9 @@ public class EngineUtils
     protected static Gameboard gameboard_;
     protected static JComponent scroll_;
     
-    private static javax.swing.border.Border standardMsgBorder_ = BorderFactory.createEmptyBorder(6,10,5,10);
-    private static javax.swing.border.Border standardMenuTextBorder_ = BorderFactory.createEmptyBorder(15,20,15,20);
-    private static javax.swing.border.Border standardMenuLowerTextBorder_ = BorderFactory.createEmptyBorder(2,10,2,10);
+    private static final javax.swing.border.Border standardMsgBorder_ = BorderFactory.createEmptyBorder(6,10,5,10);
+    private static final javax.swing.border.Border standardMenuTextBorder_ = BorderFactory.createEmptyBorder(15,20,15,20);
+    private static final javax.swing.border.Border standardMenuLowerTextBorder_ = BorderFactory.createEmptyBorder(2,10,2,10);
     
     /**
      * Get standard border around message areas
@@ -636,7 +636,7 @@ public class EngineUtils
     /**
      * add cancelable phase
      */
-    public synchronized static void addCancelable(CancelablePhase phase)
+    public static synchronized void addCancelable(CancelablePhase phase)
     {
         if (cancelables_ == null) cancelables_ = new ArrayList();
 
@@ -646,7 +646,7 @@ public class EngineUtils
     /**
      * remove cancelable phase
      */
-    public synchronized static void removeCancelable(CancelablePhase phase)
+    public static synchronized void removeCancelable(CancelablePhase phase)
     {
         if (cancelables_ == null) return;
 
@@ -656,7 +656,7 @@ public class EngineUtils
     /**
      * cancel cancelable phases and clear list
      */
-    public synchronized static void cancelCancelables()
+    public static synchronized void cancelCancelables()
     {
         if (cancelables_ == null || cancelables_.isEmpty()) return;
 
@@ -667,7 +667,7 @@ public class EngineUtils
     /**
      * cancel each item in the list and clear the list
      */
-    private synchronized static void cancel()
+    private static synchronized void cancel()
     {
         CancelablePhase c;
         ArrayList dup = new ArrayList(cancelables_);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
@@ -64,11 +64,11 @@ public class EngineWindow extends BaseFrame
 {
     protected static Logger logger = LogManager.getLogger(EngineWindow.class);
 
-    private GameEngine engine_;
-    private GameContext context_;
+    private final GameEngine engine_;
+    private final GameContext context_;
     private EngineBasePanel base_;
-    private int DESIRED_MIN_WIDTH;
-    private int DESIRED_MIN_HEIGHT;
+    private final int DESIRED_MIN_WIDTH;
+    private final int DESIRED_MIN_HEIGHT;
     private boolean bFull_;
 
     /**

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
@@ -376,7 +376,7 @@ public class GameContext
     /**
      * Runnable for processing phase later in swing loop
      */
-    private class ProcessPhaseRunnable implements Runnable
+    private final class ProcessPhaseRunnable implements Runnable
     {
         String _sPhaseName;
         TypedHashMap _params;

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -67,16 +67,16 @@ import java.util.prefs.Preferences;
  */
 public abstract class GameEngine extends BaseApp
 {
-    private Logger logger = LogManager.getLogger(GameEngine.class);
+    private final Logger logger = LogManager.getLogger(GameEngine.class);
 
     // debugging settings
-    private static boolean TESTING_SKIP_SPLASH = false;
-    private boolean bExitEarlyTest = false;
+    private static final boolean TESTING_SKIP_SPLASH = false;
+    private final boolean bExitEarlyTest = false;
 
     // private stuff - does not change once created
     private static GameEngine engine_ = null;
     private GamedefConfig gamedef_;
-    private String sMainModule_;
+    private final String sMainModule_;
 
     // subclass access
     protected SplashScreen splashscreen_;
@@ -95,7 +95,7 @@ public abstract class GameEngine extends BaseApp
     private String sLastReal_ = null;
     private String sLastGen_ = null;
     private EnginePrefs prefNode_;
-    private String sPrefNode_;
+    private final String sPrefNode_;
     private String sKeyNode_;
     private boolean bSkipSplashChoice_ = false;
     private String guid_;
@@ -1008,7 +1008,7 @@ public abstract class GameEngine extends BaseApp
     ////
 
     // list of contexts
-    private Map<String, ContextTracker> contexts_ = new HashMap<>();
+    private final Map<String, ContextTracker> contexts_ = new HashMap<>();
 
     /**
      * note that a context was created

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
@@ -73,7 +73,7 @@ import java.util.Date;
  *
  * @author  Doug Donohoe
  */
-public class GameListPanel extends DDPanel implements ListSelectionListener,
+public final class GameListPanel extends DDPanel implements ListSelectionListener,
                                             PropertyChangeListener,
                                             ActionListener
 {
@@ -88,9 +88,9 @@ public class GameListPanel extends DDPanel implements ListSelectionListener,
     protected GameEngine engine_;
     protected GameContext context_;
     protected GamePhase gamephase_;
-    private String STYLE;
-    private int[] COLUMN_WIDTHS;
-    private String[] COLUMN_NAMES;
+    private final String STYLE;
+    private final int[] COLUMN_WIDTHS;
+    private final String[] COLUMN_NAMES;
     private DDTextField name_;
     private com.donohoedigital.gui.DDButton delete_;
     private DDTable saveTable_;
@@ -102,7 +102,7 @@ public class GameListPanel extends DDPanel implements ListSelectionListener,
     private boolean bOnlineSave_ = false;
     public boolean bOnlineLoad_ = false;
     private String sBegin_;
-    private boolean bDemo_;
+    private final boolean bDemo_;
     
     // save game info
     private static final int[] COLUMN_WIDTHS_LOAD = new int[] {
@@ -558,7 +558,7 @@ public class GameListPanel extends DDPanel implements ListSelectionListener,
         }
     }
 
-    private static CompareFile LISTSORTER = new CompareFile();
+    private static final CompareFile LISTSORTER = new CompareFile();
     
     /**
      * Sort in descending order (most recent at top)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameboardCenterLayout.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameboardCenterLayout.java
@@ -50,7 +50,7 @@ import java.util.HashMap;
  */
 public class GameboardCenterLayout implements LayoutManager2, Serializable
 {
-    private HashMap info = new HashMap();
+    private final HashMap info = new HashMap();
 
     public void addLayoutComponent( String s, Component component1 )
     {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Help.java
@@ -78,7 +78,7 @@ public class Help extends BasePhase implements ListSelectionListener,
     private TableModel model_;
     private DDImageButton bak_, fwd_;
     private int nHistIndex_ = 0;
-    private List<HelpTopic> history_ = new ArrayList<>();
+    private final List<HelpTopic> history_ = new ArrayList<>();
     private String STYLE;
     private boolean bRunning_ = false;
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/MenuBackground.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/MenuBackground.java
@@ -63,8 +63,8 @@ public class MenuBackground extends DDScrollPane
     public static final String PARAM_MENUBOX_HELP_NAME = "menubox-help-name";
 
     // members
-    private DDPanel menubox_;
-    private String sHelpName_;
+    private final DDPanel menubox_;
+    private final String sHelpName_;
 
     /**
      * Creates a new instance of BasicBackground

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
@@ -64,7 +64,7 @@ import java.awt.event.ActionListener;
  */
 public abstract class SendMessageDialog extends DialogPhase implements DDMessageListener, ActionListener
 {
-    private static Logger sLogger = LogManager.getLogger(SendMessageDialog.class);
+    private static final Logger sLogger = LogManager.getLogger(SendMessageDialog.class);
 
     // params
     public static final String PARAM_SLEEP_MILLIS = "sleep";
@@ -605,7 +605,7 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
     /**
      * handle scrolling
      */
-    private static Point ptop = new Point(0, 0);
+    private static final Point ptop = new Point(0, 0);
 
     protected void _setStatusText(String sText)
     {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/TableExporter.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/TableExporter.java
@@ -51,8 +51,8 @@ public class TableExporter implements DDTable.Exporter
 {
     static Logger logger = LogManager.getLogger(TableExporter.class);
 
-    private GameContext context_;
-    private String sName_;
+    private final GameContext context_;
+    private final String sName_;
     
     public TableExporter(GameContext context, String sName)
     {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/TerritoryComponent.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/TerritoryComponent.java
@@ -136,9 +136,9 @@ public class TerritoryComponent extends DDPanel
         }
     }
     
-    private static Font font_ = StylesConfig.getFont("territory.label");
+    private static final Font font_ = StylesConfig.getFont("territory.label");
     // BUG 133 - static (only draw one at a time)
-    private static Rectangle bounds_ = new Rectangle();    
+    private static final Rectangle bounds_ = new Rectangle();    
     
     /**
      * Draw territory the piece belongs to, scaled to size of 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UDPStatus.java
@@ -196,20 +196,20 @@ public class UDPStatus extends BasePhase implements DDTable.TableMenuItems
     }
 
     // column names
-    private static String COL_LINK = "udp.link";
-    private static String COL_REMOTE = "udp.remote";
-    private static String COL_MTU = "udp.mtu";
-    private static String COL_AVG = "udp.avg";
-    private static String COL_TIME = "udp.time";
-    private static String COL_SEND = "udp.send";
-    private static String COL_RESEND = "udp.resend";
-    private static String COL_RECEIVE = "udp.receive";
-    private static String COL_DUP = "udp.dup";
-    private static String COL_PKTSNT = "udp.pktsnt"; // not used for now
-    private static String COL_PKTERR = "udp.pkterr"; // not used for now
-    private static String COL_PKTRCV = "udp.pktrcv"; // not used for now
-    private static String COL_BYTESIN = "udp.bytesin";
-    private static String COL_BYTESOUT = "udp.bytesout";
+    private static final String COL_LINK = "udp.link";
+    private static final String COL_REMOTE = "udp.remote";
+    private static final String COL_MTU = "udp.mtu";
+    private static final String COL_AVG = "udp.avg";
+    private static final String COL_TIME = "udp.time";
+    private static final String COL_SEND = "udp.send";
+    private static final String COL_RESEND = "udp.resend";
+    private static final String COL_RECEIVE = "udp.receive";
+    private static final String COL_DUP = "udp.dup";
+    private static final String COL_PKTSNT = "udp.pktsnt"; // not used for now
+    private static final String COL_PKTERR = "udp.pkterr"; // not used for now
+    private static final String COL_PKTRCV = "udp.pktrcv"; // not used for now
+    private static final String COL_BYTESIN = "udp.bytesin";
+    private static final String COL_BYTESOUT = "udp.bytesout";
 
     // client table info
     private static final int[] COLUMN_WIDTHS = new int[] {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/UserRegistration.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/UserRegistration.java
@@ -74,11 +74,11 @@ public class UserRegistration extends BasePhase implements PropertyChangeListene
     private DDButton returnButton_;
     private DDButton reregButton_;
     private JComponent focus_;
-    private RegistrationMessage msg_ = new RegistrationMessage(EngineMessage.CAT_USER_REG);
-    private List<DDOption> options_ = new ArrayList<>();
+    private final RegistrationMessage msg_ = new RegistrationMessage(EngineMessage.CAT_USER_REG);
+    private final List<DDOption> options_ = new ArrayList<>();
     private long nRegTime_ = 0;
     private Preferences prefs_;
-    private static String REGTIME = "regtime";
+    private static final String REGTIME = "regtime";
     
     /** 
      * Creates a new instance of UserRegistration 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/Ban.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/Ban.java
@@ -75,7 +75,7 @@ public class Ban
     /**
      * Implements command line application interface.
      */
-    private static class BanApp extends BaseCommandLineApp
+    private static final class BanApp extends BaseCommandLineApp
     {
         private BanApp(String sConfigName, String[] args)
         {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/EngineMailErrorHandler.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/EngineMailErrorHandler.java
@@ -53,7 +53,7 @@ public class EngineMailErrorHandler implements DDMailErrorHandler
 {
     //static Logger logger = LogManager.getLogger(EngineMailErrorHandler.class);
     
-    private EngineServlet servlet_;
+    private final EngineServlet servlet_;
     /** 
      * Creates a new instance of EngineMailErrorHandler 
      */

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/PlayerQueue.java
@@ -48,7 +48,7 @@ import java.io.*;
  *
  * @author  donohoe
  */
-public class PlayerQueue extends ServerDataFile
+public final class PlayerQueue extends ServerDataFile
 {
     //static Logger logger = LogManager.getLogger(PlayerQueue.class);
     

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
@@ -109,7 +109,7 @@ public class RegAnalyzer
     /**
      * Implements command line application interface.
      */
-    private static class RegAnalyzerApp extends BaseCommandLineApp
+    private static final class RegAnalyzerApp extends BaseCommandLineApp
     {
         private RegAnalyzerApp(String sConfigName, String[] args)
         {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/RegDayOfYearCount.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/RegDayOfYearCount.java
@@ -41,9 +41,9 @@ package com.donohoedigital.games.server;
  */
 public class RegDayOfYearCount
 {
-    private int count;
-    private int day;
-    private int year;
+    private final int count;
+    private final int day;
+    private final int year;
 
     public RegDayOfYearCount(int count, int day, int year)
     {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/ServerSideGame.java
@@ -65,7 +65,7 @@ import java.util.Locale;
 /**
  * @author donohoe
  */
-public class ServerSideGame extends ServerDataFile implements GameInfo
+public final class ServerSideGame extends ServerDataFile implements GameInfo
 {
     static Logger logger = LogManager.getLogger(ServerSideGame.class);
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/PublicBan.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/PublicBan.java
@@ -37,10 +37,10 @@ package com.donohoedigital.games.server.model;
  */
 public class PublicBan
 {
-    private long banTill;
-    private String sKey;
-    private String sComment;
-    private String sDate;
+    private final long banTill;
+    private final String sKey;
+    private final String sComment;
+    private final String sDate;
 
     public PublicBan(String sKey, String sDate, long banTill, String sComment)
     {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/Registration.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/Registration.java
@@ -68,7 +68,7 @@ public class Registration implements BaseModel<Long>
 
     @Column(name = "reg_product_version", nullable = false)
     private String versionAsString;
-    transient private Version version;
+    private transient Version version;
 
     @Column(name = "reg_ip_address", nullable = false)
     private String ip;
@@ -313,7 +313,7 @@ public class Registration implements BaseModel<Long>
         this.state = state;
     }
 
-    transient private boolean ignoreSet = false;
+    private transient boolean ignoreSet = false;
 
     /**
      * version used by jpa

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/model/util/RegInfo.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/model/util/RegInfo.java
@@ -56,14 +56,14 @@ public class RegInfo implements Comparable<RegInfo>
     static Logger logger = LogManager.getLogger(RegInfo.class);
     
     // info
-    private String sKey_;
-    private List<Registration> msgs_ = new ArrayList<>();
-    private List<Registration> reg_msgs_ = new ArrayList<>();
-    private List<Registration> act_msgs_ = new ArrayList<>();
-    private List<Registration> patch_msgs_ = new ArrayList<>();
-    private List<Registration> dup_msgs_ = new ArrayList<>();
+    private final String sKey_;
+    private final List<Registration> msgs_ = new ArrayList<>();
+    private final List<Registration> reg_msgs_ = new ArrayList<>();
+    private final List<Registration> act_msgs_ = new ArrayList<>();
+    private final List<Registration> patch_msgs_ = new ArrayList<>();
+    private final List<Registration> dup_msgs_ = new ArrayList<>();
     private long mostRecent_;
-    private static SimpleDateFormat date_ = new SimpleDateFormat("MM/dd/yyyy 'at' HH:mm:ss", Locale.US);
+    private static final SimpleDateFormat date_ = new SimpleDateFormat("MM/dd/yyyy 'at' HH:mm:ss", Locale.US);
 
     private boolean banned = false;
     private String bannedComment = null;

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/Crosshair.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/Crosshair.java
@@ -54,7 +54,7 @@ public class Crosshair extends JComponent
     
     //static Logger logger = LogManager.getLogger(Crosshair.class);
     
-    private XYConstraints xyConstraints_; // constraints used to manage this point
+    private final XYConstraints xyConstraints_; // constraints used to manage this point
     
     static int defaultSize = 17;
     private boolean bDraw_ = true;

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameManager.java
@@ -58,12 +58,12 @@ import java.awt.event.*;
  */
 public abstract class GameManager extends BaseApp implements KeyListener, StatusDisplay
 {
-    private Logger logger = LogManager.getLogger(GameManager.class);
+    private final Logger logger = LogManager.getLogger(GameManager.class);
     
     // debugging settings
-    private boolean bDoSave = true;
-    private boolean bExitEarly = false;
-    private String sTitle;
+    private final boolean bDoSave = true;
+    private final boolean bExitEarly = false;
+    private final String sTitle;
     
     // config stuff
     protected GameboardConfig gameconfig_;

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
@@ -106,7 +106,7 @@ public class GameboardTerritoryManager extends GameManager implements CustomTerr
         super(sConfigName, "Territory Manager", args);
     }
     
-    private int nDefaultSize = 800;
+    private final int nDefaultSize = 800;
     
     /**
      * Create UI
@@ -206,8 +206,8 @@ public class GameboardTerritoryManager extends GameManager implements CustomTerr
 //    private String RESOURCE = PropertyConfig.getStringProperty("define.territoryPointType.resource", "notdefined", false);
 //    private String NATIVE = PropertyConfig.getStringProperty("define.territoryPointType.native", "notdefined", false);
 //    private Double SCALE_MARKER = .9d; // must match resource piece getScale() override
-    private Double SCALE_BUTTON = .4d; // must match buttonpiece getScale() override
-    private Double SCALE_ICON = .75d; // approximation
+    private final Double SCALE_BUTTON = .4d; // must match buttonpiece getScale() override
+    private final Double SCALE_ICON = .75d; // approximation
     
     public void drawTerritoryPart(Gameboard board, Graphics2D g, Territory t, GeneralPath path, Rectangle territoryBounds, int iPart) 
     {

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/XConnectorLines.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/XConnectorLines.java
@@ -75,8 +75,8 @@ public class XConnectorLines extends ImageComponent {
     
     // used for performance so a new rect and line 
     // isn't needed everytime we repaint
-    private Rectangle bounds_ = new Rectangle();
-    private Line2D line_ = new Line2D.Float();
+    private final Rectangle bounds_ = new Rectangle();
+    private final Line2D line_ = new Line2D.Float();
     
     protected void paintComponent(Graphics g)
     {

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/XPoints.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/XPoints.java
@@ -58,8 +58,8 @@ public class XPoints extends XConnectorLines implements KeyListener,
     
     static Logger logger = LogManager.getLogger(XPoints.class);
     protected MapPoints allPoints_;
-    private GameboardConfig gameconfig_;
-    private GameboardBorderManager manager_;
+    private final GameboardConfig gameconfig_;
+    private final GameboardBorderManager manager_;
         
     DrawingUtil util_;
     BorderPoint borderPointSelected_;   // border point selected (with focus)
@@ -91,7 +91,7 @@ public class XPoints extends XConnectorLines implements KeyListener,
     }
     
     // used for performance so new rect isn't needed everytime we repaint
-    private Rectangle bounds_ = new Rectangle();
+    private final Rectangle bounds_ = new Rectangle();
     
     ///
     /// Drawing methods
@@ -252,7 +252,7 @@ public class XPoints extends XConnectorLines implements KeyListener,
         }
         
         // if mouse button 2 pressed, add new border
-        if (e.getButton() == e.BUTTON3 || addToBorder == null)
+        if (e.getButton() == MouseEvent.BUTTON3 || addToBorder == null)
         {    
             Component cFocus = FocusManager.getCurrentManager().getFocusOwner();
             Border b = manager_.chooseBorder("Create New Border", point.getX(), point.getY(), false);

--- a/code/gui/src/main/java/com/donohoedigital/gui/ColorChooserPanel.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ColorChooserPanel.java
@@ -58,7 +58,7 @@ public class ColorChooserPanel extends DDPanel
     private static final int BLUE = 2;
     private static final int ALPHA = 3;
 
-    private String STYLE;
+    private final String STYLE;
     private DDLabel sample_;
     private Color color_;
     ColorPanel red_, green_, blue_, alpha_;

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDButtonUI.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDButtonUI.java
@@ -61,7 +61,7 @@ public class DDButtonUI extends MetalButtonUI
 {
     static Logger logger = LogManager.getLogger(DDButtonUI.class);
     
-    private final static DDButtonUI ddButtonUI = new DDButtonUI(); 
+    private static final DDButtonUI ddButtonUI = new DDButtonUI(); 
  
     public static ComponentUI createUI(JComponent c) {
         return ddButtonUI;

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDFileChooser.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDFileChooser.java
@@ -51,8 +51,8 @@ public class DDFileChooser extends JFileChooser implements DDTextVisibleComponen
 {
     //static Logger logger = LogManager.getLogger(DDFileChooser.class);
 
-    private Preferences prefs_;
-    private String sPrefName_;
+    private final Preferences prefs_;
+    private final String sPrefName_;
 
     /**
      * Creates a new instance of DDFileChooser

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlEditorKit.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlEditorKit.java
@@ -51,7 +51,7 @@ public class DDHtmlEditorKit extends HTMLEditorKit
 {
     private StyleSheet sheet_ = null;
 
-    private static HashMap hmTagViewClasses_ = new HashMap();
+    private static final HashMap hmTagViewClasses_ = new HashMap();
 
     static
     {

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDInternalFrameTitlePane.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDInternalFrameTitlePane.java
@@ -55,7 +55,7 @@ public class DDInternalFrameTitlePane extends MetalInternalFrameTitlePane
 {    
     InternalDialog dialog_;
     
-    private static Color modaltitle_ = StylesConfig.getColor("modal.title");
+    private static final Color modaltitle_ = StylesConfig.getColor("modal.title");
     
     /** Creates a new instance of DDInternalFrameTitlePane */
     public DDInternalFrameTitlePane(InternalDialog f) 

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDMultiResIcon.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDMultiResIcon.java
@@ -65,7 +65,7 @@ import java.util.TreeMap;
  *
  * @author Doug Donohoe
  */
-public class DDMultiResIcon implements Icon
+public final class DDMultiResIcon implements Icon
 {
     /**
      * Variant sizes looked for in images.xml.  Covers the common scales for the ~20px artwork

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDOption.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDOption.java
@@ -239,7 +239,7 @@ public abstract class DDOption extends DDPanel implements MouseListener
     }
 
     // small perf improvement
-    private static StringBuilder sbHelp = new StringBuilder();
+    private static final StringBuilder sbHelp = new StringBuilder();
     /**
      * when get mouse entered, set help text
      */

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDSplitPane.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDSplitPane.java
@@ -49,7 +49,7 @@ import java.awt.Point;
 public class DDSplitPane extends JSplitPane implements DDComponent
 {
     // our ui
-    private DDSplitPaneUI ui_;
+    private final DDSplitPaneUI ui_;
     private Color thumbFocusOverlay_=  null;
 
     public DDSplitPane(String sName, String sStyle,

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDSplitPaneDivider.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDSplitPaneDivider.java
@@ -48,11 +48,11 @@ import java.awt.Insets;
  */
 public class DDSplitPaneDivider extends BasicSplitPaneDivider
 {
-    private DDSplitPane split_;
+    private final DDSplitPane split_;
 
-    private DDMetalBumps ddbumps_;
+    private final DDMetalBumps ddbumps_;
     private Color thumbColor;
-    private int inset = 2;
+    private final int inset = 2;
 
     public DDSplitPaneDivider(BasicSplitPaneUI ui, DDSplitPane split)
     {

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDTabPanel.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDTabPanel.java
@@ -52,7 +52,7 @@ public abstract class DDTabPanel extends DDPanel implements AncestorListener
     private int nTabNum_;
     private Icon icon_;
     private Icon error_;
-    private List<DDOption> options_ = new ArrayList<>();
+    private final List<DDOption> options_ = new ArrayList<>();
     private String sHelp_;
 
     public DDTabPanel()

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDTable.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDTable.java
@@ -170,7 +170,7 @@ public class DDTable extends JTable implements DDTextVisibleComponent, MouseList
     {
     }
 
-    private static ImageIcon exportIcon_ = ImageConfig.getImageIcon("menuicon.export");
+    private static final ImageIcon exportIcon_ = ImageConfig.getImageIcon("menuicon.export");
 
     public void mouseReleased(MouseEvent e)
     {

--- a/code/gui/src/main/java/com/donohoedigital/gui/EmptyImageComponent.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/EmptyImageComponent.java
@@ -50,8 +50,8 @@ import java.awt.image.BufferedImage;
  */
 public class EmptyImageComponent extends ImageComponent 
 {
-    private int nWidth_;
-    private int nHeight_;
+    private final int nWidth_;
+    private final int nHeight_;
     
     /** 
      * Creates a new instance of EmptyImageComponent 

--- a/code/gui/src/main/java/com/donohoedigital/gui/GlassButtonUI.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GlassButtonUI.java
@@ -66,7 +66,7 @@ public class GlassButtonUI extends DDButtonUI
     private static final Color SHADOW = new Color(0,0,0,100);
     private static final Color HILITE = new Color(255,255,255,75);
 
-    private final static GlassButtonUI gButtonUI = new GlassButtonUI();
+    private static final GlassButtonUI gButtonUI = new GlassButtonUI();
 
     public static ComponentUI createUI(JComponent c) {
         return gButtonUI;
@@ -91,7 +91,7 @@ public class GlassButtonUI extends DDButtonUI
         paintReflections(g, gb);
     }
 
-    private Rectangle bounds_ = new Rectangle();
+    private final Rectangle bounds_ = new Rectangle();
     private java.awt.geom.Area cliparea_;
     private Shape button_;
     private Area buttonarea_;

--- a/code/gui/src/main/java/com/donohoedigital/gui/GuiManager.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/GuiManager.java
@@ -53,7 +53,7 @@ import java.awt.event.MouseListener;
 /**
  * @author Doug Donohoe
  */
-public class GuiManager implements MouseListener
+public final class GuiManager implements MouseListener
 {
     //static Logger logger = LogManager.getLogger(GuiManager.class);
 
@@ -290,7 +290,7 @@ public class GuiManager implements MouseListener
     }
 
     // small perf improvement for below
-    private static StringBuilder sbHelpName = new StringBuilder();
+    private static final StringBuilder sbHelpName = new StringBuilder();
 
     /**
      * Get default help message

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionCombo.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionCombo.java
@@ -54,8 +54,8 @@ public class OptionCombo extends DDOption implements ItemListener
 {
     //static Logger logger = LogManager.getLogger(OptionCombo.class);
     private DDLabel label_;
-    private DDComboBox combo_;
-    private String sDefault_;
+    private final DDComboBox combo_;
+    private final String sDefault_;
 
     /** 
      * Creates a new instance of OptionCombo 

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionSlider.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionSlider.java
@@ -55,8 +55,8 @@ public class OptionSlider extends DDOption implements ChangeListener
 {
     //static Logger logger = LogManager.getLogger(OptionSlider.class);
     
-    private DDLabel label_;
-    private DDSlider slider_;
+    private final DDLabel label_;
+    private final DDSlider slider_;
     private Integer nDefault_;
 
     /** 

--- a/code/gui/src/main/java/com/donohoedigital/gui/OptionTextArea.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/OptionTextArea.java
@@ -57,10 +57,10 @@ public class OptionTextArea extends DDOption implements PropertyChangeListener
 {
     //static Logger logger = LogManager.getLogger(OptionTextArea.class);
     
-    private DDLabel label_;
-    private DDTextArea text_;
-    private String sDefault_;
-    private JScrollPane scroll_;
+    private final DDLabel label_;
+    private final DDTextArea text_;
+    private final String sDefault_;
+    private final JScrollPane scroll_;
 
     /** 
      * Creates a new instance of OptionTextArea 

--- a/code/gui/src/main/java/com/donohoedigital/gui/ScaleConstraintsFixed.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ScaleConstraintsFixed.java
@@ -41,7 +41,7 @@ package com.donohoedigital.gui;
  */
 public class ScaleConstraintsFixed
 {
-    private int nVert_, nHoriz_;
+    private final int nVert_, nHoriz_;
 
     public ScaleConstraintsFixed(int nVerticalAlign, int nHorizontalAlign)
     {

--- a/code/gui/src/main/java/com/donohoedigital/gui/ScaleLayout.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/ScaleLayout.java
@@ -58,7 +58,7 @@ public class ScaleLayout implements LayoutManager2, Cloneable
     
     private static final ScaleConstraints defaultConstraints = new ScaleConstraints();
     
-    private HashMap info = new HashMap();
+    private final HashMap info = new HashMap();
     
     public ScaleLayout() {
     }

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/Jsp.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/Jsp.java
@@ -38,7 +38,7 @@ import org.apache.jasper.runtime.JspFactoryImpl;
 public class Jsp {
 
     // Need to set a JspFactory in Tomcat 8
-    synchronized static void init() {
+    static synchronized void init() {
         if (JspFactory.getDefaultFactory() == null) {
             JspFactory.setDefaultFactory(new JspFactoryImpl());
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonDisplay.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonDisplay.java
@@ -58,7 +58,7 @@ public class ButtonDisplay extends ChainPhase implements Runnable
     
     private PokerGame game_;
     private PokerTable table_;
-    private static int BUTTON_DELAY = 100;
+    private static final int BUTTON_DELAY = 100;
     
     /** 
      * Creates a new instance of ButtonDisplay 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonPiece.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ButtonPiece.java
@@ -56,10 +56,10 @@ import java.awt.geom.GeneralPath;
  */
 public class ButtonPiece extends PokerGamePiece
 {
-    private static GeneralPath path_ = GuiUtils.drawSVGpath(
+    private static final GeneralPath path_ = GuiUtils.drawSVGpath(
             "M26.018,77.979v-5.375h5.375v-43.5h-5.375v-5.375h26.769c8.594,0,15.301,2.305,20.123,6.91c4.82,4.605,7.232,11.014,7.232,19.225c0,8.529-2.338,15.348-7.014,20.455s-10.918,7.66-18.73,7.66H26.018z M42.768,72.104h6.213c6.343,0,11.103-1.863,14.277-5.594c3.172-3.73,4.76-9.313,4.76-16.75c0-6.896-1.648-12.063-4.941-15.5c-3.295-3.438-8.236-5.156-14.822-5.156h-5.486V72.104z",
             false);
-    private static ButtonImageComponent ic_ = new ButtonImageComponent();
+    private static final ButtonImageComponent ic_ = new ButtonImageComponent();
 
     /**
      * Creates a new instance of ButtonPiece 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/CardPiece.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/CardPiece.java
@@ -332,7 +332,7 @@ public class CardPiece extends PokerGamePiece
     private static String sLastBack_ = null;
     private static ImageComponent icBack_ = null;
 
-    private synchronized static ImageComponent getDefault()
+    private static synchronized ImageComponent getDefault()
     {
         if (icDefault_ == null)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingPanel.java
@@ -49,7 +49,7 @@ public class ChipRatingPanel extends DDPanel
     private static final ImageIcon halfChip_ = ImageConfig.getImageIcon("rating16_half");
     private static final ImageIcon emptyChip_ = ImageConfig.getImageIcon("rating16_empty");
 
-    private JLabel[] chips_ = new JLabel[5];
+    private final JLabel[] chips_ = new JLabel[5];
 
     int value_ = 0;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingSlider.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ChipRatingSlider.java
@@ -47,13 +47,13 @@ import java.awt.Dimension;
 
 public class ChipRatingSlider extends DDPanel implements ChangeListener
 {
-    private ChipRatingPanel chips_;
-    private DDLabel label_;
-    private DDSlider slider_;
-    private DDPanel leftInner_;
-    private DDPanel leftOuter_;
-    private DDPanel pad_;
-    private String sType_;
+    private final ChipRatingPanel chips_;
+    private final DDLabel label_;
+    private final DDSlider slider_;
+    private final DDPanel leftInner_;
+    private final DDPanel leftOuter_;
+    private final DDPanel pad_;
+    private final String sType_;
 
     public ChipRatingSlider(String sStyle, String sType, int minValue, int maxValue)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/CountdownPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/CountdownPanel.java
@@ -53,15 +53,15 @@ import java.awt.event.ActionListener;
  */
 public class CountdownPanel extends DDPanel implements ActionListener
 {
-    private PokerGame game_;
+    private final PokerGame game_;
     private Timer count_;
     private int timeout_;
     private int thinkbank_;
     private double total_;
     private long timepoint_;
     private long elapsed_;
-    private GameClock clock_;
-    private boolean bSupported_; // BUG 498
+    private final GameClock clock_;
+    private final boolean bSupported_; // BUG 498
 
     public CountdownPanel(PokerGame game)
     {
@@ -149,8 +149,8 @@ public class CountdownPanel extends DDPanel implements ActionListener
         repaint();
     }
 
-    private String secPlural = PropertyConfig.getMessage("msg.seconds.plural", "");
-    private String secSingular = PropertyConfig.getMessage("msg.seconds.singular", "");
+    private final String secPlural = PropertyConfig.getMessage("msg.seconds.plural", "");
+    private final String secSingular = PropertyConfig.getMessage("msg.seconds.singular", "");
 
     /**
      * tooltip text

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DDCardView.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DDCardView.java
@@ -53,10 +53,10 @@ public class DDCardView extends DDView
 {
     static Logger logger = LogManager.getLogger(DDCardView.class);
 
-    private static CardThumbnail piece_ = new CardThumbnail();
+    private static final CardThumbnail piece_ = new CardThumbnail();
 
     private Card card_;
-    private int border_ = 1;
+    private final int border_ = 1;
     public static final int HEIGHT = 26;
     public static final int WIDTH = 20;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DDHandGroupView.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DDHandGroupView.java
@@ -55,7 +55,7 @@ public class DDHandGroupView extends ComponentView
     public static final int DEFAULT_HEIGHT = 200;
     public static final int DEFAULT_WIDTH = 200;
 
-    private HandGroup group_;
+    private final HandGroup group_;
     private int width_ = 0;
     private int height_ = 0;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DatabaseQueryTableModel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DatabaseQueryTableModel.java
@@ -45,9 +45,9 @@ import java.util.Vector;
 
 public class DatabaseQueryTableModel extends DDPagingTableModel
 {
-    private Database database_;
-    private String query_;
-    private BindArray bindArray_;
+    private final Database database_;
+    private final String query_;
+    private final BindArray bindArray_;
 
     public boolean isCellEditable(int row, int column)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DeckProfilePanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DeckProfilePanel.java
@@ -70,9 +70,9 @@ public class DeckProfilePanel extends DDPanel implements ChangeListener
     private static final String COMMON_NAME = "deckback";
     public static final String DECK_PROFILE = "deck";
 
-    private DDLabelBorder displayBorder_;
-    private ProfileList profileList_;
-    private DeckCardPanel card_;
+    private final DDLabelBorder displayBorder_;
+    private final ProfileList profileList_;
+    private final DeckCardPanel card_;
         
     /** 
      * Get component with options, also fill array with same options

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GameInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GameInfoDialog.java
@@ -75,7 +75,7 @@ public class GameInfoDialog extends DialogPhase
     private PokerGame game_;
     private TournamentProfile profile_;
     private DDTabbedPane tab_;
-    private ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
+    private final ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
     private boolean bLobbyMode_;
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroup.java
@@ -61,7 +61,7 @@ public class HandGroup extends BaseProfile {
 
     private static HandGroup ALL_HANDS = null;
 
-    public synchronized static HandGroup getAllHands()
+    public static synchronized HandGroup getAllHands()
     {
         if (ALL_HANDS == null)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandGroupDialog.java
@@ -54,7 +54,7 @@ public class HandGroupDialog extends OptionMenuDialog implements PropertyChangeL
 
     private HandGroup profile_;
 
-    private TypedHashMap dummy_ = new TypedHashMap();
+    private final TypedHashMap dummy_ = new TypedHashMap();
 
     private DDPanel base_;
     private HandGroupGridPanel gridPanel_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandHistoryPanel.java
@@ -58,9 +58,9 @@ public class HandHistoryPanel extends DDPanel
 {
 
     private String where_;
-    private BindArray bindArray_;
-    private HoldemHand currentHand_;
-    private int pageSize_;
+    private final BindArray bindArray_;
+    private final HoldemHand currentHand_;
+    private final int pageSize_;
 
     private int handCount_;
     private int handFirst_;
@@ -70,20 +70,20 @@ public class HandHistoryPanel extends DDPanel
 
     private List<Object> hands_;
 
-    private GameContext context_;
-    private DDTabbedPane tabs_;
-    private DDHtmlArea detailsHtmlArea_;
-    private DDHtmlArea summaryHtmlArea_;
-    private DDCheckBox showAllCheckbox_;
-    private DDCheckBox showReasonCheckbox_;
-    private ListPanel handsList_;
-    private JScrollPane summaryScroll_;
-    private DDLabel titleLabel_;
-    private DDLabel pagingLabel_;
-    private DDButton pageDownButton_;
-    private DDButton pageUpButton_;
-    private DDButton exportButton_;
-    private ImageIcon icon_ = ImageConfig.getImageIcon("ddlogo20");
+    private final GameContext context_;
+    private final DDTabbedPane tabs_;
+    private final DDHtmlArea detailsHtmlArea_;
+    private final DDHtmlArea summaryHtmlArea_;
+    private final DDCheckBox showAllCheckbox_;
+    private final DDCheckBox showReasonCheckbox_;
+    private final ListPanel handsList_;
+    private final JScrollPane summaryScroll_;
+    private final DDLabel titleLabel_;
+    private final DDLabel pagingLabel_;
+    private final DDButton pageDownButton_;
+    private final DDButton pageUpButton_;
+    private final DDButton exportButton_;
+    private final ImageIcon icon_ = ImageConfig.getImageIcon("ddlogo20");
 
     public HandHistoryPanel(GameContext context, String sStyle, String where, BindArray bindArray, HoldemHand currentHand, int pageSize)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandLadder.java
@@ -50,18 +50,18 @@ public class HandLadder
     private static final int SAME_TYPE_LOWER_RANK = 5;
     private static final int LOWER_TYPE = 6;
 
-    private Hand pocket_;
-    private Hand community_;
+    private final Hand pocket_;
+    private final Hand community_;
 
     private int handScore_;
     private int handType_;
 
-    private HandList[] ladder_;
+    private final HandList[] ladder_;
 
-    private HandList[] strongerHandsByType_;
-    private HandList[] weakerHandsByType_;
+    private final HandList[] strongerHandsByType_;
+    private final HandList[] weakerHandsByType_;
 
-    private int[] countByType_;
+    private final int[] countByType_;
     private int totalCount_;
 
     HandInfoFast handInfo_ = new HandInfoFast();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
@@ -58,7 +58,7 @@ public class HandStrength
     static Logger logger = LogManager.getLogger(HandStrength.class);
     
     // debug output
-    private static boolean DEBUG = false;
+    private static final boolean DEBUG = false;
     
     // number of straights made by opponents
     private int nNumStraights_ = 0;
@@ -283,7 +283,7 @@ public class HandStrength
         }
     }
     
-    private static Format fPerc = new Format("%2.1f");
+    private static final Format fPerc = new Format("%2.1f");
     
     /** 
      * figure score for each hand and record wins (ties count as wins)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemExpert.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemExpert.java
@@ -110,15 +110,15 @@ public class HoldemExpert {
     }
     
     // groups
-    private static ArrayList[] GROUPS = new ArrayList[8];
-    private static ArrayList aGROUP1 = new ArrayList();
-    private static ArrayList aGROUP2 = new ArrayList();
-    private static ArrayList aGROUP3 = new ArrayList();
-    private static ArrayList aGROUP4 = new ArrayList();
-    private static ArrayList aGROUP5 = new ArrayList();
-    private static ArrayList aGROUP6 = new ArrayList();
-    private static ArrayList aGROUP7 = new ArrayList();
-    private static ArrayList aGROUP8 = new ArrayList();
+    private static final ArrayList[] GROUPS = new ArrayList[8];
+    private static final ArrayList aGROUP1 = new ArrayList();
+    private static final ArrayList aGROUP2 = new ArrayList();
+    private static final ArrayList aGROUP3 = new ArrayList();
+    private static final ArrayList aGROUP4 = new ArrayList();
+    private static final ArrayList aGROUP5 = new ArrayList();
+    private static final ArrayList aGROUP6 = new ArrayList();
+    private static final ArrayList aGROUP7 = new ArrayList();
+    private static final ArrayList aGROUP8 = new ArrayList();
     
     // specific hands
     public static final HandSorted AA = new HandSorted(Card.CLUBS_A, Card.SPADES_A);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemHand.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemHand.java
@@ -159,7 +159,7 @@ public class HoldemHand implements DataMarshal
      * Seed - degree of randomness from timing of hands and number of actions in hand
      * MersenneTwisterFast recommends passing in an int
      */
-    private synchronized static int NEXT_SEED()
+    private static synchronized int NEXT_SEED()
     {
         long mult = (long) lastSEED * (long) SEEDADJ;
         int seed = (int) (mult % Integer.MAX_VALUE);
@@ -173,7 +173,7 @@ public class HoldemHand implements DataMarshal
     /**
      * adj seed
      */
-    private synchronized static void ADJUST_SEED()
+    private static synchronized void ADJUST_SEED()
     {
         long now = System.currentTimeMillis();
         long adj = SEEDADJ + (now - lastADJ);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
@@ -864,8 +864,8 @@ public class HoldemSimulator
         }
     }
 
-    private static int DONE = -2;
-    private static int INIT = -1;
+    private static final int DONE = -2;
+    private static final int INIT = -1;
 
     private static class IndexKeeper
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/OtherTables.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/OtherTables.java
@@ -424,8 +424,8 @@ public class OtherTables
     /////
 
     // instances for sorting
-    private static SortChipsAtStart SORTCHIPSATSTART = new SortChipsAtStart();
-    private static SortFilledSeats SORTFILLEDSEATS = new SortFilledSeats();
+    private static final SortChipsAtStart SORTCHIPSATSTART = new SortChipsAtStart();
+    private static final SortFilledSeats SORTFILLEDSEATS = new SortFilledSeats();
     
     // sort players by chips they have at start of hand
     private static class SortChipsAtStart implements Comparator<PokerPlayer>

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileOptions.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileOptions.java
@@ -192,11 +192,11 @@ public class PlayerProfileOptions extends BasePhase implements ChangeListener
     {
         return new PlayerProfileList(engine, context, PROFILE_NAME);
     }
-    
+
     /**
      * Our list editor
      */
-    private static class PlayerProfileList extends ProfileList
+    private static final class PlayerProfileList extends ProfileList
     {
         private PlayerProfileList(GameEngine engine, GameContext context, String sMsgName)
         {
@@ -490,8 +490,8 @@ public class PlayerProfileOptions extends BasePhase implements ChangeListener
                                          formatter.format(hist.getEndDate())
         );
     }
-    
-    private class DeleteButton extends GlassButton implements ActionListener
+
+    private final class DeleteButton extends GlassButton implements ActionListener
     {
         int nIndex_;
 
@@ -513,8 +513,8 @@ public class PlayerProfileOptions extends BasePhase implements ChangeListener
             }
         }
     }
-    
-    private class DeleteAllButton extends GlassButton implements ActionListener
+
+    private final class DeleteAllButton extends GlassButton implements ActionListener
     {
         private DeleteAllButton()
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerCustomTerritoryDrawer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerCustomTerritoryDrawer.java
@@ -63,8 +63,8 @@ public class PokerCustomTerritoryDrawer implements CustomTerritoryDrawer
 
     static Logger logger = LogManager.getLogger(PokerCustomTerritoryDrawer.class);
 
-    private PokerGame game_;
-    private MersenneTwisterFast random_ = new MersenneTwisterFast();
+    private final PokerGame game_;
+    private final MersenneTwisterFast random_ = new MersenneTwisterFast();
 
     /**
      * Creates a new instance of PokerCustomTerritoryDrawer

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
@@ -34,6 +34,7 @@ package com.donohoedigital.games.poker;
 
 import com.donohoedigital.base.ApplicationError;
 import com.donohoedigital.base.Utils;
+import com.donohoedigital.config.BaseDataFile;
 import com.donohoedigital.config.DebugConfig;
 import com.donohoedigital.config.PropertyConfig;
 import com.donohoedigital.db.BindArray;
@@ -2121,7 +2122,7 @@ public class PokerDatabase
 
         PlayerProfile profile = PlayerProfileOptions.getDefaultProfile();
 
-        ieHand.profileNumber = profile.getFileNumber(profile.getFile());
+        ieHand.profileNumber = BaseDataFile.getFileNumber(profile.getFile());
         ieHand.handID = handID;
 
         Database database = getDatabase();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGameboard.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGameboard.java
@@ -68,13 +68,13 @@ public class PokerGameboard extends Gameboard
     static Logger logger = LogManager.getLogger(PokerGameboard.class);
 
     private static final GeneralPath FELT = GuiUtils.drawSVGpath("M180,0c90,1,760,1,850,0c90,1,180,184,180,443.5c0,260.5-90,442.5-180,442.5s-760,0-850,0S0,704,0,443.5C0,184,90,1,180,0z", false);
-    private static Rectangle FBOUNDS = FELT.getBounds();
+    private static final Rectangle FBOUNDS = FELT.getBounds();
 
-    private PokerGame game_;
+    private final PokerGame game_;
     protected int nSmallWidth_, nSmallHeight_;
     protected int nStartingWidth_, nStartingHeight_;
 
-    private PokerGameboardDelegate delegate_;
+    private final PokerGameboardDelegate delegate_;
 
     // default - green felt
     private Color top_ = new Color(38,175,23);
@@ -618,7 +618,7 @@ public class PokerGameboard extends Gameboard
     /**
      * for use above
      */
-    private static class Faux2 extends ImageComponent
+    private static final class Faux2 extends ImageComponent
     {
         FauxPokerGameboard parent;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -718,7 +718,7 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
     /**
      * Poker TCP/IP server
      */
-    private class PokerTCPServer extends Peer2PeerServer implements PokerConnectionServer
+    private final class PokerTCPServer extends Peer2PeerServer implements PokerConnectionServer
     {
         private PokerTCPServer()
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPrefsPlayerList.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPrefsPlayerList.java
@@ -47,15 +47,15 @@ import java.util.prefs.Preferences;
  * Time: 10:34:46 AM
  * To change this template use File | Settings | File Templates.
  */
-public class PokerPrefsPlayerList extends AbstractPlayerList
+public final class PokerPrefsPlayerList extends AbstractPlayerList
 {
     // these have to match gamedef.xml entry
     
     public static final String LIST_MUTE = "muted";
     public static final String LIST_BANNED = "banned";
 
-    private String sListName_;
-    private String sListNameKey_;
+    private final String sListName_;
+    private final String sListNameKey_;
     protected boolean bUseKey_ = false;
 
     private static Map<String, PokerPrefsPlayerList> share_ = null;
@@ -63,7 +63,7 @@ public class PokerPrefsPlayerList extends AbstractPlayerList
     /**
      * Get shared PlayerList
      */
-    public synchronized static PokerPrefsPlayerList getSharedList(String sListName)
+    public static synchronized PokerPrefsPlayerList getSharedList(String sListName)
     {
         if (share_ == null)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerShowdownPanel.java
@@ -64,16 +64,16 @@ public class PokerShowdownPanel extends DDTabPanel implements DDProgressFeedback
 {
     static Logger logger = LogManager.getLogger(PokerShowdownPanel.class);
 
-    private static Dimension resultsSize = new Dimension(90, 50);
+    private static final Dimension resultsSize = new Dimension(90, 50);
 
-    private GameContext context_;
-    private PokerTable table_;
+    private final GameContext context_;
+    private final PokerTable table_;
     private DDProgressBar progress_;
-    private String STYLE;
-    private SimulatorDialog sim_;
+    private final String STYLE;
+    private final SimulatorDialog sim_;
     private OptionInteger numOpponents_, numSims_;
     private DDRadioButton allcombo_, simcombo_;
-    private List<DDLabelBorder> opponents_ = new ArrayList<>();
+    private final List<DDLabelBorder> opponents_ = new ArrayList<>();
     private boolean bStopRequested_ = false;
     private boolean bIterWayBig_;
     private GlassButton run_, stop_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerSimulatorPanel.java
@@ -54,7 +54,7 @@ public class PokerSimulatorPanel extends DDTabPanel implements DDProgressFeedbac
     private DDProgressBar progress_;
     private boolean bStopRequested_ = false;
     private GlassButton stop_, run_;
-    private SimulatorDialog sim_;
+    private final SimulatorDialog sim_;
 
     public PokerSimulatorPanel(SimulatorDialog sim)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -1971,7 +1971,7 @@ public class PokerTable implements ObjectID
     /**
      * Helper class to track listener and the event types it is interested in
      */
-    private static class ListenerInfo
+    private static final class ListenerInfo
     {
         public static final ListenerInfo NULL_LISTENER = new ListenerInfo(null, 0);
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
@@ -59,9 +59,9 @@ import java.net.InetSocketAddress;
  */
 public class PokerUDPServer extends UDPServer implements PokerConnectionServer, ChatLobbyManager
 {
-    private static Logger logger = LogManager.getLogger(PokerUDPServer.class);
+    private static final Logger logger = LogManager.getLogger(PokerUDPServer.class);
 
-    private PokerMain main_;
+    private final PokerMain main_;
     private UDPLink chatLink_;
     private InetSocketAddress chatServer_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PreFlopBias.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PreFlopBias.java
@@ -37,7 +37,7 @@ import com.donohoedigital.games.poker.engine.Card;
 
 public class PreFlopBias
 {
-    private static String openavgfull =
+    private static final String openavgfull =
             "E E E M M M L L L D D D D "+
             "E E M L L L D D           "+
             "M L E M l D d             "+
@@ -52,7 +52,7 @@ public class PreFlopBias
             "D                     l   "+
             "D                       l ";
     
-    private static String opentightfull =
+    private static final String opentightfull =
             "E E M M M L L l D D D D D "+
             "E E M L L D D d           "+
             "M L E M l D d             "+
@@ -67,7 +67,7 @@ public class PreFlopBias
             "d                     D   "+
             "d                       D ";
             
-    private static String openloosefull =
+    private static final String openloosefull =
             "E E E E M M M M L L L D D "+
             "E E M L L L D D D d       "+
             "M L E M l D D d           "+
@@ -82,7 +82,7 @@ public class PreFlopBias
             "D                     L   "+
             "D                       L ";
     
-    private static String openavgshort =
+    private static final String openavgshort =
             "E E E E E M M M M L L L L "+
             "E E E E M L L D D d d     "+
             "E L E E M L D D d         "+

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerNightTable.java
@@ -491,7 +491,7 @@ public class ShowPokerNightTable extends ShowPokerTable implements PropertyChang
     }
 
     // runnable for in swing thread
-    private Runnable update_ = () -> {
+    private final Runnable update_ = () -> {
         updateLevel();
         checkButtons();
     };

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowPokerTable.java
@@ -308,7 +308,7 @@ public abstract class ShowPokerTable extends ChainPhase implements
     /**
      * Camera button
      */
-    private class Camera extends DDImageButton implements ActionListener
+    private final class Camera extends DDImageButton implements ActionListener
     {
         private Camera()
         {
@@ -852,8 +852,8 @@ public abstract class ShowPokerTable extends ChainPhase implements
     }
 
     // for fast bounds
-    private Rectangle bounds_ = new Rectangle();
-    private Rectangle resizeBounds_ = new Rectangle();
+    private final Rectangle bounds_ = new Rectangle();
+    private final Rectangle resizeBounds_ = new Rectangle();
 
     /**
      * Notify delegate that board is repainting, so resize control

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -2067,21 +2067,21 @@ public class ShowTournamentTable extends ShowPokerTable implements
     //// popup menu items
     ////
 
-    private static ImageIcon blankIcon_ = ImageConfig.getImageIcon("menuicon.blank");
-    private static ImageIcon moneyIcon_ = ImageConfig.getImageIcon("menuicon.money");
-    private static ImageIcon buttonIcon_ = ImageConfig.getImageIcon("menuicon.button");
-    private static ImageIcon dealIcon_ = ImageConfig.getImageIcon("menuicon.deal");
-    private static ImageIcon checkedIcon_ = ImageConfig.getImageIcon("menuicon.checked");
-    private static ImageIcon cardIcon_ = ImageConfig.getImageIcon("menuicon.card");
-    private static ImageIcon playertypeIcon_ = ImageConfig.getImageIcon("menuicon.playertype");
-    private static ImageIcon advisorIcon_ = ImageConfig.getImageIcon("menuicon.advisor");
-    private static ImageIcon playerNameIcon_ = ImageConfig.getImageIcon("menuicon.playername");
-    private static ImageIcon removePlayerIcon_ = ImageConfig.getImageIcon("menuicon.removeplayer");
-    private static ImageIcon sitoutIcon_ = ImageConfig.getImageIcon("menuicon.sitout");
-    private static ImageIcon banIcon_ = ImageConfig.getImageIcon("menuicon.ban");
-    private static ImageIcon unbanIcon_ = ImageConfig.getImageIcon("menuicon.unban");
-    private static ImageIcon muteIcon_ = ImageConfig.getImageIcon("menuicon.mute");
-    private static ImageIcon unmuteIcon_ = ImageConfig.getImageIcon("menuicon.unmute");
+    private static final ImageIcon blankIcon_ = ImageConfig.getImageIcon("menuicon.blank");
+    private static final ImageIcon moneyIcon_ = ImageConfig.getImageIcon("menuicon.money");
+    private static final ImageIcon buttonIcon_ = ImageConfig.getImageIcon("menuicon.button");
+    private static final ImageIcon dealIcon_ = ImageConfig.getImageIcon("menuicon.deal");
+    private static final ImageIcon checkedIcon_ = ImageConfig.getImageIcon("menuicon.checked");
+    private static final ImageIcon cardIcon_ = ImageConfig.getImageIcon("menuicon.card");
+    private static final ImageIcon playertypeIcon_ = ImageConfig.getImageIcon("menuicon.playertype");
+    private static final ImageIcon advisorIcon_ = ImageConfig.getImageIcon("menuicon.advisor");
+    private static final ImageIcon playerNameIcon_ = ImageConfig.getImageIcon("menuicon.playername");
+    private static final ImageIcon removePlayerIcon_ = ImageConfig.getImageIcon("menuicon.removeplayer");
+    private static final ImageIcon sitoutIcon_ = ImageConfig.getImageIcon("menuicon.sitout");
+    private static final ImageIcon banIcon_ = ImageConfig.getImageIcon("menuicon.ban");
+    private static final ImageIcon unbanIcon_ = ImageConfig.getImageIcon("menuicon.unban");
+    private static final ImageIcon muteIcon_ = ImageConfig.getImageIcon("menuicon.mute");
+    private static final ImageIcon unmuteIcon_ = ImageConfig.getImageIcon("menuicon.unmute");
 
     /**
      * Class used to track what the menu item does
@@ -2748,7 +2748,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
     //// mouse translation
     ////
 
-    private MouseTranslator mouseTrans_ = new MouseTranslator();
+    private final MouseTranslator mouseTrans_ = new MouseTranslator();
 
     /**
      * mouse motion/click translation - need for mouse motion/click handling

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/SimulatorDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/SimulatorDialog.java
@@ -69,8 +69,8 @@ public class SimulatorDialog extends BasePhase implements ChangeListener
 {
     static Logger logger = LogManager.getLogger(SimulatorDialog.class);
 
-    private static ImageIcon blankIcon_ = ImageConfig.getImageIcon("menuicon.blank");
-    private static ImageIcon checkedIcon_ = ImageConfig.getImageIcon("menuicon.checked");
+    private static final ImageIcon blankIcon_ = ImageConfig.getImageIcon("menuicon.blank");
+    private static final ImageIcon checkedIcon_ = ImageConfig.getImageIcon("menuicon.checked");
 
     static int MENU_CLEAR_ALL = 0;
     static int MENU_CLEAR_OPP = 1;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TableListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TableListPanel.java
@@ -64,9 +64,9 @@ public class TableListPanel extends DDTabPanel implements ChangeListener, Action
 {
     private static final int NUMDISPLAY = 2;
 
-    private GameContext context_;
-    private PokerGame game_;
-    private String STYLE;
+    private final GameContext context_;
+    private final PokerGame game_;
+    private final String STYLE;
     private DDPanel tbls_;
     private TablePanel[] tables_;
     private DDSlider slider_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentOptions.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentOptions.java
@@ -152,7 +152,7 @@ public class TournamentOptions extends BasePhase implements ChangeListener, Ance
     /**
      * Our list editor
      */
-    private class TournamentProfileList extends ProfileList
+    private final class TournamentProfileList extends ProfileList
     {
         private TournamentProfileList(GameEngine engine, List<BaseProfile> profiles,
                                       String sStyle,

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentProfileDialog.java
@@ -75,14 +75,14 @@ public class TournamentProfileDialog extends OptionMenuDialog implements Propert
     static Logger logger = LogManager.getLogger(TournamentProfileDialog.class);
 
     static com.donohoedigital.base.Format fPerc = new com.donohoedigital.base.Format("%1.3f");
-    private javax.swing.border.Border empty_ = null;
+    private final javax.swing.border.Border empty_ = null;
     private TournamentProfile profile_;
     private PokerGame game_; // used when editing during a tournament
-    private TypedHashMap dummy_ = new TypedHashMap();
-    private TypedHashMap labelignore_ = new TypedHashMap();
+    private final TypedHashMap dummy_ = new TypedHashMap();
+    private final TypedHashMap labelignore_ = new TypedHashMap();
     private TypedHashMap orig_;
-    private ArrayList rebuyOptions_ = new ArrayList();
-    private ArrayList addonOptions_ = new ArrayList();
+    private final ArrayList rebuyOptions_ = new ArrayList();
+    private final ArrayList addonOptions_ = new ArrayList();
     private DDPanel base_;
     private DDTextField name_;
     private DDNumberSpinner numPlayers_;
@@ -96,9 +96,9 @@ public class TournamentProfileDialog extends OptionMenuDialog implements Propert
     private DDRadioButton buttonAuto_, buttonPerc_, buttonAmount_;
     private DDRadioButton buttonSatellite_;
     private boolean bDetailsTabReady_ = false;
-    private SpotPanel[] spots_ = new SpotPanel[TournamentProfile.MAX_SPOTS];
-    private String[] saveA_ = new String[TournamentProfile.MAX_SPOTS];
-    private String[] saveP_ = new String[TournamentProfile.MAX_SPOTS];
+    private final SpotPanel[] spots_ = new SpotPanel[TournamentProfile.MAX_SPOTS];
+    private final String[] saveA_ = new String[TournamentProfile.MAX_SPOTS];
+    private final String[] saveP_ = new String[TournamentProfile.MAX_SPOTS];
     private int nNumSpots_ = 0;
     private DDRadioButton buttonSelected_;
     private DDButton clear_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentSummaryPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/TournamentSummaryPanel.java
@@ -60,21 +60,21 @@ import java.util.List;
  */
 public class TournamentSummaryPanel extends DDPanel
 {
-    private String STYLE;
-    private String BEVEL_STYLE;
-    private GameContext context_;
+    private final String STYLE;
+    private final String BEVEL_STYLE;
+    private final GameContext context_;
     private DDHtmlArea html_, onlineHtml_;
     private DDLabel double_;
     private DDLabel payinfo_;
     private TournamentModel payout_;
     private TournamentModel levels_;
     private TournamentModel opponents_;
-    private DDTabbedPane tab_;
-    private String sHelpName_;
+    private final DDTabbedPane tab_;
+    private final String sHelpName_;
     private TournamentProfile profile_;
     private TournamentProfileHtml profileHtml_;
-    private ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
-    private boolean bListMode_;
+    private final ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
+    private final boolean bListMode_;
 
 
     public TournamentSummaryPanel(GameContext context, String sStyle, String sTabStyle, String sTableBevelStyle,
@@ -404,21 +404,21 @@ public class TournamentSummaryPanel extends DDPanel
             COL_PLACE, COL_PAYOUT
     };
     // client table info
-    private int[] PAYOUT_WIDTHS = new int[]{
+    private final int[] PAYOUT_WIDTHS = new int[]{
             55, 275
     };
-    private static String[] LEVELS_NAMES = new String[]{
+    private static final String[] LEVELS_NAMES = new String[]{
             COL_NUM, COL_ANTE, COL_SMALL, COL_BIG, COL_TIME, COL_GAMETYPE
     };
     // client table info
-    private int[] LEVELS_WIDTHS = new int[]{
+    private final int[] LEVELS_WIDTHS = new int[]{
             35, CW, CW, CW, 35, 70
     };
-    private static String[] OPP_NAMES = new String[]{
+    private static final String[] OPP_NAMES = new String[]{
             COL_OPPONENT_TYPE, COL_PERC
     };
     // client table info
-    private int[] OPP_WIDTHS = new int[]{
+    private final int[] OPP_WIDTHS = new int[]{
             250, 80
     };
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AIOutcome.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/AIOutcome.java
@@ -47,7 +47,7 @@ public class AIOutcome
     public static final int RAISE = 2;
     public static final int RERAISE = 2;
 
-    private ArrayList tuples_ = new ArrayList();
+    private final ArrayList tuples_ = new ArrayList();
 
     private float checkFold;
     private float call;
@@ -55,11 +55,11 @@ public class AIOutcome
 
     private boolean computed_ = false;
 
-    private PokerPlayer player_;
+    private final PokerPlayer player_;
     private BetRange betRange_;
-    private int potStatus_;
-    private int round_;
-    private boolean isLimit_;
+    private final int potStatus_;
+    private final int round_;
+    private final boolean isLimit_;
     private String allInReason_;
 
     private class Tuple

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketOdds.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketOdds.java
@@ -44,13 +44,13 @@ import java.util.HashMap;
  *
  * Computations are based on one-card lookahead (two cards is expensive and not particularly valuable).
  */
-public class PocketOdds
+public final class PocketOdds
 {
     private static long fpBoard_ = 0;
 
-    private static HashMap cache_ = new HashMap();
+    private static final HashMap cache_ = new HashMap();
 
-    private PocketMatrixShort ehs_ = new PocketMatrixShort();
+    private final PocketMatrixShort ehs_ = new PocketMatrixShort();
 
     private float ehsAverage_ = 0.0f;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketRanks.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketRanks.java
@@ -41,13 +41,13 @@ import java.util.HashMap;
 /**
  * Reusable computation of relative ranking of hands (Raw Hand Strength) with a given board.
  */
-public class PocketRanks
+public final class PocketRanks
 {
     private static long fpFlop_ = 0;
 
-    private static HashMap cache_ = new HashMap();
+    private static final HashMap cache_ = new HashMap();
 
-    private PocketMatrixShort rhs_ = new PocketMatrixShort();
+    private final PocketMatrixShort rhs_ = new PocketMatrixShort();
 
     /**
      * PocketRanks is a wrapper on PocketMatrixShort, and stores a ranking for each possible

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketScores.java
@@ -42,13 +42,13 @@ import java.util.HashMap;
 /**
  * Reusable computation of hand scores with a given board.
  */
-public class PocketScores
+public final class PocketScores
 {
     private static long fpFlop_ = 0;
 
-    private static HashMap cache_ = new HashMap();
+    private static final HashMap cache_ = new HashMap();
 
-    private PocketMatrixInt score_ = new PocketMatrixInt();
+    private final PocketMatrixInt score_ = new PocketMatrixInt();
 
     /**
      * PocketScores is a wrapper on PocketMatrixInt, and stores a raw hand score for each possible

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/PocketWeights.java
@@ -50,7 +50,7 @@ import java.util.List;
  * <p/>
  * TODO: reincorporate noise/accuracy
  */
-public class PocketWeights
+public final class PocketWeights
 {
     static Logger logger = LogManager.getLogger(PocketWeights.class);
 
@@ -61,7 +61,7 @@ public class PocketWeights
 
     private PocketMatrixFloat[] weights_ = null;
 
-    private float[] apparentStrength_ = new float[10];
+    private final float[] apparentStrength_ = new float[10];
     private int callCount_;
     private int raiseCount_;
     private int potSize_;
@@ -495,8 +495,8 @@ public class PocketWeights
         public float adjustWeight(PokerPlayer player, int card1, int card2, float weight, float rhs);
     }
 
-    private PreFlopActor preflopActor = new PreFlopActor();
-    private Tuple tuple = new Tuple();
+    private final PreFlopActor preflopActor = new PreFlopActor();
+    private final Tuple tuple = new Tuple();
 
     private void processPreFlopAction(HandAction action)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
@@ -55,9 +55,9 @@ public class RuleEngine implements AIConstants
 
     static Logger logger = LogManager.getLogger(RuleEngine.class);
 
-    private static ArrayList outcomeNames_ = new ArrayList();
-    private static ArrayList factorNames_ = new ArrayList();
-    private static ArrayList curveNames_ = new ArrayList();
+    private static final ArrayList outcomeNames_ = new ArrayList();
+    private static final ArrayList factorNames_ = new ArrayList();
+    private static final ArrayList curveNames_ = new ArrayList();
 
     public static final int OUTCOME_NONE = -1;
     public static final int OUTCOME_FOLD = 0;
@@ -127,10 +127,10 @@ public class RuleEngine implements AIConstants
     public static final int CURVE_CUBE = 3;
 
     private V2Player ai_;
-    private float[] score_;
-    private boolean[] eligible_;
-    private float[] weights_;
-    private OutcomeAdjustment[][] adjustments_;
+    private final float[] score_;
+    private final boolean[] eligible_;
+    private final float[] weights_;
+    private final OutcomeAdjustment[][] adjustments_;
 
     private int strongestOutcome_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorGridPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorGridPanel.java
@@ -47,8 +47,8 @@ import java.awt.event.MouseEvent;
 
 public class AdvisorGridPanel extends DDPanel
 {
-    private PocketMatrixByte outcomes_ = new PocketMatrixByte();
-    private PocketMatrixString outcomeStrings_ = new PocketMatrixString();
+    private final PocketMatrixByte outcomes_ = new PocketMatrixByte();
+    private final PocketMatrixString outcomeStrings_ = new PocketMatrixString();
 
     private boolean bPreFlop_ = true;
     private boolean bMinorGrid_ = true;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/AdvisorInfoDialog.java
@@ -84,7 +84,7 @@ public class AdvisorInfoDialog extends DialogPhase
 
     JComponent ladder_ = null;
 
-    private ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
+    private final ImageComponent ic_ = new ImageComponent("ddlogo20", 1.0d);
 
     /**
      * Init phase, storing engine and gamephase.  Called createUI()

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandProbabilityMatrixPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandProbabilityMatrixPanel.java
@@ -44,10 +44,10 @@ public class HandProbabilityMatrixPanel extends DDPanel
 {
     private HandProbabilityMatrix matrix_;
 
-    private DDPanel[][] panels_ = new DDPanel[52][52];
+    private final DDPanel[][] panels_ = new DDPanel[52][52];
 
-    private static int gridline_ = 1;
-    private static int subgridline_ = 1;
+    private static final int gridline_ = 1;
+    private static final int subgridline_ = 1;
 
     public HandProbabilityMatrixPanel()
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionDialog.java
@@ -64,7 +64,7 @@ public class HandSelectionDialog extends OptionMenuDialog
     static Logger logger = LogManager.getLogger(HandSelectionDialog.class);
 
     private HandSelectionScheme profile_;
-    private TypedHashMap dummy_ = new TypedHashMap();
+    private final TypedHashMap dummy_ = new TypedHashMap();
     private DDTextField name_;
     private HandGroupGridPanel gridPanel_;
     private ListPanel groupsList_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/HandSelectionPanel.java
@@ -48,10 +48,10 @@ public class HandSelectionPanel extends DDPanel
 {
     static ChangeListener changeListener = null;
 
-    private DDComboBox handSelectionFull_;
-    private DDComboBox handSelectionShort_;
-    private DDComboBox handSelectionVeryShort_;
-    private DDComboBox handSelectionHup_;
+    private final DDComboBox handSelectionFull_;
+    private final DDComboBox handSelectionShort_;
+    private final DDComboBox handSelectionVeryShort_;
+    private final DDComboBox handSelectionHup_;
 
     PlayerType profile_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/OpponentMixPanel.java
@@ -47,7 +47,7 @@ import java.util.List;
 public class OpponentMixPanel extends DDTabPanel
 {
     private ListPanel typesList_;
-    private TournamentProfile profile_;
+    private final TournamentProfile profile_;
 
     public OpponentMixPanel(TournamentProfile profile)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeDialog.java
@@ -62,7 +62,7 @@ public class PlayerTypeDialog extends OptionMenuDialog implements PropertyChange
     static Logger logger = LogManager.getLogger(PlayerTypeDialog.class);
 
     private PlayerType profile_;
-    private TypedHashMap dummy_ = new TypedHashMap();
+    private final TypedHashMap dummy_ = new TypedHashMap();
     private TypedHashMap orig_;
     private DDTextField name_;
     private GlassButton desc_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeManager.java
@@ -46,8 +46,8 @@ import java.awt.Dimension;
 
 public class PlayerTypeManager extends ProfileManagerPanel
 {
-    private GlassButton roster_;
-    private GameContext context_;
+    private final GlassButton roster_;
+    private final GameContext context_;
 
     public PlayerTypeManager(GameEngine engine, GameContext context, String sStyle)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/PlayerTypeSlidersPanel.java
@@ -50,8 +50,8 @@ public class PlayerTypeSlidersPanel extends DDPanel
 {
     public static ChangeListener changeListener = null;
 
-    private ListPanel listPanel_;
-    private DDHtmlArea helpPanel_;
+    private final ListPanel listPanel_;
+    private final DDHtmlArea helpPanel_;
 
     public PlayerTypeSlidersPanel(String sStyle)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/WeightGridPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/gui/WeightGridPanel.java
@@ -44,7 +44,7 @@ import java.awt.Color;
 
 public class WeightGridPanel extends AdvisorGridPanel
 {
-    private Color[] colors_ = new Color[101];
+    private final Color[] colors_ = new Color[101];
 
     private PokerPlayer player_;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/AdvanceAction.java
@@ -61,7 +61,7 @@ public class AdvanceAction extends DashboardItem implements ActionListener
     private static AdvanceAction impl_; // TODO store in PokerGame or PokerContext
 
     private DDPanel cheatbase_;
-    private ArrayList buttons_ = new ArrayList();
+    private final ArrayList buttons_ = new ArrayList();
     private DDLabel label_;
     private Advance checkfold_;
     private Advance call_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardClock.java
@@ -226,5 +226,5 @@ public class DashboardClock extends DashboardItem implements GameClockListener
     }
 
     // runnable for invoking clock ticked event in swing thread
-    private Runnable updateTimeRunner_ = this::updateTime;
+    private final Runnable updateTimeRunner_ = this::updateTime;
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardItem.java
@@ -74,7 +74,7 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
     public static final int NOT_SET = -1;
 
     // members
-    private String sName_;
+    private final String sName_;
     private DashboardHeader header_;
     private JComponent body_;
     private boolean bInDashboard_ = true;
@@ -447,7 +447,7 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
     }
 
     // runnable for invoking table changed event in swing thread
-    private Runnable tableChangedRunner_ = () ->
+    private final Runnable tableChangedRunner_ = () ->
         tableChanged(game_.getCurrentTable());
 
     /**
@@ -475,7 +475,7 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
      * invoke in timer thread (to get out of any locks held by
      * callers like TournamentDirector).
      */
-    private PokerTableListener listener_ = event ->
+    private final PokerTableListener listener_ = event ->
             // run immediately
             timer.schedule(new TableEventTask(event), 0);
 
@@ -483,7 +483,7 @@ public class DashboardItem implements Comparable<DashboardItem>, DataMarshal,
      * Task for particular poker table event.  When invoked, runs immediately
      * in swing thread using invokeAndWait.
      */
-    private class TableEventTask extends TimerTask
+    private final class TableEventTask extends TimerTask
     {
         private PokerTableEvent event;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardManager.java
@@ -55,10 +55,10 @@ public class DashboardManager
 {
     static Logger logger = LogManager.getLogger(DashboardManager.class);
 
-    private ArrayList items_;
+    private final ArrayList items_;
     private DMTypedHashMap prefs_;
     private String sPrefName_;
-    private PokerGame game_;
+    private final PokerGame game_;
 
     public DashboardManager(PokerGame game)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardPanel.java
@@ -57,9 +57,9 @@ public class DashboardPanel extends DDPanel
 {
     static Logger logger = LogManager.getLogger(DashboardPanel.class);
 
-    private DashboardManager mgr_;
-    private DDPanel dashitems_;
-    private DDScrollPane sp_;
+    private final DashboardManager mgr_;
+    private final DDPanel dashitems_;
+    private final DDScrollPane sp_;
 
     public DashboardPanel(DashboardManager mgr)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/ObserversDash.java
@@ -86,7 +86,7 @@ public class ObserversDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = this::updateAll;
+    private final Runnable updateRunner_ = this::updateAll;
 
     /**
      * update observer list

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/OnlineDash.java
@@ -62,7 +62,7 @@ public class OnlineDash extends DashboardItem
     private static final String OBSERVING = PropertyConfig.getMessage("msg.observing.title");
 
     private DDPanel base_;
-    private PokerPlayer player_;
+    private final PokerPlayer player_;
     private DDCheckBox sitout_, mucklose_, muckwin_;
     private TournamentDirector td_;
 
@@ -203,7 +203,7 @@ public class OnlineDash extends DashboardItem
     }
 
     // runnable for setting label text in swing thread
-    private Runnable updateRunner_ = this::updateAll;
+    private final Runnable updateRunner_ = this::updateAll;
 
     ///
     /// display logic

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/Rank.java
@@ -243,7 +243,7 @@ public class Rank extends DashboardItem
     private String sRank_;
 
     // runnable for setting label text in swing thread
-    private Runnable setLabelRunner_ = () -> {
+    private final Runnable setLabelRunner_ = () -> {
         labelInfo_.setText(sTextToUpdate_);
         setTitle(getTitle());
     };

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/impexp/ImpExpParadise.java
@@ -47,9 +47,9 @@ public class ImpExpParadise implements ImpExp
 {
     private String paradisePlayerName_ = "DD Player";
 
-    private HandInfoFast info = new HandInfoFast();
+    private final HandInfoFast info = new HandInfoFast();
 
-    private NumberFormat chipAmountFormat = NumberFormat.getInstance(Locale.US);
+    private final NumberFormat chipAmountFormat = NumberFormat.getInstance(Locale.US);
 
     public void setPlayerName(String name)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
@@ -65,16 +65,16 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
 {
     static Logger logger = LogManager.getLogger(ChatListPanel.class);
 
-    private static ImageIcon exportIcon_ = ImageConfig.getImageIcon("menuicon.export");
+    private static final ImageIcon exportIcon_ = ImageConfig.getImageIcon("menuicon.export");
     private static final String WHITESPACE = "[\\s\\xA0]+";
 
-    private GameContext context_;
+    private final GameContext context_;
     private Point start_ = null;
     private Point end_;
 
     // limit display
     private int MAX_MESSAGES = 500;
-    private ArrayList messages_;
+    private final ArrayList messages_;
 
     /**
      * Create new panel specifying styles, scrollbar policies

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatLobbyPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatLobbyPanel.java
@@ -52,7 +52,7 @@ import java.awt.Dimension;
  */
 public class ChatLobbyPanel extends ChatPanel
 {
-    private ChatLobbyManager mgr_;
+    private final ChatLobbyManager mgr_;
     private PlayerProfile profile_;
     protected String cAdmin_;
     protected String cAdminBG_;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
@@ -69,12 +69,12 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
 {
     static Logger logger = LogManager.getLogger(ChatPanel.class);
 
-    private boolean bOnlineInGame_;
+    private final boolean bOnlineInGame_;
     private int nDisplayOpt_ = -1;
     private JComponent center_;
 
-    private GameContext context_;
-    private PokerGame game_;
+    private final GameContext context_;
+    private final PokerGame game_;
     private PokerPlayer local_;
     private ChatManager mgr_;
 
@@ -126,7 +126,7 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
         createContents();
     }
 
-    private GameListener gamelistener_ = new GameListener();
+    private final GameListener gamelistener_ = new GameListener();
 
     /**
      * Game loaded, reset local player in chat (can change if we disconnect/reconnect)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
@@ -66,21 +66,21 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
     static Logger logger = LogManager.getLogger(HostStatus.class);
 
     // LEDs
-    private static ImageIcon REDLED = ImageConfig.getImageIcon("led-red");
-    private static ImageIcon GREENLED = ImageConfig.getImageIcon("led-green");
-    private static ImageIcon YELLOWLED = ImageConfig.getImageIcon("led-yellow");
+    private static final ImageIcon REDLED = ImageConfig.getImageIcon("led-red");
+    private static final ImageIcon GREENLED = ImageConfig.getImageIcon("led-green");
+    private static final ImageIcon YELLOWLED = ImageConfig.getImageIcon("led-yellow");
 
     // members
-    private PokerGame game_;
-    private OnlineManager mgr_;
-    private PokerPlayer host_;
-    private PokerPlayer local_;
+    private final PokerGame game_;
+    private final OnlineManager mgr_;
+    private final PokerPlayer host_;
+    private final PokerPlayer local_;
     private boolean bConnected_ = false;
-    private boolean bInGame_;
+    private final boolean bInGame_;
 
     // ui
-    private DDLabel status_;
-    private DDCheckBox details_;
+    private final DDLabel status_;
+    private final DDCheckBox details_;
     private PokerErrorDialog error_;
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
@@ -279,7 +279,7 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
     /**
      * Auto join - sleep to let ui show then click start
      */
-    private class AutoJoin implements Runnable
+    private final class AutoJoin implements Runnable
     {
         DDButton button;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
@@ -657,7 +657,7 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
         }
     }
 
-    private static ImageIcon switchIcon_ = ImageConfig.getImageIcon("menuicon.switch");
+    private static final ImageIcon switchIcon_ = ImageConfig.getImageIcon("menuicon.switch");
 
     /**
      * mute menu item

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
@@ -401,7 +401,7 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
         return getSelectedPlayer(table) != null;
     }
 
-    private static ImageIcon infoIcon_ = ImageConfig.getImageIcon("menuicon.info");
+    private static final ImageIcon infoIcon_ = ImageConfig.getImageIcon("menuicon.info");
 
     public void addMenuItems(DDTable table, DDPopupMenu menu)
     {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
@@ -92,7 +92,7 @@ public class OnlineManager implements ChatManager
     static int RCNT = 0;
 
     // members
-    private GameContext context_;
+    private final GameContext context_;
     private PokerGame game_;
     private PokerMain main_;
     PokerConnectionServer p2p_;
@@ -108,7 +108,7 @@ public class OnlineManager implements ChatManager
     private final List<OnlineMessage> tdQueue_ = new ArrayList<>();
     private OnlineManagerQueue oQueue_ = null;
     private PokerPrefsPlayerList banned_;
-    private Set<String> sentMessageAboutRejectedPlayer = new HashSet<>();
+    private final Set<String> sentMessageAboutRejectedPlayer = new HashSet<>();
 
     /**
      * Creates a new instance of OnlineManager
@@ -2658,7 +2658,7 @@ public class OnlineManager implements ChatManager
     /**
      * Methods throw this error with the message to return
      */
-    private static class OnlineError extends RuntimeException
+    private static final class OnlineError extends RuntimeException
     {
         private DDMessageTransporter reply;
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManagerQueue.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManagerQueue.java
@@ -66,20 +66,20 @@ public class OnlineManagerQueue implements Runnable
     static Logger logger = LogManager.getLogger(OnlineManagerQueue.class);
 
     // settings
-    private static int SLEEP_UNAVAIL = 25; // millis to sleep when no worker thread available
-    private static int LOG_UNAVAIL = 1000; // millis to wait before logging no worker warning
+    private static final int SLEEP_UNAVAIL = 25; // millis to sleep when no worker thread available
+    private static final int LOG_UNAVAIL = 1000; // millis to wait before logging no worker warning
 
     // info
-    private OnlineManager mgr_;
+    private final OnlineManager mgr_;
     private Thread threadQ_ = null;
     WorkerPool pool_;
 
     // instance info
     private ArrayList msgQ_ = new ArrayList();
     private boolean bDone_ = false;
-    private int nWait_ = 100;
+    private final int nWait_ = 100;
     private boolean bSleeping_ = false;
-    private Object SLEEPCHECK = new Object();
+    private final Object SLEEPCHECK = new Object();
     private int nElapsedNoWorkerTime_ = 0;
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
@@ -61,9 +61,9 @@ import java.util.List;
  */
 public class OnlineServer
 {
-    private static Logger logger = LogManager.getLogger(OnlineServer.class);
+    private static final Logger logger = LogManager.getLogger(OnlineServer.class);
 
-    private static OnlineServer manager_ = new OnlineServer();
+    private static final OnlineServer manager_ = new OnlineServer();
 
     /**
      * Get a manager instance.

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/PokerP2PHeadless.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/PokerP2PHeadless.java
@@ -60,11 +60,11 @@ public class PokerP2PHeadless implements OnlineMessageListener, DDMessageListene
     static Logger logger = LogManager.getLogger(PokerP2PHeadless.class);
 
     // members
-    private PokerGame game_;
+    private final PokerGame game_;
     private OnlineManager mgr_;
-    private P2PURL url_;
+    private final P2PURL url_;
     private Peer2PeerMessenger msgr_;
-    private OnlineMessage omsg_;
+    private final OnlineMessage omsg_;
     private OnlineMessage oreply_;
     private DDMessage mReturn_;
     private int nStatus_;
@@ -184,7 +184,7 @@ public class PokerP2PHeadless implements OnlineMessageListener, DDMessageListene
             oreply_ = reply;
             timer_.interrupt();   
             DDMessage ret = reply.getData();
-            ret.setStatus(msgr_.getStatus(ret));
+            ret.setStatus(Peer2PeerMessenger.getStatus(ret));
             messageReceived(ret);
         }
     }

--- a/code/poker/src/main/java/com/zookitec/layout/ComponentEF.java
+++ b/code/poker/src/main/java/com/zookitec/layout/ComponentEF.java
@@ -34,7 +34,7 @@ import java.lang.ref.WeakReference;
 /**
  * An expression factory used to create expressions for attributes of a component.
  */
-public class ComponentEF {
+public final class ComponentEF {
 
     static final int TOP         =  0;
     static final int BOTTOM      =  1;
@@ -61,7 +61,7 @@ public class ComponentEF {
     /**
      * array of maps from component to expression for each attribte
      */
-    private static WeakHashMap [] cache = new WeakHashMap[ATTRIBUTE_COUNT];
+    private static final WeakHashMap [] cache = new WeakHashMap[ATTRIBUTE_COUNT];
 
     private ComponentEF() {}
 

--- a/code/poker/src/main/java/com/zookitec/layout/ContainerEF.java
+++ b/code/poker/src/main/java/com/zookitec/layout/ContainerEF.java
@@ -34,7 +34,7 @@ import java.util.WeakHashMap;
  * An expression factory used to create expressions for
  * attributes of the container being laid out.
  */
-public class ContainerEF {
+public final class ContainerEF {
 
     private static final int TOP         =  0;
     private static final int BOTTOM      =  1;
@@ -48,7 +48,7 @@ public class ContainerEF {
     /**
      * array of maps from container to expression for each attribte
      */
-    private static WeakHashMap [] cache = new WeakHashMap[ATTRIBUTE_COUNT];
+    private static final WeakHashMap [] cache = new WeakHashMap[ATTRIBUTE_COUNT];
 
 
     private ContainerEF() {}

--- a/code/poker/src/main/java/com/zookitec/layout/ExplicitLayout.java
+++ b/code/poker/src/main/java/com/zookitec/layout/ExplicitLayout.java
@@ -54,7 +54,7 @@ public class ExplicitLayout implements LayoutManager2, Serializable {
      *
      * @serial
      */
-    private Hashtable component2constraints;
+    private final Hashtable component2constraints;
 
 
     /**
@@ -62,7 +62,7 @@ public class ExplicitLayout implements LayoutManager2, Serializable {
      *
      * @serial
      */
-    private Hashtable name2constraints;
+    private final Hashtable name2constraints;
 
 
 

--- a/code/poker/src/main/java/com/zookitec/layout/GeomEF.java
+++ b/code/poker/src/main/java/com/zookitec/layout/GeomEF.java
@@ -30,7 +30,7 @@ package com.zookitec.layout;
  * An expression factory used to create expressions for points on geometric shapes.
  *
  */
-public class GeomEF {
+public final class GeomEF {
 
 
     private GeomEF() {}

--- a/code/poker/src/main/java/com/zookitec/layout/GroupEF.java
+++ b/code/poker/src/main/java/com/zookitec/layout/GroupEF.java
@@ -34,7 +34,7 @@ import java.awt.Component;
  * that depend on attributes of a group of components.
  *
  */
-public class GroupEF {
+public final class GroupEF {
 
 
     private GroupEF() {}

--- a/code/poker/src/main/java/com/zookitec/layout/MathEF.java
+++ b/code/poker/src/main/java/com/zookitec/layout/MathEF.java
@@ -33,7 +33,7 @@ import java.lang.ref.WeakReference;
 /**
  * An expression factory used to create expressions for common mathematical operations.
  */
-public class MathEF {
+public final class MathEF {
 
     private static final int ADD = 0;
     private static final int SUB = 1;
@@ -43,7 +43,7 @@ public class MathEF {
     private static final int MAX = 5;
     private static final int SUM = 6;
 
-    private static WeakHashMap cache = new WeakHashMap();
+    private static final WeakHashMap cache = new WeakHashMap();
 
     /**
      * A constant Expression whose value is 0.0.

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/CardSuit.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/CardSuit.java
@@ -37,7 +37,7 @@ import com.donohoedigital.config.PropertyConfig;
 /**
  * Global representation of card suits.
  */
-public class CardSuit implements Comparable<CardSuit>
+public final class CardSuit implements Comparable<CardSuit>
 {
     public static final int NUM_SUITS = 4;
 
@@ -54,8 +54,8 @@ public class CardSuit implements Comparable<CardSuit>
     public static final CardSuit HEARTS = new CardSuit(HEARTS_RANK, "heart");
     public static final CardSuit SPADES = new CardSuit(SPADES_RANK, "spade");
 
-    private int rank_;
-    private String name_;
+    private final int rank_;
+    private final String name_;
     private String abbr_;
 
     /**

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/TournamentProfileHtml.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/TournamentProfileHtml.java
@@ -53,7 +53,7 @@ import static com.donohoedigital.games.poker.model.TournamentProfile.*;
  */
 public class TournamentProfileHtml
 {
-    private TournamentProfile profile;
+    private final TournamentProfile profile;
 
     // cache for quick display
     private String htmlCache_;

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentProfile.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/TournamentProfile.java
@@ -414,7 +414,7 @@ public class TournamentProfile extends BaseProfile implements DataMarshal, Simpl
     /**
      * PlayerList which stores data in TournamentProfile
      */
-    private static class InviteePlayerList extends AbstractPlayerList
+    private static final class InviteePlayerList extends AbstractPlayerList
     {
         TournamentProfile profile;
 

--- a/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/PokerURL.java
+++ b/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/PokerURL.java
@@ -49,8 +49,8 @@ import java.util.StringTokenizer;
  */
 public class PokerURL extends P2PURL 
 {
-    private String sID_;
-    private String sPass_;
+    private final String sID_;
+    private final String sPass_;
     
     public PokerURL(String spec) {
         super(spec);

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/ChatServer.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/ChatServer.java
@@ -63,14 +63,14 @@ import java.util.List;
  */
 public class ChatServer implements UDPLinkHandler, UDPManagerMonitor, UDPLinkMonitor
 {
-    private static Logger logger = LogManager.getLogger(ChatServer.class);
+    private static final Logger logger = LogManager.getLogger(ChatServer.class);
 
     private OnlineProfileService onlineProfileService;
     private BannedKeyService bannedKeyService;
 
     // members
-    private UDPServer udp_;
-    private int nPort_;
+    private final UDPServer udp_;
+    private final int nPort_;
     private final List<LinkInfo> links_ = Collections.synchronizedList(new ArrayList<LinkInfo>());
 
     /**
@@ -451,7 +451,7 @@ public class ChatServer implements UDPLinkHandler, UDPManagerMonitor, UDPLinkMon
     /**
      * list of links
      */
-    private class LinkInfo implements Comparable<LinkInfo>
+    private final class LinkInfo implements Comparable<LinkInfo>
     {
         UDPLink link;
         String sRealKey;

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/BanList.java
@@ -231,7 +231,7 @@ public class BanList extends AdminPokerPage
     /**
      * The leaderboard table
      */
-    private class BanListTableView extends CountDataView<BannedKey>
+    private final class BanListTableView extends CountDataView<BannedKey>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/OnlineProfileSearch.java
@@ -201,7 +201,7 @@ public class OnlineProfileSearch extends AdminPokerPage
     /**
      * The leaderboard table
      */
-    private class GameListTableView extends CountDataView<OnlineProfile>
+    private final class GameListTableView extends CountDataView<OnlineProfile>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/admin/pages/RegistrationSearch.java
@@ -217,7 +217,7 @@ public class RegistrationSearch extends AdminPokerPage
     /**
      * The leaderboard table
      */
-    private class GameListTableView extends CountDataView<Registration>
+    private final class GameListTableView extends CountDataView<Registration>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GameDetail.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GameDetail.java
@@ -128,7 +128,7 @@ public class GameDetail extends OnlinePokerPage
         add(new StringLabel("tournamentProfile", new TournamentProfileHtml(tournament).toHTML(null)).setEscapeModelStrings(false));
     }
 
-    private class FinishTable extends Fragment
+    private final class FinishTable extends Fragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -144,7 +144,7 @@ public class GameDetail extends OnlinePokerPage
         }
     }
 
-    private class FinishData extends PageableServiceProvider<TournamentHistory>
+    private final class FinishData extends PageableServiceProvider<TournamentHistory>
     {
         private static final long serialVersionUID = 42L;
 
@@ -184,7 +184,7 @@ public class GameDetail extends OnlinePokerPage
         }
     }
 
-    private class FinishTableView extends CountDataView<TournamentHistory>
+    private final class FinishTableView extends CountDataView<TournamentHistory>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GamesList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/GamesList.java
@@ -259,10 +259,10 @@ public abstract class GamesList extends OnlinePokerPage
     }
 
     ////
-    //// List
-    ////
+     //// List
+     ////
 
-    private class GameData extends PageableServiceProvider<OnlineGame> implements NameRangeSearch
+    private final class GameData extends PageableServiceProvider<OnlineGame> implements NameRangeSearch
     {
         private static final long serialVersionUID = 42L;
 
@@ -342,7 +342,7 @@ public abstract class GamesList extends OnlinePokerPage
     /**
      * The leaderboard table
      */
-    private class GameListTableView extends CountDataView<OnlineGame>
+    private final class GameListTableView extends CountDataView<OnlineGame>
     {
         private static final long serialVersionUID = 42L;
 
@@ -410,10 +410,10 @@ public abstract class GamesList extends OnlinePokerPage
     }
 
     ////
-    //// Fragments
-    ////
+     //// Fragments
+     ////
 
-    private class RecentGamesDescription extends Fragment
+    private final class RecentGamesDescription extends Fragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -423,7 +423,7 @@ public abstract class GamesList extends OnlinePokerPage
         }
     }
 
-    private class CurrentGameLoggedInDescription extends Fragment
+    private final class CurrentGameLoggedInDescription extends Fragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -433,7 +433,7 @@ public abstract class GamesList extends OnlinePokerPage
         }
     }
 
-    private class CurrentGameNotLoggedInDescription extends Fragment
+    private final class CurrentGameNotLoggedInDescription extends Fragment
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/History.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/History.java
@@ -218,10 +218,10 @@ public class History extends OnlinePokerPage
     }
 
     ////
-    //// List
-    ////
+     //// List
+     ////
 
-    private class HistoryTable extends Fragment
+    private final class HistoryTable extends Fragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -245,7 +245,7 @@ public class History extends OnlinePokerPage
         }
     }
 
-    private class HistoryData extends PageableServiceProvider<TournamentHistory> implements NameRangeSearch
+    private final class HistoryData extends PageableServiceProvider<TournamentHistory> implements NameRangeSearch
     {
         private static final long serialVersionUID = 42L;
 
@@ -321,7 +321,7 @@ public class History extends OnlinePokerPage
         }
     }
 
-    private class HistoryTableView extends CountDataView<TournamentHistory>
+    private final class HistoryTableView extends CountDataView<TournamentHistory>
     {
         private static final long serialVersionUID = 42L;
         private static final int ITEMS_PER_PAGE = 20;
@@ -396,7 +396,7 @@ public class History extends OnlinePokerPage
         }
     }
 
-    private class StoppedBusted extends FinishFragment
+    private final class StoppedBusted extends FinishFragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -409,7 +409,7 @@ public class History extends OnlinePokerPage
         }
     }
 
-    private class StoppedChips extends FinishFragment
+    private final class StoppedChips extends FinishFragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -422,7 +422,7 @@ public class History extends OnlinePokerPage
         }
     }
 
-    private class Finished extends FinishFragment
+    private final class Finished extends FinishFragment
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/HostList.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/HostList.java
@@ -195,7 +195,7 @@ public class HostList extends OnlinePokerPage
     /**
      * The leaderboard table
      */
-    private class GameListTableView extends CountDataView<HostSummary>
+    private final class GameListTableView extends CountDataView<HostSummary>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Leaderboard.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Leaderboard.java
@@ -183,7 +183,7 @@ public class Leaderboard extends OnlinePokerPage
      * leader data, fetched from TournamentHistoryService
      */
     @SuppressWarnings({"PublicInnerClass"})
-    public class LeaderData extends AliasedPageableServiceProvider<LeaderboardSummary> implements NameRangeSearch
+    public final class LeaderData extends AliasedPageableServiceProvider<LeaderboardSummary> implements NameRangeSearch
     {
         private static final long serialVersionUID = 42L;
 
@@ -276,7 +276,7 @@ public class Leaderboard extends OnlinePokerPage
     /**
      * The leaderboard table
      */
-    private class LeaderboardTableView extends CountDataView<LeaderboardSummary>
+    private final class LeaderboardTableView extends CountDataView<LeaderboardSummary>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/MyProfile.java
@@ -142,10 +142,10 @@ public class MyProfile extends OnlinePokerPage
     }
 
     ////
-    //// List
-    ////
+     //// List
+     ////
 
-    private class AliasTable extends Fragment
+    private final class AliasTable extends Fragment
     {
         private static final long serialVersionUID = 42L;
 
@@ -253,7 +253,7 @@ public class MyProfile extends OnlinePokerPage
         }
     }
 
-    private class OnlineProfileSummaryModel extends LoadableDetachableModel<List<OnlineProfileSummary>>
+    private final class OnlineProfileSummaryModel extends LoadableDetachableModel<List<OnlineProfileSummary>>
     {
         PokerUser userinfo;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Search.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/pages/online/Search.java
@@ -142,10 +142,10 @@ public class Search extends OnlinePokerPage
     }
 
     ////
-    //// List
-    ////
+     //// List
+     ////
 
-    private class SearchData extends PageableServiceProvider<OnlineProfile>
+    private final class SearchData extends PageableServiceProvider<OnlineProfile>
     {
         private static final long serialVersionUID = 42L;
 
@@ -185,7 +185,7 @@ public class Search extends OnlinePokerPage
     /**
      * The leaderboard table
      */
-    private class GameListTableView extends CountDataView<OnlineProfile>
+    private final class GameListTableView extends CountDataView<OnlineProfile>
     {
         private static final long serialVersionUID = 42L;
 

--- a/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Aliases.java
+++ b/code/pokerwicket/src/main/java/com/donohoedigital/games/poker/wicket/panels/Aliases.java
@@ -110,7 +110,7 @@ public class Aliases extends VoidPanel
      * the aliases for a newly retired player (e.g., - where did "xyz" go?)
      */
 
-    private class AliasModel extends LoadableDetachableModel<List<OnlineProfile>>
+    private final class AliasModel extends LoadableDetachableModel<List<OnlineProfile>>
     {
         PokerUser user;
         private static final long serialVersionUID = 42L;

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/CapabilitiesTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/CapabilitiesTest.java
@@ -48,8 +48,8 @@ import java.awt.event.WindowEvent;
  * displayed nicely in components.
  */
 class GCWrapper {
-    private GraphicsConfiguration gc;
-    private int index;
+    private final GraphicsConfiguration gc;
+    private final int index;
     
     public GCWrapper(GraphicsConfiguration gc, int index) {
         this.gc = gc;
@@ -70,17 +70,17 @@ class GCWrapper {
  */
 public class CapabilitiesTest extends JFrame implements ItemListener {
     
-    private JComboBox gcSelection = new JComboBox();
-    private JCheckBox imageAccelerated = new JCheckBox("Accelerated", false);
-    private JCheckBox imageTrueVolatile = new JCheckBox("Volatile", false);
-    private JCheckBox flipping = new JCheckBox("Flipping", false);
-    private JLabel flippingMethod = new JLabel("");
-    private JCheckBox fullScreen = new JCheckBox("Full Screen Only", false);
-    private JCheckBox multiBuffer = new JCheckBox("Multi-Buffering", false);
-    private JCheckBox fbAccelerated = new JCheckBox("Accelerated", false);
-    private JCheckBox fbTrueVolatile = new JCheckBox("Volatile", false);
-    private JCheckBox bbAccelerated = new JCheckBox("Accelerated", false);
-    private JCheckBox bbTrueVolatile = new JCheckBox("Volatile", false);
+    private final JComboBox gcSelection = new JComboBox();
+    private final JCheckBox imageAccelerated = new JCheckBox("Accelerated", false);
+    private final JCheckBox imageTrueVolatile = new JCheckBox("Volatile", false);
+    private final JCheckBox flipping = new JCheckBox("Flipping", false);
+    private final JLabel flippingMethod = new JLabel("");
+    private final JCheckBox fullScreen = new JCheckBox("Full Screen Only", false);
+    private final JCheckBox multiBuffer = new JCheckBox("Multi-Buffering", false);
+    private final JCheckBox fbAccelerated = new JCheckBox("Accelerated", false);
+    private final JCheckBox fbTrueVolatile = new JCheckBox("Volatile", false);
+    private final JCheckBox bbAccelerated = new JCheckBox("Accelerated", false);
+    private final JCheckBox bbTrueVolatile = new JCheckBox("Volatile", false);
     
     public CapabilitiesTest(GraphicsDevice dev) {
         super(dev.getDefaultConfiguration());

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/Experiments.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class Experiments
 {
-    private Logger logger = LogManager.getLogger(Experiments.class);
+    private final Logger logger = LogManager.getLogger(Experiments.class);
 
     @Test
     public void testNullEquals()

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/ItalicBug.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/ItalicBug.java
@@ -38,10 +38,8 @@
 
 package com.donohoedigital.proto.tests;
 
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
+import javax.swing.*;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Font;
@@ -75,7 +73,7 @@ public class ItalicBug
     {
         JFrame frame = new JFrame();
         JPanel panel = new JPanel();
-        frame.setDefaultCloseOperation(frame.EXIT_ON_CLOSE);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         panel.setLayout(new BorderLayout());
         
         JLabel label = new JLabel("Lucida Sans Regular - italic - 32");

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MultiBufferTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MultiBufferTest.java
@@ -45,13 +45,13 @@ import java.awt.image.BufferStrategy;
 
 public class MultiBufferTest {
     
-    private boolean bFullScreen = false;
+    private final boolean bFullScreen = false;
     
-    private static Color[] COLORS = new Color[] {
+    private static final Color[] COLORS = new Color[] {
         Color.red, Color.blue, Color.green, Color.white, Color.black,
         Color.yellow, Color.gray, Color.cyan, Color.pink, Color.lightGray,
         Color.magenta, Color.orange, Color.darkGray };
-    private static DisplayMode[] BEST_DISPLAY_MODES = new DisplayMode[] {
+    private static final DisplayMode[] BEST_DISPLAY_MODES = new DisplayMode[] {
         new DisplayMode(640, 480, 32, 0),
         new DisplayMode(640, 480, 16, 0),
         new DisplayMode(640, 480, 8, 0)

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/SoundTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/SoundTest.java
@@ -55,7 +55,7 @@ import com.donohoedigital.udp.UDPServer;
 public class SoundTest extends BaseCommandLineApp
 {
     // logging
-    private Logger logger;
+    private final Logger logger;
 
     /**
      * Run emailer

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
@@ -52,12 +52,12 @@ import org.apache.logging.log4j.Logger;
 public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, UDPManagerMonitor, UDPLinkMonitor
 {
     // logging
-    private Logger logger;
+    private final Logger logger;
 
     // members
-    private boolean bSend;
-    private boolean bDebug;
-    private int port;
+    private final boolean bSend;
+    private final boolean bDebug;
+    private final int port;
 
     /**
      * Run emailer

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
@@ -77,8 +77,8 @@ public class LanClientList
         }
     }
 
-    private Map<String, LanClientInfo> list_ = new HashMap<>();
-    private LanControllerInterface controller_;
+    private final Map<String, LanClientInfo> list_ = new HashMap<>();
+    private final LanControllerInterface controller_;
     
     
     /** 

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanEvent.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanEvent.java
@@ -45,9 +45,9 @@ package com.donohoedigital.p2p;
 public class LanEvent 
 {
     
-    private int action_;
-    private LanClientList list_;
-    private String sKey_;
+    private final int action_;
+    private final LanClientList list_;
+    private final String sKey_;
     
     /** 
      * Creates a new instance of LanEvent 

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanManager.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanManager.java
@@ -61,19 +61,19 @@ public class LanManager implements DDMessageListener
 
     private static final boolean DEBUG = false;
 
-    private static int ALIVE_SECONDS = 5;
-    private static int ALIVE_REFRESH_CNT = 10;
-    private static int ALIVE_INIT_CNT = 10;
+    private static final int ALIVE_SECONDS = 5;
+    private static final int ALIVE_REFRESH_CNT = 10;
+    private static final int ALIVE_INIT_CNT = 10;
 
     private Peer2PeerMulticast multi_;
     private Alive alive_;
     private String sLocalHost_;
     private String sLocalIP_;
-    private LanControllerInterface controller_;
-    private LanClientList clients_;
-    private String guid_;
-    private String key_;
-    private long startTime_ = System.currentTimeMillis();
+    private final LanControllerInterface controller_;
+    private final LanClientList clients_;
+    private final String guid_;
+    private final String key_;
+    private final long startTime_ = System.currentTimeMillis();
 
     /**
      * Creates a new instance of LanManager

--- a/code/server/src/main/java/com/donohoedigital/p2p/P2PURL.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/P2PURL.java
@@ -45,10 +45,10 @@ import com.donohoedigital.base.ApplicationError;
  */
 public class P2PURL
 {
-    private String sProtocol_;
-    private String sHost_;
+    private final String sProtocol_;
+    private final String sHost_;
     private int nPort_;
-    private String sURI_;
+    private final String sURI_;
 
     public static final String PROTOCOL_DELIM = "://";
     public static final String PORT_DELIM = ":";

--- a/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMulticast.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMulticast.java
@@ -61,11 +61,11 @@ public class Peer2PeerMulticast implements Runnable
 {
     static Logger logger = LogManager.getLogger(Peer2PeerMulticast.class);
     
-    private static int PACKET_SIZE = 49152; // 64K max, including overhead
+    private static final int PACKET_SIZE = 49152; // 64K max, including overhead
     
     private Thread t_;
-    private int nPort_;
-    private String sIP_;
+    private final int nPort_;
+    private final String sIP_;
     private InetAddress ia_;
     private MulticastSocket ms_;
     private boolean bDone_;

--- a/code/server/src/main/java/com/donohoedigital/server/ServletDebug.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ServletDebug.java
@@ -47,8 +47,8 @@ public class ServletDebug
     public static boolean bVerbose_ = true; // extra output
     public static boolean bDebug_ = true; // print URL
     // TODO: get from config file
-    private static String sFile_ = null;
-    private static boolean bAppend_ = true;
+    private static final String sFile_ = null;
+    private static final boolean bAppend_ = true;
     private static final String THIS_REQUEST_HANDLED="_trh_";
 
     public static void setVerbose(boolean b)

--- a/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
+++ b/code/server/src/main/java/com/donohoedigital/server/SocketThread.java
@@ -54,7 +54,7 @@ import java.util.StringTokenizer;
 public class SocketThread extends Thread
 {
     static Logger logger = LogManager.getLogger(SocketThread.class);
-    private static boolean DEBUG = false;
+    private static final boolean DEBUG = false;
     
     protected static final int READ_TIMEOUT_MILLIS = PropertyConfig.getRequiredIntegerProperty("settings.server.readtimeout.millis");
     protected static final int READ_WAIT_MILLIS = PropertyConfig.getRequiredIntegerProperty("settings.server.readwait.millis");

--- a/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
@@ -49,11 +49,11 @@ public class ThreadPool
 {
     static Logger logger = LogManager.getLogger(ThreadPool.class);
     
-    private GameServer server_;
+    private final GameServer server_;
     private final List<SocketThread> idle_ = new LinkedList<>();
     private final List<SocketThread> workers_ = new ArrayList<>();
-    private Class<?> socketClass_;
-    private BaseServlet servlet_;
+    private final Class<?> socketClass_;
+    private final BaseServlet servlet_;
 
     public ThreadPool(GameServer server, int poolSize, BaseServlet servlet, String sSocketClass)
     {

--- a/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
@@ -72,11 +72,11 @@ public class ProxySocketThread extends SocketThread implements PostWriter, DDMes
 {
     static Logger logger = LogManager.getLogger(ProxySocketThread.class);
     
-    private DDHttpClient.HttpOptions options_;
+    private final DDHttpClient.HttpOptions options_;
     private URL proxy_;
-    private String sDestHost_ = "tbd.com";
-    private int nDestPort_ = 8877;
-    private String sDestHostPort_ = sDestHost_ + ":" + nDestPort_;
+    private final String sDestHost_ = "tbd.com";
+    private final int nDestPort_ = 8877;
+    private final String sDestHostPort_ = sDestHost_ + ":" + nDestPort_;
     
     /** 
      * Creates a new instance of ProxySocketThread 

--- a/code/udp/src/main/java/com/donohoedigital/udp/DispatchQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/DispatchQueue.java
@@ -50,11 +50,11 @@ public class DispatchQueue extends Thread
     static Logger logger = LogManager.getLogger(DispatchQueue.class);
 
     // members
-    private LinkedBlockingQueue queue_ = new LinkedBlockingQueue();
+    private final LinkedBlockingQueue queue_ = new LinkedBlockingQueue();
     private boolean bDone_ = false;
 
     // control messages
-    private Object QUIT = new Object();
+    private final Object QUIT = new Object();
 
     /**
      * new dispatch queue

--- a/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
@@ -51,15 +51,15 @@ public class IncomingQueue
     static Logger logger = LogManager.getLogger(IncomingQueue.class);
 
     // message comparator
-    private static UDPMessageComparator comparator_ = new UDPMessageComparator();
+    private static final UDPMessageComparator comparator_ = new UDPMessageComparator();
 
     // last dispatch count
     static final int LAST_DISPATCH_CNT = -1;
 
     // members
-    private ArrayList<UDPData> queue_ = new ArrayList<>();
+    private final ArrayList<UDPData> queue_ = new ArrayList<>();
     private int nLastProcessedID_;
-    private UDPLink link_;
+    private final UDPLink link_;
 
     /**
      * Default constructor
@@ -157,7 +157,7 @@ public class IncomingQueue
     //// DISPATCH
     ////
 
-    private ArrayList<UDPData> process_ = new ArrayList<>(10);
+    private final ArrayList<UDPData> process_ = new ArrayList<>(10);
 
     /**
      * Dispatch messages.  Basically the messages in the queue are sorted

--- a/code/udp/src/main/java/com/donohoedigital/udp/OutgoingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/OutgoingQueue.java
@@ -51,13 +51,13 @@ public class OutgoingQueue extends Thread
     static Logger logger = LogManager.getLogger(OutgoingQueue.class);
 
     // members
-    private LinkedBlockingQueue queue_ = new LinkedBlockingQueue();
+    private final LinkedBlockingQueue queue_ = new LinkedBlockingQueue();
     private boolean bDone_ = false;
-    private AtomicLong bytesOnQueue_ = new AtomicLong(0);
+    private final AtomicLong bytesOnQueue_ = new AtomicLong(0);
     private int peak_ = 0;
 
     // control messages
-    private Object QUIT = new Object();
+    private final Object QUIT = new Object();
 
     /**
      * new dispatch queue

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPLink.java
@@ -67,29 +67,29 @@ public class UDPLink
     private static final int GOODBYE_TIMEOUT = 1000;
 
     // misc
-    private static long TBD_REMOTE_ID = -1;
+    private static final long TBD_REMOTE_ID = -1;
 
     // members
-    private UDPManager manager_;
-    private DispatchQueue dispatchQueue_;
+    private final UDPManager manager_;
+    private final DispatchQueue dispatchQueue_;
     private UDPID id_;
     private InetSocketAddress local_;
     private InetSocketAddress remote_;
     private String sName_;
 
     // time params from handler
-    private int TIMEOUT_MILLIS;
-    private int POSSIBLE_TIMEOUT_NOTIFICATION_START;
-    private int POSSIBLE_TIMEOUT_NOTIFICATION_INTERVAL;
+    private final int TIMEOUT_MILLIS;
+    private final int POSSIBLE_TIMEOUT_NOTIFICATION_START;
+    private final int POSSIBLE_TIMEOUT_NOTIFICATION_INTERVAL;
 
     // queue to send (synchronized blocks are used around sendQueue_)
-    private LinkedList<UDPData> sendQueue_ = new LinkedList<>();
-    private UDPStats stats_ = new UDPStats();
+    private final LinkedList<UDPData> sendQueue_ = new LinkedList<>();
+    private final UDPStats stats_ = new UDPStats();
 
     // session related stuff (set in resetSession() or newSession())
     private int nMessageID_;
     private IncomingQueue incomingQueue_;
-    private OutgoingQueue outgoingQueue_;
+    private final OutgoingQueue outgoingQueue_;
     private AckList acks_;
     private AckList mtuAcks_;
     private long localSessionID_;
@@ -99,8 +99,8 @@ public class UDPLink
     private long lastMessageReceived_;
     private boolean bGoodbyeInProgress_ = false;
     private boolean bDone_ = false;
-    private ArrayList<UDPLinkMonitor> monitors_ = new ArrayList<>();
-    private long start = System.currentTimeMillis();
+    private final ArrayList<UDPLinkMonitor> monitors_ = new ArrayList<>();
+    private final long start = System.currentTimeMillis();
 
     // data size related stuff
     public static final int MIN_MTU = 576;
@@ -356,7 +356,7 @@ public class UDPLink
     }
 
     // mtu test num (used to identify new test on receiving end)
-    private byte testNum = 0;
+    private final byte testNum = 0;
     private int nLastMTUTest_;
     private boolean bMTUTestDone_;
 
@@ -1258,7 +1258,7 @@ public class UDPLink
      * Class to track average time for ack to come back after being received.
      * Tracks last 100
      */
-    public static class UDPStats
+    public static final class UDPStats
     {
         // send/error/resend
         private int packetReceived;

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
@@ -59,19 +59,19 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
     static int ACK_SEND_MILLIS = 333;
 
     // members
-    private UDPServer server_;
-    private UDPLinkHandler handler_;
+    private final UDPServer server_;
+    private final UDPLinkHandler handler_;
     private final List<UDPManagerMonitor> monitors_ = new ArrayList<>();
     private final LinkedBlockingQueue<Object> queue_ = new LinkedBlockingQueue<>();
     private final List<UDPLink> links_ = Collections.synchronizedList(new ArrayList<UDPLink>());
-    private List<UDPLink> linksCopy_ = Collections.synchronizedList(new ArrayList<UDPLink>());
+    private final List<UDPLink> linksCopy_ = Collections.synchronizedList(new ArrayList<UDPLink>());
     boolean bDone_ = false;
-    private Timer timer_;
+    private final Timer timer_;
 
     // control messages
-    private Object QUIT = new Object();
-    private Object SENDALL = new Object();
-    private Object SENDACK = new Object();
+    private final Object QUIT = new Object();
+    private final Object SENDALL = new Object();
+    private final Object SENDACK = new Object();
 
     /**
      * new udp manager

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPManagerEvent.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPManagerEvent.java
@@ -63,8 +63,8 @@ public class UDPManagerEvent
     }
 
     // members
-    private Type type_;
-    private UDPLink link_;
+    private final Type type_;
+    private final UDPLink link_;
 
     /**
      * Constructor - basic

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/labels/BasicPluralLabelProvider.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/labels/BasicPluralLabelProvider.java
@@ -43,8 +43,8 @@ public class BasicPluralLabelProvider implements PluralLabelProvider
 {
     private static final long serialVersionUID = 42L;
 
-    private String plural;
-    private String singular;
+    private final String plural;
+    private final String singular;
 
     public BasicPluralLabelProvider(String singular, String plural)
     {

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/labels/DateLabel.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/labels/DateLabel.java
@@ -42,7 +42,7 @@ import org.apache.wicket.util.convert.IConverter;
 
 import java.util.Date;
 
-public class DateLabel extends Label implements IGenericComponent<Date, DateLabel>
+public final class DateLabel extends Label implements IGenericComponent<Date, DateLabel>
 {
     private static final long serialVersionUID = 1L;
 

--- a/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
+++ b/code/wicket/src/main/java/com/donohoedigital/wicket/models/AliasedCompoundPropertyModel.java
@@ -54,9 +54,9 @@ public class AliasedCompoundPropertyModel<T> extends CompoundPropertyModel<T>
     private static final long serialVersionUID = 42L;
 
     /**
-	 * Internal alias representation.
+     * Internal alias representation.
      */
-	private class Alias implements IClusterable
+    private final class Alias implements IClusterable
 	{
 		private static final long serialVersionUID = 1L;
 

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -120,15 +120,31 @@ name: com.donohoedigital.FinalAndModifiers
 displayName: Final fields and modifier hygiene
 description: >
   Mark private fields final where they are assigned exactly once, drop redundant
-  modifiers, and add missing @Override.  Deliberately does NOT finalize locals or
+  modifiers, order modifiers canonically.  Deliberately does NOT finalize locals or
   parameters (see FinalizeLocalVariables) - that is line noise, not information.
-  REVIEW: verify Hibernate entity classes are untouched before applying.
+  MissingOverrideAnnotation is deliberately NOT used anywhere.  It would have added 2139
+  annotations across 516 files, 268 of which change by nothing else, and IntelliJ does not
+  flag missing @Override by default.  Rejected as unrequested churn.
+  Hibernate entities are safe: FinalizePrivateFields only finalizes a field assigned
+  exactly once, and entity fields are assigned in their setters.  No final was added to
+  OnlineGame, TournamentHistory, OnlineProfile, Registration, BannedKey or UpgradedKey,
+  and the Hibernate-backed tests (PokerDatabaseTest, OnlineGameTest, OnlineProfileTest,
+  TournamentHistoryTest and the service tests) pass against a real database.
+  AFTER RUNNING THIS, revert "final" on four fields.  FinalizePrivateFields counts
+  assignments but does not check definite assignment or where the assignment lives:
+    gameengine/.../GameListPanel.java      name_
+        constructor returns early in the bDemo_ branch, so the field is not definitely
+        assigned on every path -> "variable name_ might not have been initialized"
+    poker/.../ShowTournamentTable.java     amount_, amountText_, slider_
+        assigned in a regular method rather than a constructor
+        -> "cannot assign a value to final variable"
+  Both are compile errors, so a re-run can never slip past CI unnoticed - which is why
+  the recipe is kept rather than dropped.
 recipeList:
   - org.openrewrite.staticanalysis.FinalizePrivateFields
   - org.openrewrite.staticanalysis.FinalClass
   - org.openrewrite.staticanalysis.ModifierOrder
   - org.openrewrite.staticanalysis.StaticAccessViaInstance
-  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
   - org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
 
 ---


### PR DESCRIPTION
PR 8 of the modernization series.

Applied with `mvn rewrite:run -Drewrite.activeRecipes=com.donohoedigital.FinalAndModifiers`,
then four fields reverted by hand — see below.

**213 files, +616/−612.**

| Count | Change |
|------:|--------|
| 386 | private field marked `final` |
| 196 | modifier order / redundant modifiers |
| 32 | class marked `final` |
| — | plus `StaticAccessViaInstance`, nested-enum cleanup |

## Hibernate entities are fine — and the tests prove it

`FinalizePrivateFields` only finalizes a field assigned exactly once, and entity fields are
assigned in their setters, so `OnlineGame`, `TournamentHistory`, `OnlineProfile`,
`Registration`, `BannedKey` and `UpgradedKey` take no `final`.

More usefully than inspecting the patch: **the Hibernate-backed tests run against a real
database and pass** — `PokerDatabaseTest`, `OnlineGameTest`, `OnlineProfileTest`,
`TournamentHistoryTest`, plus `OnlineGameServiceTest`, `OnlineProfileServiceTest` and
`TournamentHistoryServiceTest`. A wrongly-finalized entity field would fail there, since
Hibernate sets fields reflectively.

## Four fields reverted

The recipe counts assignments but checks neither **definite assignment** nor **where the
assignment lives**. Both defects are compile errors, caught by the build:

| Field | Failure |
|---|---|
| `GameListPanel.name_` | *variable might not have been initialized* — the constructor returns early in the `bDemo_` branch, so it isn't assigned on every path |
| `ShowTournamentTable.amount_`, `.amountText_`, `.slider_` | *cannot assign a value to final variable* — assigned in a regular method, not a constructor |

**This group is therefore not idempotent** — re-running re-adds `final` to those four. A
verification re-run produces exactly that patch and nothing else.

That's tolerable here specifically because both failures are **compile errors**: a re-run
cannot slip past CI unnoticed. It's the inverse of `RemoveExtraSemicolons` in PR #235, which
silently mangled whitespace into `}/**` and was dropped for exactly that reason. The four
fields are documented in `rewrite.yml`.

## `MissingOverrideAnnotation` dropped

Removed from this group and from the project, at Doug's call. It would have added **2139
annotations across 516 files, 268 of which change by nothing else** — 74% of the original
diff — and IntelliJ doesn't flag missing `@Override` by default, so it was scope beyond what
the IDE asks for.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**, Hibernate tests included
- Compiler used as the oracle for override breakage from `static` changes, per Doug — javac
  rejects an instance method overriding a static one, so no manual review needed there
- Re-run produces only the 4 documented fields