### PR TITLE
Use parameterized logging instead of concatenation

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
+++ b/code/common/src/main/java/com/donohoedigital/base/ManagedQueue.java
@@ -231,9 +231,8 @@ public abstract class ManagedQueue<T>
         {
             if (!queue.offer(item, waitLimitWarningMillis, TimeUnit.MILLISECONDS))
             {
-                logger.warn("Exceeded " + waitLimitWarningMillis +
-                            " milliseconds waiting to add item: " + item);
-                logger.debug("All stacktraces at this time: \n" + Utils.getAllStacktraces());
+                logger.warn("Exceeded {} milliseconds waiting to add item: {}", waitLimitWarningMillis, item);
+                logger.debug("All stacktraces at this time: \n{}", Utils.getAllStacktraces());
                 if (waitLimitErrorMillis <= 0 || !queue.offer(item, waitLimitErrorMillis, TimeUnit.MILLISECONDS))
                 {
                     throw new ApplicationError("Exceeded " + waitLimitErrorMillis +

--- a/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DDMessage.java
@@ -568,8 +568,8 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
      */
     public void debugPrint()
     {
-        if (nStatus_ != DDMessageListener.STATUS_NONE) logger.debug("MSG-Status: " + nStatus_);
-        logger.debug("MSG-Params: " + super.toString());
+        if (nStatus_ != DDMessageListener.STATUS_NONE) logger.debug("MSG-Status: {}", nStatus_);
+        logger.debug("MSG-Params: {}", super.toString());
         
         
         if (msgdata_ == null || msgdata_.isEmpty())
@@ -582,7 +582,7 @@ public class DDMessage extends TypedHashMap implements PostWriter, PostReader, D
             for (int i = 0; i < msgdata_.size(); i++)
             {
                 sData = getDataAtAsString(i);
-                logger.debug("MSG-Data[" + i +"]: " + sData.length() + " bytes of data, displayed below:");
+                logger.debug("MSG-Data[{}]: {} bytes of data, displayed below:", i, sData.length());
                 StringTokenizer tok = new StringTokenizer(sData,"\n");
                 while (tok.hasMoreTokens())
                 {

--- a/code/common/src/main/java/com/donohoedigital/comms/DMArrayList.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DMArrayList.java
@@ -143,8 +143,7 @@ public class DMArrayList<E> extends ArrayList<E> implements DataMarshal
             }
             else
             {
-                logger.debug("Warning: skipping unsupported array entry #" + i + 
-                                " class is "+(oValue != null ? oValue.getClass().getName():"null"));
+                logger.debug("Warning: skipping unsupported array entry #{} class is {}", i, (oValue != null ? oValue.getClass().getName() : "null"));
             }
         }
         return list.marshal(state);

--- a/code/common/src/main/java/com/donohoedigital/comms/NameValueToken.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/NameValueToken.java
@@ -184,8 +184,7 @@ public class NameValueToken implements DataMarshal
             }
             else
             {
-                logger.debug("Warning: skipping unsupported map entry '" + sName + 
-                                "' class is "+(oValue != null ? oValue.getClass().getName():"null"));
+                logger.debug("Warning: skipping unsupported map entry '{}' class is {}", sName, (oValue != null ? oValue.getClass().getName() : "null"));
             }
         }
     }

--- a/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/AudioConfig.java
@@ -227,7 +227,7 @@ public class AudioConfig extends XMLConfigFileLoader
         AudioDef audio = getAudioDef(sName, bReportMissing);
         if (audio == null)
         {
-            aLogger.warn("Unable to play " + sName + " (not defined)");
+            aLogger.warn("Unable to play {} (not defined)", sName);
             return null;
         }
         AudioPlayer player = new AudioPlayer(audio, fGain, sleepSecs, bLoop);
@@ -403,7 +403,7 @@ public class AudioConfig extends XMLConfigFileLoader
         {
             if (bReportMissing)
             {
-                aLogger.warn("No audio found for " + sName);
+                aLogger.warn("No audio found for {}", sName);
             }
             return null;
         }
@@ -477,7 +477,7 @@ public class AudioConfig extends XMLConfigFileLoader
         URL url = new MatchingResources("classpath*:config/" + location).getSingleResourceURL();
         if (url == null)
         {
-            aLogger.warn("Audio " + sName + " not found at " + location + ".  Skipping");
+            aLogger.warn("Audio {} not found at {}.  Skipping", sName, location);
             return;
         }
 

--- a/code/common/src/main/java/com/donohoedigital/config/BaseDataFile.java
+++ b/code/common/src/main/java/com/donohoedigital/config/BaseDataFile.java
@@ -137,7 +137,7 @@ public abstract class BaseDataFile
         long lastMod2 = file_.lastModified();
         if (lastMod_ != 0 && lastMod2 != lastMod_)
         {
-            logger.warn("Saving file " + file_.getAbsolutePath() + ", but last modified changed from " + lastMod_ + " to " + lastMod2);
+            logger.warn("Saving file {}, but last modified changed from {} to {}", file_.getAbsolutePath(), lastMod_, lastMod2);
         }
         
         // this actually changes last mod date!

--- a/code/common/src/main/java/com/donohoedigital/config/DataElement.java
+++ b/code/common/src/main/java/com/donohoedigital/config/DataElement.java
@@ -177,7 +177,7 @@ public class DataElement
 
         if (sDisplayValue == null)
         {
-            logger.warn("WARNING: No display value for " + sName_ + "." + oValue);
+            logger.warn("WARNING: No display value for {}.{}", sName_, oValue);
 
             return oValue.toString();
         }

--- a/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/DebugConfig.java
@@ -93,7 +93,7 @@ public class DebugConfig
         boolean b = PropertyConfig.getBooleanProperty(sName, false, false);
         if (b)
         {
-            logger.debug("Debug setting " + sName + " is on.");
+            logger.debug("Debug setting {} is on.", sName);
         }
         return b;
     }

--- a/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/HelpConfig.java
@@ -156,7 +156,7 @@ public class HelpConfig extends XMLConfigFileLoader
         URL url = new MatchingResources("classpath*:config/" + location).getSingleResourceURL();
         if (url == null)
         {
-            hLogger.warn("Help " + sName + " not found at " + location + ".  Skipping");
+            hLogger.warn("Help {} not found at {}.  Skipping", sName, location);
             return;
         }
         

--- a/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageConfig.java
@@ -100,7 +100,7 @@ public class ImageConfig extends XMLConfigFileLoader
         ImageDef image = getImageDef(sName);
         if (image == null) 
         {
-            iLogger.warn("No image found for " + sName);
+            iLogger.warn("No image found for {}", sName);
             return null;
         }
         return image.getImageIcon();
@@ -129,7 +129,7 @@ public class ImageConfig extends XMLConfigFileLoader
         ImageDef image = getImageDef(sName);
         if (image == null) 
         {
-            iLogger.warn("No image found for " + sName);
+            iLogger.warn("No image found for {}", sName);
             return null;
         }
         return image.getAnimatedImageIcon();
@@ -143,7 +143,7 @@ public class ImageConfig extends XMLConfigFileLoader
         ImageDef image = getImageDef(sName);
         if (image == null) 
         {
-            iLogger.warn("No image found for cursor " + sName);
+            iLogger.warn("No image found for cursor {}", sName);
             return null;
         }
 
@@ -204,7 +204,7 @@ public class ImageConfig extends XMLConfigFileLoader
         {
             if (bReportMissing && !sName.contains("default"))
             {
-                iLogger.warn("No image found for " + sName);
+                iLogger.warn("No image found for {}", sName);
             }
             return null;
         }
@@ -272,7 +272,7 @@ public class ImageConfig extends XMLConfigFileLoader
             url = new MatchingResources("classpath*:config/" + location).getSingleResourceURL();
             if (url == null)
             {
-                iLogger.warn("Image " + sName + " not found at " + location + ".  Skipping");
+                iLogger.warn("Image {} not found at {}.  Skipping", sName, location);
                 return;
             }
         }

--- a/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ImageDef.java
@@ -290,7 +290,7 @@ public class ImageDef
         }
         catch (Throwable e)
         {
-            logger.error("Error creating buffered image from " + url);
+            logger.error("Error creating buffered image from {}", url);
             logger.error(Utils.formatExceptionText(e));
         }
         return null;

--- a/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
+++ b/code/common/src/main/java/com/donohoedigital/config/PropertyConfig.java
@@ -144,7 +144,7 @@ public class PropertyConfig extends Properties
             File override = new File(userdir, "testing.properties");
             if (override.exists())
             {
-                logger.info("Loading testing overrides from " + override.getPath());
+                logger.info("Loading testing overrides from {}", override.getPath());
                 FileInputStream stream = ConfigUtils.getFileInputStream(override);
                 try
                 {
@@ -188,7 +188,7 @@ public class PropertyConfig extends Properties
         // log if doing overrides
         if (bOverride)
         {
-            logger.info("Loading local overrides from " + file.getPath());
+            logger.info("Loading local overrides from {}", file.getPath());
         }
 
         //logger.debug("Loading: " + props);
@@ -324,7 +324,7 @@ public class PropertyConfig extends Properties
         String sValue = getStringProperty(sKey);
         if (sValue == null)
         {
-            logger.error("Property value not found for: '" + sKey + '\'');
+            logger.error("Property value not found for: '{}'", sKey);
         }
         return sValue;
     }
@@ -364,7 +364,7 @@ public class PropertyConfig extends Properties
         {
             if (!sKey.contains("default"))
             {
-                logger.warn("Property value not found for: '" + sKey + '\'');
+                logger.warn("Property value not found for: '{}'", sKey);
             }
         }
 

--- a/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
+++ b/code/common/src/main/java/com/donohoedigital/config/ShutdownManager.java
@@ -143,7 +143,7 @@ public final class ShutdownManager implements Thread.UncaughtExceptionHandler
      */
     public void uncaughtException(Thread t, Throwable e)
     {
-        logger.fatal("Uncaught exception in thread " + t.getName(), e);
+        logger.fatal("Uncaught exception in thread {}", t.getName(), e);
         exitAbnormal(UNCAUGHTEXCEPTION, "uncaught exception: " + e.getMessage());
     }
 
@@ -168,14 +168,14 @@ public final class ShutdownManager implements Thread.UncaughtExceptionHandler
         // log message if non-normal or if we ran shutdown hooks
         boolean log = verbose && (shutdownType != NORMAL || !listeners.isEmpty());
         if (log) {
-            logger.info("Shutting down (" + shutdownType + "): " + shutdownDetails + " ...");
+            logger.info("Shutting down ({}): {} ...", shutdownType, shutdownDetails);
         }
 
         // run listeners
         Collections.reverse(listeners);
         for (ShutdownListener listener : listeners) {
             try {
-                if (log) logger.info("Calling shutdown listener: " + listener);
+                if (log) logger.info("Calling shutdown listener: {}", listener);
                 listener.shutdown(shutdownType, shutdownDetails);
             }
             catch (Throwable t) {

--- a/code/common/src/test/java/com/donohoedigital/config/ActivationTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/ActivationTest.java
@@ -53,7 +53,7 @@ public class ActivationTest
     public void testGuid()
     {
         String key = Activation.createKeyFromGuid(22, "BD4206D4-72B0-EA5D-6FF7-1B50F92CCD49", null);
-        logger.debug("Key: " + key + " length: " + key.length());
+        logger.debug("Key: {} length: {}", key, key.length());
 
         for (String guid : new String[]{"foo", "BD4206D4-72B0-EA5D-6FF7-1B50F92CCD4z"})
         {
@@ -85,7 +85,7 @@ public class ActivationTest
         }
         catch (Exception e)
         {
-            logger.debug("Expected exception: " + e.getMessage());
+            logger.debug("Expected exception: {}", e.getMessage());
         }
     }
 }

--- a/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/DataElementConfigTest.java
@@ -71,7 +71,7 @@ public class DataElementConfigTest
         List<?> values = dogs.getListValues();
         for (Object o : values)
         {
-            logger.info("Value: " + o);
+            logger.info("Value: {}", o);
         }
         assertTrue(values.contains("tahoe"));
         assertTrue(values.contains("dexter"));

--- a/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/HelpConfigTest.java
@@ -62,7 +62,7 @@ public class HelpConfigTest
             HelpTopic ht = HelpConfig.getHelpTopic("test"+i);
             String contents = ht.getContents();
             assertNotNull(contents);
-            logger.info("Topic " + i + ": " + contents.trim());
+            logger.info("Topic {}: {}", i, contents.trim());
         }
     }
 }

--- a/code/common/src/test/java/com/donohoedigital/config/MatchingResourcesTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/MatchingResourcesTest.java
@@ -62,7 +62,7 @@ public class MatchingResourcesTest
         URL[] match = mr.getAllMatchesURL();
         assertTrue(match.length == 1);
 
-        logger.info("URL: " + match[0]);
+        logger.info("URL: {}", match[0]);
         assertTrue(mr.getURL(null) == null);
 
         Resource[] none = new MatchingResources("classpath*:com/donohoedigital/config/NoSuchFile.class").getAllMatches();
@@ -83,7 +83,7 @@ public class MatchingResourcesTest
         }
         catch (Exception ae)
         {
-            logger.debug("Expected exception: " + ae.getMessage());
+            logger.debug("Expected exception: {}", ae.getMessage());
         }
 
         // test multiple matches
@@ -94,7 +94,7 @@ public class MatchingResourcesTest
         }
         catch (Exception ae)
         {
-            logger.debug("Expected exception: " + ae.getMessage());
+            logger.debug("Expected exception: {}", ae.getMessage());
         }
 
     }
@@ -105,7 +105,7 @@ public class MatchingResourcesTest
         MatchingResources mr = new MatchingResources("classpath*:com/donohoedigital/config/*.class");
         assertTrue(mr.getAllMatches().length > 0);
 
-        logger.info("URLs:\n" + mr);
+        logger.info("URLs:\n{}", mr);
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
+++ b/code/db/src/main/java/com/donohoedigital/db/DatabaseManager.java
@@ -140,7 +140,7 @@ public class DatabaseManager
         database.init();
         hmDatabases_.put(name, database);
 
-        logger.info("Loaded database: " + database);
+        logger.info("Loaded database: {}", database);
     }
 
     /**

--- a/code/db/src/main/java/com/donohoedigital/db/DatabaseQuery.java
+++ b/code/db/src/main/java/com/donohoedigital/db/DatabaseQuery.java
@@ -602,7 +602,7 @@ public class DatabaseQuery
         }
         catch (SQLException e)
         {
-            logger.warn("Exception on close: " + Utils.formatExceptionText(e));
+            logger.warn("Exception on close: {}", Utils.formatExceptionText(e));
         }
         finally
         {
@@ -617,7 +617,7 @@ public class DatabaseQuery
             }
             catch (SQLException e)
             {
-                logger.warn("Exception on close: " + Utils.formatExceptionText(e));
+                logger.warn("Exception on close: {}", Utils.formatExceptionText(e));
             }
         }
 

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/comms/ActionItem.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/comms/ActionItem.java
@@ -251,16 +251,14 @@ public class ActionItem extends DMTypedHashMap
         if (l == null)
         {
             // BUG 199 - don't throw exception.  Log error and return false.
-            logger.warn("Setting player acted, but player not part of this action: " + 
-                                    id + "(action " + getActionID() +")");
+            logger.warn("Setting player acted, but player not part of this action: {}(action {})", id, getActionID());
             return false;
         }
         
         if (!l.equals(INIT_LONG))
         {
             // BUG 199 - don't throw exception.  Log error and return false.
-            logger.warn("Setting player acted, but player already acted " +
-                                    id + "(action " + getActionID() +")");
+            logger.warn("Setting player acted, but player already acted {}(action {})", id, getActionID());
             return false;
         }
         setLong(sId, Utils.getCurrentTimeStamp());

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/BorderPoint.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/BorderPoint.java
@@ -202,8 +202,7 @@ public class BorderPoint extends MapPoint
             }
         }
         bCurrentBorder_ = null;
-        logger.warn("setCurrentBorder to border: " + border.shortDesc() + 
-                            " - is not a border in point " + longDesc(null));
+        logger.warn("setCurrentBorder to border: {} - is not a border in point {}", border.shortDesc(), longDesc(null));
     }
     
     /**
@@ -233,8 +232,7 @@ public class BorderPoint extends MapPoint
                 return myBorders_.getBorder(nIndex);
             }
         }
-        logger.warn("nextBorder() not found for " + bCurrentBorder_.shortDesc() +
-                                    " in point " + longDesc(null));
+        logger.warn("nextBorder() not found for {} in point {}", bCurrentBorder_.shortDesc(), longDesc(null));
         return null;
     }
     
@@ -274,7 +272,7 @@ public class BorderPoint extends MapPoint
     private BorderPoint getNavPoint(int nType, Border border)
     {
          if (border == null) {
-            logger.warn("myBorder is null in BorderPoint.getNavXPoint() " + toString());
+            logger.warn("myBorder is null in BorderPoint.getNavXPoint() {}", toString());
             return null;
         }
         int nSize = border.size();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Borders.java
@@ -213,7 +213,7 @@ public class Borders extends TreeSet<Border> {
             borderwriter.close();
         }
         
-        logger.info("Saved " + id + " border files");
+        logger.info("Saved {} border files", id);
         
         writer.printElementLine(NUMBORDERFILES, id, nIndent);
         writer.printNewLine();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameState.java
@@ -264,11 +264,11 @@ public class GameState extends MsgState implements SaveFile
     {
         if (bCheckEmpty && !entries_.isEmpty())
         {
-            logger.warn("GameState resetAfterRead: " + sName_ + ": has " + entries_.size() + " entries left.");
+            logger.warn("GameState resetAfterRead: {}: has {} entries left.", sName_, entries_.size());
             for (int i = 0; i < entries_.size(); i++)
             {
                 GameStateEntry entry = entries_.get(i);
-                logger.debug("Entry["+i+"]: " + entry.marshal(null));
+                logger.debug("Entry[{}]: {}", i, entry.marshal(null));
             }
         }
         reset();
@@ -356,25 +356,25 @@ public class GameState extends MsgState implements SaveFile
         {
             if (bak.exists() && !bak.delete())
             {
-                logger.warn("Unable to delete " + bak.getName());
+                logger.warn("Unable to delete {}", bak.getName());
             }
             
             if (!file_.renameTo(bak))
             {
-                logger.warn("Unable to rename " + file_.getName() + " to " + bak.getName());             
+                logger.warn("Unable to rename {} to {}", file_.getName(), bak.getName());             
             }
         }
         
         // move temp file to existing file
         if (!tmp.renameTo(file_))
         {
-            logger.warn("Unable to rename " + tmp.getName() + " to " + file_.getName());
+            logger.warn("Unable to rename {} to {}", tmp.getName(), file_.getName());
         }
         
         // cleanup backup file
         if (bak.exists() && !bak.delete())
         {
-            logger.warn("Unable to delete " + bak.getName());
+            logger.warn("Unable to delete {}", bak.getName());
         }
         
     }
@@ -878,8 +878,7 @@ public class GameState extends MsgState implements SaveFile
             }
             catch (Throwable e)
             {
-                logger.error("Error loading " + file.getAbsolutePath() + ": " +
-                             Utils.formatExceptionText(e));
+                logger.error("Error loading {}: {}", file.getAbsolutePath(), Utils.formatExceptionText(e));
             }
         }
 

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameboardConfig.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/GameboardConfig.java
@@ -287,7 +287,7 @@ public class GameboardConfig extends XMLConfigFileLoader
     {
         if (!bSave_)
         {
-            logger.warn("Save disabled for " + fConfigFile_.getAbsolutePath());
+            logger.warn("Save disabled for {}", fConfigFile_.getAbsolutePath());
             return;
         }
         
@@ -297,7 +297,7 @@ public class GameboardConfig extends XMLConfigFileLoader
         printXML(writer, 0);
         writer.close();
         
-        logger.info("Saved " + fConfigFile_.getAbsolutePath());
+        logger.info("Saved {}", fConfigFile_.getAbsolutePath());
     }
     
     /**

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/TerritoryPoint.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/TerritoryPoint.java
@@ -126,7 +126,7 @@ public class TerritoryPoint extends MapPoint
     private TerritoryPoint getNavPoint(int nType)
     {
         if (myTerritory_ == null) {
-            logger.warn("myTerritory_ is null in TerritoryPoint.getNavXPoint() " + this);
+            logger.warn("myTerritory_ is null in TerritoryPoint.getNavXPoint() {}", this);
             return null;
         }
         int nSize = myTerritory_.size();

--- a/code/gamecommon/src/main/java/com/donohoedigital/games/config/Token.java
+++ b/code/gamecommon/src/main/java/com/donohoedigital/games/config/Token.java
@@ -292,10 +292,10 @@ public class Token
     
     public void debugPrintActionHistory()
     {
-        logger.debug("Action history for: " + toString());
+        logger.debug("Action history for: {}", toString());
         for (int i = 0; i < actionHistory_.size(); i++)
         {
-            logger.debug("#" + i + ":" + getAction(i));
+            logger.debug("#{}:{}", i, getAction(i));
         }
     }
     

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Activate.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Activate.java
@@ -252,12 +252,12 @@ public class Activate extends BasePhase implements PropertyChangeListener
                     String local = localaddr.getHostAddress();
                     if (local == null || local.equals("127.0.0.1") || local.equals("0.0.0.0"))
                     {
-                        logger.warn("Skipping verification: no local address: " + local);
+                        logger.warn("Skipping verification: no local address: {}", local);
                         bVerify = false;
                     }
                     else
                     {
-                        logger.info("Verifying from local addr: " + localaddr.getHostAddress());
+                        logger.info("Verifying from local addr: {}", localaddr.getHostAddress());
                     }
                 }
                 catch (UnknownHostException uhe)

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/ButtonBox.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/ButtonBox.java
@@ -137,7 +137,7 @@ public class ButtonBox extends DDPanel implements AncestorListener
         
         if (sEnter != null && sEnter.length() > 0 && bDefaultSet == false)
         {
-            logger.warn("Unable to set enter button " + sEnter + " (no matching button found)");
+            logger.warn("Unable to set enter button {} (no matching button found)", sEnter);
         }
         
         if (bVertical) {

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePiece.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineGamePiece.java
@@ -223,7 +223,7 @@ public abstract class EngineGamePiece extends GamePiece {
         // get point at which we draw this piece
         TerritoryPoint tp = t.getTerritoryPoint(tpName_);
         if (tp == null) {
-            logger.warn("No '" + tpName_ + "' territory point defined for " + t.getName());
+            logger.warn("No '{}' territory point defined for {}", tpName_, t.getName());
             return;
         }
         
@@ -278,7 +278,7 @@ public abstract class EngineGamePiece extends GamePiece {
         
         if (TESTING(EngineConstants.TESTING_DEBUG_REPAINT_DETAILS))
         {
-            logger.debug("Drawing " + getTerritory().getName() + ":" + getName());
+            logger.debug("Drawing {}:{}", getTerritory().getName(), getName());
         }
         drawImageAt(g, ic, nNum, nHiddenNum, 0, x, y, width, height, board.dScale_);
     }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/EngineWindow.java
@@ -310,7 +310,7 @@ public class EngineWindow extends BaseFrame
        public void actionPerformed(ActionEvent e)
        {
             TOGGLE(UDPServer.TESTING_UDP);
-            logger.debug("UDP flags turned " + (TESTING(UDPServer.TESTING_UDP) ? "on":"off"));
+            logger.debug("UDP flags turned {}", (TESTING(UDPServer.TESTING_UDP) ? "on" : "off"));
             UDPServer.setDebugFlags();
        }
     }
@@ -323,7 +323,7 @@ public class EngineWindow extends BaseFrame
        public void actionPerformed(ActionEvent e)
        {
             TOGGLE(EngineConstants.TESTING_UDP_APP);
-            logger.debug("UDP APP flags turned " + (TESTING(EngineConstants.TESTING_UDP_APP) ? "on":"off"));
+            logger.debug("UDP APP flags turned {}", (TESTING(EngineConstants.TESTING_UDP_APP) ? "on" : "off"));
        }
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameContext.java
@@ -446,7 +446,7 @@ public class GameContext
     {
         if ((engine_.isBDemo() || engine_.isActivationNeeded()) && TODOphase_ != null)
         {
-            logger.warn("Skipping " + sPhaseName + " because TODO phase is not null: " + TODOphase_);
+            logger.warn("Skipping {} because TODO phase is not null: {}", sPhaseName, TODOphase_);
             return null;
         }
 
@@ -496,7 +496,7 @@ public class GameContext
         }
         catch (ApplicationError ae)
         {
-            logger.warn("GameContext - ApplicationError caught processing phase " + sPhaseName);
+            logger.warn("GameContext - ApplicationError caught processing phase {}", sPhaseName);
             switch (ae.getErrorCode())
             {
                 case ErrorCodes.ERROR_NULL:
@@ -515,7 +515,7 @@ public class GameContext
         }
         catch (Throwable e)
         {
-            logger.warn("GameContext - Exception caught processing phase " + sPhaseName);
+            logger.warn("GameContext - Exception caught processing phase {}", sPhaseName);
             logger.warn(Utils.formatExceptionText(e));
             _handleProcessPhaseException(e);
         }
@@ -728,7 +728,7 @@ public class GameContext
         }
         else
         {
-            logger.warn("Not able to step back " + nStepsBack);
+            logger.warn("Not able to step back {}", nStepsBack);
         }
     }
 

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameEngine.java
@@ -170,7 +170,7 @@ public abstract class GameEngine extends BaseApp
             sOverrideKey_ = getCommandLineOptions().getString("key", null);
             if (sOverrideKey_ != null)
             {
-                logger.debug("Activation key set to " + sOverrideKey_);
+                logger.debug("Activation key set to {}", sOverrideKey_);
             }
         }
 
@@ -191,10 +191,8 @@ public abstract class GameEngine extends BaseApp
                 isBannedLicenseKey(sKey))
             {
                 // TODO: remove debug once bug figured out
-                logger.debug("Activation needed, sKey=" + sKey +
-                             " validate: " + !Activation.validate(getKeyStart(), sKey, getLocale()) +
-                             " (keystart = " + getKeyStart() + " locale= " + getLocale() + ")" +
-                             " isBanned?: " + isBannedLicenseKey(sKey));
+                logger.debug("Activation needed, sKey={} validate: {} (keystart = {} locale= {})" +
+                    " isBanned?: {}", sKey, !Activation.validate(getKeyStart(), sKey, getLocale()), getKeyStart(), getLocale(), isBannedLicenseKey(sKey));
 
                 activationNeeded = true;
             }
@@ -492,7 +490,7 @@ public abstract class GameEngine extends BaseApp
         if (key == null && isAutoGenLicenseKey())
         {
             key = Activation.createKeyFromGuid(getKeyStart(), getGUID(), getLocale());
-            logger.debug("KEY: " + key);
+            logger.debug("KEY: {}", key);
             node.put(Activation.REGKEY, key);
         }
         return key;

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/GameListPanel.java
@@ -375,7 +375,7 @@ public final class GameListPanel extends DDPanel implements ListSelectionListene
             else
             {
                 if (dialog_ != null) dialog_.removeDialog();
-                logger.info("Loading saved game: " + selected_.getFile().getAbsolutePath());
+                logger.info("Loading saved game: {}", selected_.getFile().getAbsolutePath());
                 LoadSavedGame.loadGame(context_, selected_);
             }
         }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/SendMessageDialog.java
@@ -379,7 +379,7 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
             nStatus_ != DDMessageListener.STATUS_OK &&
             nStatus_ != DDMessageListener.STATUS_APPL_ERROR)
         {
-            sLogger.warn("Ignoring error [" + nStatus_ + "]: " + errors_[nStatus_]);
+            sLogger.warn("Ignoring error [{}]: {}", nStatus_, errors_[nStatus_]);
             if (nStatus_ == DDMessageListener.STATUS_SERVER_ERROR ||
                 nStatus_ == DDMessageListener.STATUS_UNKNOWN_ERROR)
             {
@@ -387,7 +387,7 @@ public abstract class SendMessageDialog extends DialogPhase implements DDMessage
 
                 if (sMsg != null)
                 {
-                    sLogger.warn("Details: " + sMsg);
+                    sLogger.warn("Details: {}", sMsg);
                 }
             }
             updateStep(DDMessageListener.STEP_DONE);

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Support.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Support.java
@@ -160,7 +160,7 @@ public class Support extends OptionMenu
             File f = ConfigManager.getUserHome();
             if (!Utils.openFolder(f))
             {
-                logger.error("Unable to open folder: " + f.getAbsolutePath());
+                logger.error("Unable to open folder: {}", f.getAbsolutePath());
                 EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.error.myfiles", f.getAbsolutePath()));
             }
         }

--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/TableExporter.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/TableExporter.java
@@ -69,7 +69,7 @@ public class TableExporter implements DDTable.Exporter
         if (oResult != null && oResult instanceof File)
         {
             File file = (File) oResult;
-            logger.info("Exporting table to " + file.getAbsolutePath());
+            logger.info("Exporting table to {}", file.getAbsolutePath());
             ConfigUtils.writeFile((File)oResult, table.toCSV(true), false);
         }
 

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
@@ -154,7 +154,7 @@ public class RegAnalyzer
             // Create app to parse command line options
             RegAnalyzerApp info = new RegAnalyzerApp("servertools", args);
 
-            logger.info("Analyzer initializing, params: " + Utils.toString(args, " "));
+            logger.info("Analyzer initializing, params: {}", Utils.toString(args, " "));
 
             // create application context
             ApplicationContext ctx = new ClassPathXmlApplicationContext("app-context-gameserver.xml");
@@ -198,7 +198,7 @@ public class RegAnalyzer
         // do the work
         long time = System.currentTimeMillis();
         doAnalyze();
-        logger.debug("Elapsed time: " + (System.currentTimeMillis() - time));
+        logger.debug("Elapsed time: {}", (System.currentTimeMillis() - time));
     }
 
     private void setOptions(TypedHashMap htOptions)
@@ -341,7 +341,7 @@ public class RegAnalyzer
 	private void doAnalyze()
 	{
         // load each file's registrations
-        logger.debug("RUNNING: scanning registration records in " + sGame_);
+        logger.debug("RUNNING: scanning registration records in {}", sGame_);
 
         // query values - banned keys are required; all other values are options
         doBannedKeys();

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/RegistrationServiceTest.java
@@ -71,7 +71,7 @@ public class RegistrationServiceTest
         Registration reg = ServerTestData.createRegistration("RegistrationServiceTest", "9999-8888-7777-6666");
         service.saveRegistration(reg);
 
-        logger.info("Saved: " + reg);
+        logger.info("Saved: {}", reg);
         assertNotNull(reg.getId());
 
         Registration reg2 = ServerTestData.createRegistration("RegistrationServiceTest", "9999-8888-7777-6666");

--- a/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
+++ b/code/gameserver/src/test/java/com/donohoedigital/games/server/SpringCreatedServiceTest.java
@@ -74,7 +74,7 @@ public class SpringCreatedServiceTest
         Registration reg = ServerTestData.createRegistration("RegistrationServiceTest", "3333-3333-7777-6666");
         service.saveRegistration(reg);
 
-        logger.info("Saved: " + reg);
+        logger.info("Saved: {}", reg);
         assertNotNull(reg.getId());
 
         service.deleteRegistration(reg);

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameManager.java
@@ -159,7 +159,7 @@ public abstract class GameManager extends BaseApp implements KeyListener, Status
         }
         catch (ApplicationError e)
         {
-            logger.warn("Error trying to save: " + e.toString());
+            logger.warn("Error trying to save: {}", e.toString());
         }
     }
     

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardBorderManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardBorderManager.java
@@ -93,7 +93,7 @@ public class GameboardBorderManager extends GameManager
         }
         catch (ApplicationError ae)
         {
-            logger.fatal("GameboardBorderManager ending due to ApplicationError: " + ae.toStringNoStackTrace());
+            logger.fatal("GameboardBorderManager ending due to ApplicationError: {}", ae.toStringNoStackTrace());
             System.exit(1);
         }  
     }
@@ -137,7 +137,7 @@ public class GameboardBorderManager extends GameManager
         
         if (dScale_ != dNewScale && dNewScale != NO_SCALE)
         {
-            logger.info("Setting new scale: " + dNewScale);
+            logger.info("Setting new scale: {}", dNewScale);
             gameconfig_.setScale(dNewScale);
             dScale_ = dNewScale;
         }

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
@@ -92,7 +92,7 @@ public class GameboardTerritoryManager extends GameManager implements CustomTerr
         }
         catch (ApplicationError ae)
         {
-            logger.fatal("GameboardTerritoryManager ending due to ApplicationError: " + Utils.formatExceptionText(ae));
+            logger.fatal("GameboardTerritoryManager ending due to ApplicationError: {}", Utils.formatExceptionText(ae));
             System.exit(1);
         }  
     }

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
@@ -98,7 +98,7 @@ public class PokerRankUpdater extends BaseCommandLineApp
         // do the work
         long time = System.currentTimeMillis();
         doRank();
-        logger.debug("Elapsed time: " + (System.currentTimeMillis() - time));
+        logger.debug("Elapsed time: {}", (System.currentTimeMillis() - time));
     }
 
     ///
@@ -134,14 +134,13 @@ public class PokerRankUpdater extends BaseCommandLineApp
             list = gameService.getOnlineGames(total, offset, GAMES_CHUNK, modes, null, null, null, date);
         }
 
-        logger.debug("Processed " + count + " of " + total);
+        logger.debug("Processed {} of {}", count, total);
     }
 
     private void doRank(OnlineGame game)
     {
         int count = histService.getAllTournamentHistoriesForGameCount(game.getId());
-        logger.debug("id #" + game.getId() + ": " + game.getTournament().getName() + " hosted by " + game.getHostPlayer() +
-                     " with " + count + " total players");
+        logger.debug("id #{}: {} hosted by {} with {} total players", game.getId(), game.getTournament().getName(), game.getHostPlayer(), count);
 
         histService.upgradeAllTournamentHistoriesForGame(game, null);//logger);        
     }

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/TerritoryBoard.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/TerritoryBoard.java
@@ -244,7 +244,7 @@ public class TerritoryBoard extends Gameboard implements KeyListener, DrawingUti
             // add to list of everything - which checks for duplicates
             if (allPoints_.contains(point))
             {
-                logger.warn("New territory point already exists as a defined point.  Ignoring it! - " + point.shortDesc());
+                logger.warn("New territory point already exists as a defined point.  Ignoring it! - {}", point.shortDesc());
                 return;
             }
             

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/XPoints.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/XPoints.java
@@ -236,7 +236,7 @@ public class XPoints extends XConnectorLines implements KeyListener,
         // add to list of everything - which checks for duplicates
         if (allPoints_.contains(point))
         {
-            logger.warn("New border point already exists as a defined point.  Ignoring it! - " + point.longDesc(null));
+            logger.warn("New border point already exists as a defined point.  Ignoring it! - {}", point.longDesc(null));
             return;
         }
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/BaseFrame.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/BaseFrame.java
@@ -709,7 +709,7 @@ public class BaseFrame extends JFrame implements DDWindow
                 {
                     // This is essentially the body of EventDispatchThread
                     AWTEvent event = theQueue.getNextEvent();
-                    if (!bModal_) logger.warn("***** GUI dispatching when not modal: " + event);
+                    if (!bModal_) logger.warn("***** GUI dispatching when not modal: {}", event);
                     Object src = event.getSource();
                     // can't call theQueue.dispatchEvent, so I pasted its body here
                     if (event instanceof ActiveEvent)
@@ -726,7 +726,7 @@ public class BaseFrame extends JFrame implements DDWindow
                     }
                     else
                     {
-                        logger.warn("Unable to dispatch event: " + event);
+                        logger.warn("Unable to dispatch event: {}", event);
                     }
                 }
             }
@@ -736,7 +736,7 @@ public class BaseFrame extends JFrame implements DDWindow
             }
             catch (Throwable t)
             {
-                logger.debug("Error during modal: " + Utils.formatExceptionText(t));
+                logger.debug("Error during modal: {}", Utils.formatExceptionText(t));
             }
 
             //logger.debug("GUI Modal is ended");

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDComboBox.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDComboBox.java
@@ -223,7 +223,7 @@ public class DDComboBox extends JComboBox implements
 
         if (elem == null)
         {
-            logger.warn("DataElement not found for " + sDataElement);
+            logger.warn("DataElement not found for {}", sDataElement);
             return;
         }
 
@@ -235,7 +235,7 @@ public class DDComboBox extends JComboBox implements
 
         if (!elem.isList())
         {
-            logger.warn("DataElement " + elem.getName() + " is not a list");
+            logger.warn("DataElement {} is not a list", elem.getName());
             return;
         }
 
@@ -246,7 +246,7 @@ public class DDComboBox extends JComboBox implements
 
         if (values == null || values.isEmpty())
         {
-            logger.warn("DataElement " + elem.getName() + " has no list values");
+            logger.warn("DataElement {} has no list values", elem.getName());
             return;
         }
 

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlArea.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDHtmlArea.java
@@ -169,7 +169,7 @@ public class DDHtmlArea extends JEditorPane implements DDTextVisibleComponent
         }
         catch (NullPointerException npe)
         {
-            logger.warn("Caught NPE trying to add rule: " + sb.toString());
+            logger.warn("Caught NPE trying to add rule: {}", sb.toString());
             logger.warn(Utils.formatExceptionText(npe));
         }
     }

--- a/code/gui/src/main/java/com/donohoedigital/gui/DDPanel.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/DDPanel.java
@@ -111,7 +111,7 @@ public class DDPanel extends JPanel implements DDComponent
     @Override
     public void repaint(long tm, int x, int y, int width, int height)
     {
-        if (debug) logger.debug("REPAINT: " + this);
+        if (debug) logger.debug("REPAINT: {}", this);
         Component foo = GuiUtils.getSolidRepaintComponent(this);
         if (foo != null && foo != this)
         {
@@ -140,10 +140,10 @@ public class DDPanel extends JPanel implements DDComponent
             Component foo = GuiUtils.getSolidRepaintComponent(this);
             if (foo != null && foo != this)
             {
-                logger.debug("painting " + this + "\nbut solid repaint is: " + foo);
+                logger.debug("painting {}\nbut solid repaint is: {}", this, foo);
             }
             g.getClipBounds(bounds_);
-            logger.debug("REPAINT COMPONENT "+(CNT++)+" ("+ImageComponent.getDebugColorName()+") portion " + bounds_.x +","+bounds_.y+" " +bounds_.width+"x"+bounds_.height);
+            logger.debug("REPAINT COMPONENT {} ({}) portion {},{} {}x{}", (CNT++), ImageComponent.getDebugColorName(), bounds_.x, bounds_.y, bounds_.width, bounds_.height);
             g.setColor(ImageComponent.getDebugColor());
             g.drawRect(bounds_.x, bounds_.y, bounds_.width - 1, bounds_.height - 1);
         }

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/JspEmail.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/JspEmail.java
@@ -105,7 +105,7 @@ public class JspEmail
                     File logDir = new File(new DefaultRuntimeDirectory().getServerHome(), "log");
                     File scratch = new File(logDir, "jsp-" + ConfigManager.getAppName());
                     ConfigUtils.verifyNewDirectory(scratch);
-                    logger.info("JSP Email scratch in " + scratch.getAbsolutePath());
+                    logger.info("JSP Email scratch in {}", scratch.getAbsolutePath());
                     ServletConfig config = new EmbeddedServletConfig("email", scratch.getAbsolutePath());
                     config.getServletContext().setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
                     jsp_.init(config);

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/JspFile.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/JspFile.java
@@ -102,7 +102,7 @@ public class JspFile
                     File logDir = new File(new DefaultRuntimeDirectory().getServerHome(), "log");
                     File scratch = new File(logDir, "jsp-" + ConfigManager.getAppName());
                     ConfigUtils.verifyNewDirectory(scratch);
-                    logger.info("JSP File scratch in " + scratch.getAbsolutePath());
+                    logger.info("JSP File scratch in {}", scratch.getAbsolutePath());
                     ServletConfig config = new EmbeddedServletConfig("jsp", scratch.getAbsolutePath());
                     config.getServletContext().setAttribute(InstanceManager.class.getName(), new SimpleInstanceManager());
                     jsp_.init(config);

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/StringHttpServletRequest.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/StringHttpServletRequest.java
@@ -70,7 +70,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     {
         if (str.equals("org.apache.catalina.jsp_file")) return null; // okay - we know about this
         if (str.equals("jakarta.servlet.include.servlet_path")) return null; // Jasper hook
-        logger.warn("getAttribute called " + str);
+        logger.warn("getAttribute called {}", str);
 		return null;
     }
     
@@ -118,13 +118,13 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public long getDateHeader(String str)
     {
-        logger.warn("getDateHeader called " + str);
+        logger.warn("getDateHeader called {}", str);
 		return 0;
     }
     
     public String getHeader(String str)
     {
-        logger.warn("getHeader called " + str);
+        logger.warn("getHeader called {}", str);
 		return null;
     }
     
@@ -147,7 +147,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public int getIntHeader(String str)
     {
-        logger.warn("getIntHeader called " + str);
+        logger.warn("getIntHeader called {}", str);
 		return 0;
     }
     
@@ -170,7 +170,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public String getParameter(String str)
     {
-        logger.warn("geParameter called " + str);
+        logger.warn("geParameter called {}", str);
 		return null;
     }
     
@@ -189,7 +189,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public String[] getParameterValues(String str)
     {
-        logger.warn("getParameterValues called " + str);
+        logger.warn("getParameterValues called {}", str);
 		return null;
     }
     
@@ -225,7 +225,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public String getRealPath(String str)
     {
-        logger.warn("getRealPath called " + str);
+        logger.warn("getRealPath called {}", str);
 		return null;
     }
     
@@ -249,7 +249,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public jakarta.servlet.RequestDispatcher getRequestDispatcher(String str)
     {
-        logger.warn("getRequestDispatcher called " + str);
+        logger.warn("getRequestDispatcher called {}", str);
 		return null;
     }
     
@@ -306,7 +306,7 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public HttpSession getSession(boolean param)
     {
-        logger.warn("getSession called " + param);
+        logger.warn("getSession called {}", param);
 		return null;
     }
     
@@ -348,23 +348,23 @@ public class StringHttpServletRequest implements HttpServletRequest
     
     public boolean isUserInRole(String str)
     {
-        logger.warn("isUserInRole called " + str);
+        logger.warn("isUserInRole called {}", str);
 		return false;
     }
     
     public void removeAttribute(String str)
     {
-		logger.warn("removeAttribute called " + str);
+		logger.warn("removeAttribute called {}", str);
     }
     
     public void setAttribute(String str, Object obj)
     {
-		logger.warn("setAttribute called " + str);
+		logger.warn("setAttribute called {}", str);
     }
     
     public void setCharacterEncoding(String str) throws UnsupportedEncodingException
     {
-		logger.warn("setCharacterEncoding called " + str);
+		logger.warn("setCharacterEncoding called {}", str);
     }
     
     public String getLocalAddr() 

--- a/code/jsp/src/main/java/com/donohoedigital/jsp/StringHttpServletResponse.java
+++ b/code/jsp/src/main/java/com/donohoedigital/jsp/StringHttpServletResponse.java
@@ -137,12 +137,12 @@ public class StringHttpServletResponse implements HttpServletResponse
     
     public void setBufferSize(int param)
     {
-        logger.warn("setBufferSize called " + param);
+        logger.warn("setBufferSize called {}", param);
     }
     
     public void setContentLength(int param)
     {
-        logger.warn("setContentLength called " + param);
+        logger.warn("setContentLength called {}", param);
     }
     
     public void setContentType(String str)
@@ -162,87 +162,87 @@ public class StringHttpServletResponse implements HttpServletResponse
     
     public void addDateHeader(String str, long param)
     {
-        logger.warn("addDateHeader called " + str + "=" + param);
+        logger.warn("addDateHeader called {}={}", str, param);
     }
     
     public void addHeader(String str, String str1)
     {
-        logger.warn("addHeader called " + str + "=" + str1);
+        logger.warn("addHeader called {}={}", str, str1);
     }
     
     public void addIntHeader(String str, int param)
     {
-        logger.warn("addIntHeader called " + str + "=" + param);
+        logger.warn("addIntHeader called {}={}", str, param);
     }
     
     public boolean containsHeader(String str)
     {
-        logger.warn("containsHeader called " + str);
+        logger.warn("containsHeader called {}", str);
         return false;
     }
     
     public String encodeRedirectURL(String str)
     {
-        logger.warn("encodeRedirectURL called " + str);
+        logger.warn("encodeRedirectURL called {}", str);
         return str;
     }
     
     public String encodeRedirectUrl(String str)
     {
-        logger.warn("encodeRedirectUrl called " + str);
+        logger.warn("encodeRedirectUrl called {}", str);
         return str;
     }
     
     public String encodeURL(String str)
     {
-        logger.warn("encodeURL called " + str);
+        logger.warn("encodeURL called {}", str);
         return str;
     }
     
     public String encodeUrl(String str)
     {
-        logger.warn("encodeUrl called " + str);
+        logger.warn("encodeUrl called {}", str);
         return str;
     }
     
     public void sendError(int param) throws IOException
     {
-        logger.warn("sendError called " + param);
+        logger.warn("sendError called {}", param);
     }
     
     public void sendError(int param, String str) throws IOException
     {
-        logger.warn("setError called " + param + " " + str);
+        logger.warn("setError called {} {}", param, str);
     }
     
     public void sendRedirect(String str) throws IOException
     {
-        logger.warn("sendRedirect called " + str);
+        logger.warn("sendRedirect called {}", str);
     }
     
     public void setDateHeader(String str, long param)
     {
-        logger.warn("setDateHeader called " + str);
+        logger.warn("setDateHeader called {}", str);
     }
     
     public void setHeader(String str, String str1)
     {
-        logger.warn("setHeader called " + str+"="+str1);
+        logger.warn("setHeader called {}={}", str, str1);
     }
     
     public void setIntHeader(String str, int param)
     {
-        logger.warn("setIntHeader called " + str+"="+param);
+        logger.warn("setIntHeader called {}={}", str, param);
     }
     
     public void setStatus(int param)
     {
-        logger.warn("setStatus called " + param);
+        logger.warn("setStatus called {}", param);
     }
     
     public void setStatus(int param, String str)
     {
-        logger.warn("setStatus called " + param+"="+str);
+        logger.warn("setStatus called {}={}", param, str);
     }
     
     public String getContentType() 
@@ -253,7 +253,7 @@ public class StringHttpServletResponse implements HttpServletResponse
     
     public void setCharacterEncoding(String str) 
     {
-        logger.warn("setCharacterEncoding called "+str);
+        logger.warn("setCharacterEncoding called {}", str);
     }
 
     // Servlet API 3.1 additions

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/DeckDialog.java
@@ -162,8 +162,7 @@ public class DeckDialog extends DialogPhase implements PropertyChangeListener
                 bResult = Boolean.TRUE;
                 
             } catch (Exception e) {
-                logger.error("Unable to copy " + selected_.getAbsolutePath() + " to " +
-                                    dir.getAbsolutePath());
+                logger.error("Unable to copy {} to {}", selected_.getAbsolutePath(), dir.getAbsolutePath());
                 logger.error(Utils.formatExceptionText(e));
                 EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.deck.copyfailed",selected_.getName(),
                                                     dir.getAbsolutePath()));

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -711,7 +711,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
         }
         catch (BackingStoreException bse)
         {
-            logger.warn("Unable to clear prefs for node: " + EnginePrefs.NODE_DIALOG_PHASE);
+            logger.warn("Unable to clear prefs for node: {}", EnginePrefs.NODE_DIALOG_PHASE);
         }
         EngineUtils.displayInformationDialog(context_, PropertyConfig.getMessage("msg.resetdialog"));
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandFutures.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandFutures.java
@@ -237,27 +237,22 @@ public class HandFutures
         if (DEBUG)
         {
             logger.debug("");
-            logger.debug("HAND: " + hole + "," + community);
-            logger.debug("Start: " + fName.form(HandInfo.getHandTypeDesc(ourtype)) + " " + ourscore);
-            logger.debug("TOTAL hands: " + nTotal_);
+            logger.debug("HAND: {},{}", hole, community);
+            logger.debug("Start: {} {}", fName.form(HandInfo.getHandTypeDesc(ourtype)), ourscore);
+            logger.debug("TOTAL hands: {}", nTotal_);
             int sum = 0;
             for (int i = HandInfo.HIGH_CARD; i <= HandInfo.ROYAL_FLUSH; i++)
             {
-                logger.debug("   " + fName.form(HandInfo.getHandTypeDesc(i)) + ": "+ 
-                                     HandStat.fCnt.form(nTotals_[i]) + " (" +
-                                     HandStat.fPerc.form(100.0d * ((float)nTotals_[i]) / nTotal_) + "%)" + " -- "+
-                                     HandStat.fCnt.form(nTotals2_[i]) + " (" +
-                                     HandStat.fPerc.form(getOddsImproveTo(i)) + "%)"
-                                     );
+                logger.debug("   {}: {} ({}%)" + " -- {} ({}%)", fName.form(HandInfo.getHandTypeDesc(i)), HandStat.fCnt.form(nTotals_[i]), HandStat.fPerc.form(100.0d * ((float) nTotals_[i]) / nTotal_), HandStat.fCnt.form(nTotals2_[i]), HandStat.fPerc.form(getOddsImproveTo(i)));
                 sum += nTotals_[i];
             }
-            logger.debug("SUM: " + sum);
-            logger.debug("Improve:       " + nImprovements_ + " (" + HandStat.fPerc.form(100.0f * ((float)nImprovements_) / nTotal_) + "%)");
-            logger.debug("Type Improve:  " + nTypeImprovements_ + " (" + HandStat.fPerc.form(100.0f * ((float)nTypeImprovements_) / nTotal_) + "%)");
-            logger.debug("Type Improve2: " + nTypeImprovements2_ + " (" + HandStat.fPerc.form(100.0f * ((float)nTypeImprovements2_) / nTotal_) + "%)");
-            logger.debug("Has Straight Draw: " + hasStraightDraw());
-            logger.debug("Has GutShot Draw:  " + hasGutShotStraightDraw());
-            logger.debug("Has Flush Draw:    " + hasFlushDraw() +"\n");
+            logger.debug("SUM: {}", sum);
+            logger.debug("Improve:       {} ({}%)", nImprovements_, HandStat.fPerc.form(100.0f * ((float) nImprovements_) / nTotal_));
+            logger.debug("Type Improve:  {} ({}%)", nTypeImprovements_, HandStat.fPerc.form(100.0f * ((float) nTypeImprovements_) / nTotal_));
+            logger.debug("Type Improve2: {} ({}%)", nTypeImprovements2_, HandStat.fPerc.form(100.0f * ((float) nTypeImprovements2_) / nTotal_));
+            logger.debug("Has Straight Draw: {}", hasStraightDraw());
+            logger.debug("Has GutShot Draw:  {}", hasGutShotStraightDraw());
+            logger.debug("Has Flush Draw:    {}\n", hasFlushDraw());
         }
     }
     

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandStrength.java
@@ -121,11 +121,7 @@ public class HandStrength
 
         if (DEBUG && TESTING(EngineConstants.TESTING_AI_DEBUG))
         {
-            logger.debug("STRENGTH for " + hole +"," + community+ ": " +
-                nAhead + " wins   " +
-                nTied +  " ties   " +
-                nBehind +" lose   " +
-                HandStat.fPerc.form(nStrength));
+            logger.debug("STRENGTH for {},{}: {} wins   {} ties   {} lose   {}", hole, community, nAhead, nTied, nBehind, HandStat.fPerc.form(nStrength));
         }
         return nStrength;
     }
@@ -139,7 +135,7 @@ public class HandStrength
         float nStrength = getStrength(hole, community);
         if (DEBUG && TESTING(EngineConstants.TESTING_AI_DEBUG))
         {
-            logger.debug(" raised to " + nOpponents + ": " + HandStat.fPerc.form(Math.pow(nStrength, nOpponents)));
+            logger.debug(" raised to {}: {}", nOpponents, HandStat.fPerc.form(Math.pow(nStrength, nOpponents)));
         }
         return getStrength(nStrength, nOpponents);
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HoldemSimulator.java
@@ -334,7 +334,7 @@ public class HoldemSimulator
 
         if (deckSize != deck.size())
         {
-            logger.warn("Deck size mismatch in simulator!  Before, size was " + deckSize + ", after size was " + deck.size());
+            logger.warn("Deck size mismatch in simulator!  Before, size was {}, after size was {}", deckSize, deck.size());
         }
 
         return new StatResult(hole, list, win, lose, tie);
@@ -635,7 +635,7 @@ public class HoldemSimulator
         // safety check
         if (deckSize != deck.size())
         {
-            logger.warn("Deck size mismatch in simulator!  Before, size was " + deckSize + ", after size was " + deck.size());
+            logger.warn("Deck size mismatch in simulator!  Before, size was {}, after size was {}", deckSize, deck.size());
         }
 
         // calc total at end

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfile.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfile.java
@@ -84,37 +84,37 @@ public class PlayerProfile extends BaseProfile
     public void debugPrint()
     {
         logger.debug("");
-        logger.debug("************ PROFILE for " + getName());
-        logger.debug("Wins: " + nWins_);
+        logger.debug("************ PROFILE for {}", getName());
+        logger.debug("Wins: {}", nWins_);
 
         // number of times each round is seen
         for (int i = 0; i < rounds_.length; i++)
         {
-            logger.debug("Round " + HoldemHand.getRoundName(i) + ": " + rounds_[i]);
+            logger.debug("Round {}: {}", HoldemHand.getRoundName(i), rounds_[i]);
             // flops seen - which position
             if (i == HoldemHand.ROUND_FLOP)
             {
                 for (int j = 0; j < flops_.length; j++)
                 {
-                    logger.debug("   Flops called from " + PokerPlayer.getPositionName(j) + ": " + flops_[j]);
+                    logger.debug("   Flops called from {}: {}", PokerPlayer.getPositionName(j), flops_[j]);
                 }
             }
         }
 
         // actions
-        logger.debug("Total Actions: " + nActionCnt_);
+        logger.debug("Total Actions: {}", nActionCnt_);
         for (int i = 0; i < actions_.length; i++)
         {
-            logger.debug("   Action " + HandAction.getActionName(i) + ": " + actions_[i]);
+            logger.debug("   Action {}: {}", HandAction.getActionName(i), actions_[i]);
         }
 
         // actions per round
         for (int i = 0; i < roundactions_.length; i++)
         {
-            logger.debug("Total Actions it round " + HoldemHand.getRoundName(i) + ": " + nRoundActionCnt_[i]);
+            logger.debug("Total Actions it round {}: {}", HoldemHand.getRoundName(i), nRoundActionCnt_[i]);
             for (int j = 0; j < roundactions_[0].length; j++)
             {
-                logger.debug("   Round " + HoldemHand.getRoundName(i) + ", Action " + HandAction.getActionName(j) + ": " + roundactions_[i][j]);
+                logger.debug("   Round {}, Action {}: {}", HoldemHand.getRoundName(i), HandAction.getActionName(j), roundactions_[i][j]);
             }
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileOptions.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PlayerProfileOptions.java
@@ -308,8 +308,8 @@ public class PlayerProfileOptions extends BasePhase implements ChangeListener
 
                     if (sCmdlineOverride != null && p.getName().equalsIgnoreCase(sCmdlineOverride))
                     {
-                        logger.debug("Using profile "+sCmdlineOverride+" instead of default "+(
-                                     default_ == null ? "[null]" : default_.getName()));
+                        logger.debug("Using profile {} instead of default {}", sCmdlineOverride, (
+                            default_ == null ? "[null]" : default_.getName()));
                         choose = p;
                         break;
                     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerContext.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerContext.java
@@ -218,7 +218,7 @@ public class PokerContext extends GameContext
             t = game.getTable(i);
             if (t.isAllComputer()) continue;
 
-            logger.debug("**** Holdem hand on " + t.getName() + ((current == t) ? " (current)" : "") + " when error occurred: ");
+            logger.debug("**** Holdem hand on {}{} when error occurred: ", t.getName(), ((current == t) ? " (current)" : ""));
             hhand = t.getHoldemHand();
             if (hhand != null)
             {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerDatabase.java
@@ -680,9 +680,7 @@ public class PokerDatabase
                     String intent = action.getDebug();
                     if ((intent != null) && intent.length() > INTENT_LENGTH)
                     {
-                        logger.warn(
-                                "Value of action.getDebug() is longer than " + INTENT_LENGTH + " characters.  Truncating.\n" +
-                                intent);
+                        logger.warn("Value of action.getDebug() is longer than {} characters.  Truncating.\n{}", INTENT_LENGTH, intent);
                         intent = intent.substring(0, INTENT_LENGTH);
                     }
                     pstmt.setString(9, intent);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -1356,8 +1356,7 @@ public class PokerGame extends Game implements PlayerActionListener
                         if (peek.isHuman() && table.getNumOccupiedSeats() > 0 && !table.isAllComputer())
                         {
                             idx = DiceRoller.rollDieInt(players.size()) - 1;
-                            logger.debug("TESTING: skip placing " + peek.getName() + " on table " + table.getName() +
-                                         " new index to check: " + idx);
+                            logger.debug("TESTING: skip placing {} on table {} new index to check: {}", peek.getName(), table.getName(), idx);
                         }
                         else bDone = true;
                     }
@@ -1549,7 +1548,7 @@ public class PokerGame extends Game implements PlayerActionListener
 
         if (nChips != (nBought + nExtraChips_))
         {
-            logger.error("Chip count off.  Bought=" + nBought + "   chips=" + nChips + "   nExtra=" + nExtraChips_);
+            logger.error("Chip count off.  Bought={}   chips={}   nExtra={}", nBought, nChips, nExtraChips_);
         }
     }
 
@@ -2183,7 +2182,7 @@ public class PokerGame extends Game implements PlayerActionListener
                 removeTable(table);
                 if (TournamentDirector.DEBUG_CLEANUP_TABLE)
                 {
-                    logger.debug("Removed on load: " + table.getName());
+                    logger.debug("Removed on load: {}", table.getName());
                 }
             }
         }
@@ -2224,7 +2223,7 @@ public class PokerGame extends Game implements PlayerActionListener
                 String sSavedIP = getLocalIP();
                 if (!sSavedIP.equals(sIP) && !sIP.equals("127.0.0.1"))
                 {
-                    logger.info("Updating local ip from: " + sSavedIP + " to: " + sIP);
+                    logger.info("Updating local ip from: {} to: {}", sSavedIP, sIP);
                     setLocalIP(sIP);
                     // TODO: notify user and check about public ip
                 }
@@ -2287,7 +2286,7 @@ public class PokerGame extends Game implements PlayerActionListener
                     // info message
                     if (player.isHuman())
                     {
-                        logger.info("Key in save file updated to current key for: " + player.getName());
+                        logger.info("Key in save file updated to current key for: {}", player.getName());
                     }
                 }
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPlayer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerPlayer.java
@@ -295,14 +295,14 @@ public class PokerPlayer extends GamePlayer
         {
             if (ai.getPlayerType() != playerType_)
             {
-                if (DebugConfig.isTestingOn()) logger.debug("Updating player type on existing AI. (" + playerType_.getName() + ") for player " + getName());
+                if (DebugConfig.isTestingOn()) logger.debug("Updating player type on existing AI. ({}) for player {}", playerType_.getName(), getName());
                 ai.setPlayerType(playerType_);
             }
         }
         // instantiate a new AI
         else
         {
-            if (DebugConfig.isTestingOn()) logger.debug("Creating new AI. (" + playerType_.getName() + ") for player " + getName());
+            if (DebugConfig.isTestingOn()) logger.debug("Creating new AI. ({}) for player {}", playerType_.getName(), getName());
             setPokerAI(PokerAI.createPokerAI(playerType_));
         }
     }
@@ -333,12 +333,12 @@ public class PokerPlayer extends GamePlayer
             if (isLocallyControlled() && isHuman() && !isObserver())
             {
                 playerType_ = PlayerType.getAdvisor();
-                if (DebugConfig.isTestingOn()) logger.debug("Lazily creating advisor: " + playerType_.getName() + " for " + getName());
+                if (DebugConfig.isTestingOn()) logger.debug("Lazily creating advisor: {} for {}", playerType_.getName(), getName());
                 setPokerAI(PokerAI.createPokerAI(playerType_));
             }
             else
             {
-                if (DebugConfig.isTestingOn()) logger.debug("Lazily instantiating dummy ai for player " + getName());
+                if (DebugConfig.isTestingOn()) logger.debug("Lazily instantiating dummy ai for player {}", getName());
                 ai = new PokerAI();
                 ai.init();
                 setPokerAI(ai);
@@ -379,7 +379,7 @@ public class PokerPlayer extends GamePlayer
 
             if (ai == null && DebugConfig.isTestingOn())
             {
-                logger.debug("AI cleared for " + getName());
+                logger.debug("AI cleared for {}", getName());
             }
 
             super.setGameAI(ai);
@@ -1730,8 +1730,7 @@ public class PokerPlayer extends GamePlayer
         }
         catch (Throwable e)
         {
-            logger.error("AI exception caught. Return 'fold' to keep the game going:\n"+
-                         Utils.formatExceptionText(e));
+            logger.error("AI exception caught. Return 'fold' to keep the game going:\n{}", Utils.formatExceptionText(e));
             return new HandAction(this, getHoldemHand().getRound(), HandAction.ACTION_FOLD, "aierror");
         }
     }
@@ -2014,7 +2013,7 @@ public class PokerPlayer extends GamePlayer
                     String sNew = nfile.getAbsolutePath();
                     if (!sNew.equals(sProfileLocation_))
                     {
-                        logger.warn("Player profile missing: " + sProfileLocation_  +"; change to: " + sNew);
+                        logger.warn("Player profile missing: {}; change to: {}", sProfileLocation_, sNew);
                         sProfileLocation_ = sNew;
                         file = nfile;
                     }
@@ -2024,11 +2023,11 @@ public class PokerPlayer extends GamePlayer
             // if no file, it was deleted.  Use empty one.
             if (!file.exists())
             {
-                logger.warn("Player profile missing: " + sProfileLocation_);
+                logger.warn("Player profile missing: {}", sProfileLocation_);
             }
             else
             {
-                if (DebugConfig.isTestingOn()) logger.debug("Loading file: "+file.getAbsolutePath());
+                if (DebugConfig.isTestingOn()) logger.debug("Loading file: {}", file.getAbsolutePath());
                 profile_ = new PlayerProfile(file, true);
                 setName(profile_.getName()); // update name
             }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
@@ -129,7 +129,7 @@ public class PokerUDPServer extends UDPServer implements PokerConnectionServer, 
         {
             PokerGame game = (PokerGame) main_.getDefaultContext().getGame();
             PokerPlayer p = game.getPokerPlayerFromConnection(connection);
-            logger.warn("No link found for " + p.getName() + " ("+connection+"), skipping message");
+            logger.warn("No link found for {} ({}), skipping message", p.getName(), connection);
             return 0;
         }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUtils.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUtils.java
@@ -867,7 +867,7 @@ public class PokerUtils extends EngineUtils
         if (oResult != null && oResult instanceof File)
         {
             File file = (File) oResult;
-            logger.info("Exporting screenshot to " + file.getAbsolutePath());
+            logger.info("Exporting screenshot to {}", file.getAbsolutePath());
             GuiUtils.printImageToFile(image, file);
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ShowTournamentTable.java
@@ -857,7 +857,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
             {
                 case SWING_REPAINT_SEAT:
                     if (TESTING(EngineConstants.TESTING_DEBUG_REPAINT))
-                        logger.debug("SwingIt calling repaintTerritory for " + p.getName());
+                        logger.debug("SwingIt calling repaintTerritory for {}", p.getName());
                     board_.repaintTerritory(PokerUtils.getTerritoryForTableSeat(p.getTable(), p.getSeat()));
                     break;
 
@@ -905,7 +905,7 @@ public class ShowTournamentTable extends ShowPokerTable implements
         PokerTable table = event.getTable();
         HoldemHand hhand = table.getHoldemHand();
 
-        if (TournamentDirector.DEBUG_EVENT_DISPLAY) logger.debug("Event received: " + event.toString());
+        if (TournamentDirector.DEBUG_EVENT_DISPLAY) logger.debug("Event received: {}", event.toString());
         switch (event.getType())
         {
             // new players added, repaint all

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/ai/RuleEngine.java
@@ -3294,7 +3294,7 @@ public class RuleEngine implements AIConstants
 
     private void logResults(V2Player player)
     {
-        logger.debug("RuleEngine results for " + player.getPokerPlayer().getName());
+        logger.debug("RuleEngine results for {}", player.getPokerPlayer().getName());
 
         for (int outcome = 0; outcome < outcomeNames_.size(); ++outcome)
         {
@@ -3323,11 +3323,11 @@ public class RuleEngine implements AIConstants
                 }
                 if ((sum * 100.0) > 0.0f)
                 {
-                    logger.debug("    " + getFactorLabel(factor) + " +" + (int) (sum * 100.0));
+                    logger.debug("    {} +{}", getFactorLabel(factor), (int) (sum * 100.0));
                 }
                 else if ((sum * 100.0) < 0.0f)
                 {
-                    logger.debug("    " + getFactorLabel(factor) + " " + (int) (sum * 100.0));
+                    logger.debug("    {} {}", getFactorLabel(factor), (int) (sum * 100.0));
                 }
             }
 
@@ -3335,11 +3335,11 @@ public class RuleEngine implements AIConstants
 
             if (score >= 0)
             {
-                logger.debug("==> +" + score);
+                logger.debug("==> +{}", score);
             }
             else
             {
-                logger.debug("==> " + score);
+                logger.debug("==> {}", score);
             }
         }
     }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DashboardManager.java
@@ -104,7 +104,7 @@ public class DashboardManager
             try {
                 item.demarshal(null, pref);
             } catch (Throwable e) {
-                logger.error("Error demarshalling " + pref + ": " + Utils.formatExceptionText(e));
+                logger.error("Error demarshalling {}: {}", pref, Utils.formatExceptionText(e));
             }
         }
 
@@ -199,7 +199,7 @@ public class DashboardManager
             } catch (Throwable e) {
                 prefs_.clear();
                 
-                logger.error("Error demarshalling " + sPrefs + ": " + Utils.formatExceptionText(e));
+                logger.error("Error demarshalling {}: {}", sPrefs, Utils.formatExceptionText(e));
             }
 
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DebugDash.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/dashboard/DebugDash.java
@@ -76,7 +76,7 @@ public class DebugDash extends DashboardItem implements ActionListener
 
     public void actionPerformed(ActionEvent e)
     {
-        logger.debug("Thread dump:\n" + Utils.getAllStacktraces());
+        logger.debug("Thread dump:\n{}", Utils.getAllStacktraces());
         EngineUtils.displayInformationDialog(context_, "Threaddump was written to log file.", "threaddump");
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatListPanel.java
@@ -441,7 +441,7 @@ class ChatListPanel extends ListPanel implements MouseListener, MouseMotionListe
                 if (oResult != null && oResult instanceof File)
                 {
                     File file = (File) oResult;
-                    logger.info("Exporting chat to " + file.getAbsolutePath());
+                    logger.info("Exporting chat to {}", file.getAbsolutePath());
                     ConfigUtils.writeFile((File) oResult, toHtml(), false);
                 }
         });

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ChatPanel.java
@@ -306,7 +306,7 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
                 dump.setText("Dump");
                 buttonbase.add(dump);
                 dump.addActionListener(e ->
-                    logger.debug("Thread dump:\n" + Utils.getAllStacktraces()));
+                    logger.debug("Thread dump:\n{}", Utils.getAllStacktraces()));
             }
         }
         else
@@ -617,7 +617,7 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
             PokerPlayer player = game_.getPokerPlayerFromID(nFrom);
             if (player == null)
             {
-                logger.warn("No player for chat, id=" + nFrom + " msg=" + sMsg);
+                logger.warn("No player for chat, id={} msg={}", nFrom, sMsg);
                 return;
             }
 
@@ -791,14 +791,14 @@ public class ChatPanel extends DDPanel implements PropertyChangeListener, ChatHa
     {
 
         test_ = new TestThread();
-        logger.debug("<<<<<<<<<<<<<<<<<<<< Started Test " + test_.nTestNum);
+        logger.debug("<<<<<<<<<<<<<<<<<<<< Started Test {}", test_.nTestNum);
         test_.start();
     }
 
     private void stopTest()
     {
         test_.finish();
-        logger.debug(">>>>>>>>>>>>>>>>>>>> Stopped Test " + test_.nTestNum);
+        logger.debug(">>>>>>>>>>>>>>>>>>>> Stopped Test {}", test_.nTestNum);
         test_ = null;
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStart.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStart.java
@@ -106,7 +106,7 @@ public class HostStart extends ChainPhase implements ActionListener
         // log
         String sURL = game_.getPublicConnectURL();
         if (sURL == null) sURL = game_.getLanConnectURL();
-        logger.info("Registration closed, online game starting with " + nNumHumans + " humans and " + nNumAI + " ai: " + sURL);
+        logger.info("Registration closed, online game starting with {} humans and {} ai: {}", nNumHumans, nNumAI, sURL);
 
         // if num players doesn't match profile, need to update profile
         // and, potentially, payout structure

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/HostStatus.java
@@ -308,7 +308,7 @@ public class HostStatus extends DDPanel implements HostConnectionListener, Runna
             default:
                 sLog = "unknown status ("+ nStatus+ ')';
         }
-        if (bLog && sLog != null) logger.error("Reconnected failed: " + sLog);
+        if (bLog && sLog != null) logger.error("Reconnected failed: {}", sLog);
 
         // show to user if details checkbox selected and not aborting
         if (!details_.isSelected() || bAbort_) return;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/ListGames.java
@@ -427,7 +427,7 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
             context_.setGame(game);
 
             // log it
-            logger.info("Joining game " + sConnect + "...");
+            logger.info("Joining game {}...", sConnect);
 
             // have online manager do join, which returns true
             // if successful (in which case it places the game into
@@ -523,7 +523,7 @@ public abstract class ListGames extends BasePhase implements PropertyChangeListe
         }
         catch (Throwable e)
         {
-            logger.info("Unable to get password for profile: " + profile_.getName());
+            logger.info("Unable to get password for profile: {}", profile_.getName());
             resetProfile();
             return false;
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/Lobby.java
@@ -735,7 +735,7 @@ public class Lobby extends BasePhase implements ChangeListener, PropertyChangeLi
                 }
                 catch (Throwable t)
                 {
-                    logger.error("LobbyAlive caught an unexcepted exception: " + Utils.formatExceptionText(t));
+                    logger.error("LobbyAlive caught an unexcepted exception: {}", Utils.formatExceptionText(t));
                 }
             }
         }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineLobby.java
@@ -253,13 +253,12 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
     {
         if (omsg.getCategory() == OnlineMessage.CAT_CHAT)
         {
-            if (TESTING(EngineConstants.TESTING_UDP_APP)) logger.debug("CHAT "+omsg.getPlayerName() +" said " + omsg.getChat());
+            if (TESTING(EngineConstants.TESTING_UDP_APP)) logger.debug("CHAT {} said {}", omsg.getPlayerName(), omsg.getChat());
             chat_.chatReceived(omsg);
         }
         else if (omsg.getCategory() == OnlineMessage.CAT_CHAT_ADMIN)
         {
-            if (TESTING(EngineConstants.TESTING_UDP_APP)) logger.debug("CHAT admin " + PokerConstants.toStringAdminType(omsg.getChatType()) +
-                                                         (omsg.getChat() != null ? " - "+omsg.getChat() : ""));
+            if (TESTING(EngineConstants.TESTING_UDP_APP)) logger.debug("CHAT admin {}{}", PokerConstants.toStringAdminType(omsg.getChatType()), (omsg.getChat() != null ? " - " + omsg.getChat() : ""));
             switch (omsg.getChatType())
             {
                 case PokerConstants.CHAT_ADMIN_WELCOME:
@@ -288,7 +287,7 @@ public class OnlineLobby extends BasePhase implements ChatHandler, DDTable.Table
         }
         else
         {
-            logger.warn("CHAT don't know how to handle this: "+ omsg.toStringCategory());
+            logger.warn("CHAT don't know how to handle this: {}", omsg.toStringCategory());
         }
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineServer.java
@@ -110,7 +110,7 @@ public class OnlineServer
         // since failing to remove the game should not affect the user interaction
         OnlineMessage reqOnlineMsg = new OnlineMessage(OnlineMessage.CAT_WAN_GAME_REMOVE);
         OnlineGame onlineGame = createOnlineGame(game.getGameContext());
-        logger.debug("Sending game: " + onlineGame);
+        logger.debug("Sending game: {}", onlineGame);
         reqOnlineMsg.setWanGame(onlineGame.getData());
         EngineMessage reqEngineMsg = new EngineMessage();
         reqOnlineMsg.getData().copyTo(reqEngineMsg);
@@ -207,9 +207,9 @@ public class OnlineServer
         int category = bDone ? OnlineMessage.CAT_WAN_GAME_END : OnlineMessage.CAT_WAN_GAME_STOP;
         OnlineGame onlineGame = getServerGame(game.getGameContext(), category);
         OnlineMessage reqOnlineMsg = new OnlineMessage(category);
-        logger.debug("Sending game: " + onlineGame);
+        logger.debug("Sending game: {}", onlineGame);
         reqOnlineMsg.setWanGame(onlineGame.getData());
-        logger.debug("Sending histories: " + histories);
+        logger.debug("Sending histories: {}", histories);
         if (histories != null) reqOnlineMsg.setWanHistories(histories);
         EngineMessage reqEngineMsg = new EngineMessage();
         reqOnlineMsg.getData().copyTo(reqEngineMsg);
@@ -290,7 +290,7 @@ public class OnlineServer
 
         if (resMsg.getStatus() == DDMessageListener.STATUS_APPL_ERROR)
         {
-            logger.error("WAN Game server error: " + resMsg.getApplicationErrorMessage());
+            logger.error("WAN Game server error: {}", resMsg.getApplicationErrorMessage());
         }
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/TestPublicConnect.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/TestPublicConnect.java
@@ -174,7 +174,7 @@ public class TestPublicConnect extends SendMessageDialog implements OnlineMessag
         }
         else
         {
-            logger.warn("Received test message with different GUID: " + omsg);
+            logger.warn("Received test message with different GUID: {}", omsg);
         }
     }
 

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/util/TournamentHistoryList.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/model/util/TournamentHistoryList.java
@@ -134,10 +134,7 @@ public class TournamentHistoryList extends DMArrayList<TournamentHistory>
             hist.setEnded(bEnded);
             if (bDebug)
             {
-                logger.debug("  ==> "+ hist.getPlayerName() + (hist.isComputer() ? " (ai)" : "") +
-                         " finished " + hist.getPlace() + " and won " + hist.getPrize() +
-                         " num ai: "+ nAI + "  rank: " + hist.getRank1() +
-                         " ended: "+ hist.isEnded());
+                logger.debug("  ==> {}{} finished {} and won {} num ai: {}  rank: {} ended: {}", hist.getPlayerName(), (hist.isComputer() ? " (ai)" : ""), hist.getPlace(), hist.getPrize(), nAI, hist.getRank1(), hist.isEnded());
             }
         }
     }

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
@@ -120,7 +120,7 @@ public class OnlineProfilePurger extends BaseCommandLineApp
 
         ApplicationError.assertTrue(processed == list.getTotalSize(), "Processed " + processed + " of " + list.getTotalSize() + " rows");
 
-        logger.debug("Deleting " + deleteList.size() + " total profiles");
+        logger.debug("Deleting {} total profiles", deleteList.size());
         service.deleteOnlineProfiles(deleteList);
     }
 
@@ -148,22 +148,22 @@ public class OnlineProfilePurger extends BaseCommandLineApp
             {
                 if (p.getModifyDate().getTime() < days_14.getTime())
                 {
-                    logger.debug("oooo Deleting " + p.getName() + " since this person has other profiles and this one not used in 14 days");
+                    logger.debug("oooo Deleting {} since this person has other profiles and this one not used in 14 days", p.getName());
                     delete = true;
                 }
                 else
                 {
-                    logger.debug(".... Keeping " + p.getName() + " because created in past 14 days (even though there are other profiles)");
+                    logger.debug(".... Keeping {} because created in past 14 days (even though there are other profiles)", p.getName());
                 }
             }
             else if (p.getModifyDate().getTime() < days_90.getTime())
             {
-                logger.debug("++++ Deleting " + p.getName() + " because not used in 90 days");
+                logger.debug("++++ Deleting {} because not used in 90 days", p.getName());
                 delete = true;
             }
             else
             {
-                logger.debug(".... Keeping " + p.getName() + " because created in past 90 days");
+                logger.debug(".... Keeping {} because created in past 90 days", p.getName());
             }
 
             if (delete) deleteList.add(p);

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/PokerServlet.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/PokerServlet.java
@@ -447,8 +447,7 @@ public class PokerServlet extends EngineServlet
 
         if (sErrorKey != null || sErrorMsg != null)
         {
-            logger.info("P2P connect test failed from " + ddreceived.getKey() + " [" +
-                        request.getRemoteAddr() + "] to " + url + ": " + sErrorKey);
+            logger.info("P2P connect test failed from {} [{}] to {}: {}", ddreceived.getKey(), request.getRemoteAddr(), url, sErrorKey);
             ret.setCategory(EngineMessage.CAT_APPL_ERROR);
             if (sErrorMsg != null)
                 ret.setApplicationErrorMessage(sErrorMsg);
@@ -457,8 +456,7 @@ public class PokerServlet extends EngineServlet
         }
         else
         {
-            logger.info("P2P connect test succeeded from " + ddreceived.getKey() + " [" +
-                        request.getRemoteAddr() + "] to " + url);
+            logger.info("P2P connect test succeeded from {} [{}] to {}", ddreceived.getKey(), request.getRemoteAddr(), url);
         }
 
         return ret;
@@ -579,7 +577,7 @@ public class PokerServlet extends EngineServlet
         // FIX: make this end-game stuff more robust.  Should send down everything from the client so we can deal with this
         if (game == null)
         {
-            logger.error("Unable to save ended game because it didn't exist in database: " + game + ";   histories:  " + histories);
+            logger.error("Unable to save ended game because it didn't exist in database: {};   histories:  {}", game, histories);
         }
 
         // Send an empty response.
@@ -1011,14 +1009,14 @@ public class PokerServlet extends EngineServlet
     {
         if (TESTING(TESTING_SKIP_EMAIL))
         {
-            logger.info("Skipping profile email to " + sTo + "; name=" + sName + ", password=" + sPassword);
+            logger.info("Skipping profile email to {}; name={}, password={}", sTo, sName, sPassword);
             return;
         }
         // if flag is on, send all emails to override address
         if (TESTING(TESTING_PROFILE_OVERRIDE_EMAIL))
         {
             String overrideEmail = PropertyConfig.getStringProperty(TESTING_PROFILE_OVERRIDE_EMAIL_TO, null, true);
-            logger.info("Sending profile email to " + overrideEmail + " for " + sTo + "; name=" + sName + ", password=" + sPassword);
+            logger.info("Sending profile email to {} for {}; name={}, password={}", overrideEmail, sTo, sName, sPassword);
             sTo = overrideEmail;
         }
         if (sTo == null) return; // null for key verification so skip email

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/impl/OnlineGameServiceImpl.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/impl/OnlineGameServiceImpl.java
@@ -232,8 +232,7 @@ public class OnlineGameServiceImpl implements OnlineGameService
                 {
                     // No associated profile.  Will only happen if the client profile becomes out of
                     // sync with the server profile or someone altered their profile definition.
-                    logger.warn("Missing profile in history: " + history.getPlayerName() +
-                                " for game id=" + game.getId());
+                    logger.warn("Missing profile in history: {} for game id={}", history.getPlayerName(), game.getId());
                     history.setPlayerType(PLAYER_TYPE_LOCAL); // force local
                 }
             }

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/impl/TournamentHistoryServiceImpl.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/service/impl/TournamentHistoryServiceImpl.java
@@ -88,7 +88,7 @@ public class TournamentHistoryServiceImpl implements TournamentHistoryService
         {
             if (hist.getNumPlayers() != num || !hist.getTournamentName().equals(name))
             {
-                if (logger != null) logger.info("  UPDATING history " + hist.getId() + ": "+ name + " ("+num+" players)");
+                if (logger != null) logger.info("  UPDATING history {}: {} ({} players)", hist.getId(), name, num);
                 hist.setNumPlayers(num);
                 hist.setTournamentName(name);
             }

--- a/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
+++ b/code/pokerserver/src/test/java/com/donohoedigital/games/poker/server/TournamentHistoryServiceTest.java
@@ -127,7 +127,7 @@ public class TournamentHistoryServiceTest
         // spit them out - no easy way to verify, so eyeballing :-(
         for (TournamentHistory hist : allForGame)
         {
-            logger.info("RETURN: " + hist);
+            logger.info("RETURN: {}", hist);
             assertEquals(game.getTournament().getName(), hist.getTournamentName());
             assertEquals(list.size(), hist.getNumPlayers());
         }

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
@@ -164,11 +164,11 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
 
         if (bDebug)
         {
-            logger.debug("MTU: " + link.getMTU());
-            logger.debug("MAX PAYLOAD: " + link.getMaxPayloadSize() + " (header: " + UDPLink.IP_UDP_HEADERS + ")");
-            logger.debug("MAX MESSAGE: " + link.getMaxMessageSize() + " (header: " + UDPMessage.HEADER_SIZE + ")");
-            logger.debug("MAX DATA: " + link.getMaxDataSize() + " (header: " + UDPData.HEADER_SIZE + ")");
-            logger.debug("MAX TOTAL: " + (link.getMaxDataSize() * UDPData.MAX_PARTS));
+            logger.debug("MTU: {}", link.getMTU());
+            logger.debug("MAX PAYLOAD: {} (header: {})", link.getMaxPayloadSize(), UDPLink.IP_UDP_HEADERS);
+            logger.debug("MAX MESSAGE: {} (header: {})", link.getMaxMessageSize(), UDPMessage.HEADER_SIZE);
+            logger.debug("MAX DATA: {} (header: {})", link.getMaxDataSize(), UDPData.HEADER_SIZE);
+            logger.debug("MAX TOTAL: {}", (link.getMaxDataSize() * UDPData.MAX_PARTS));
         }
 
         link.connect();
@@ -192,8 +192,8 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
 
             if (bDebug)
             {
-                logger.debug("Max long: " + Long.MAX_VALUE + " Max int: " + Integer.MAX_VALUE);
-                logger.debug("DATA_SIZE: " + (link.getMaxDataSize()) + " max size: " + (link.getMaxDataSize()) * UDPData.MAX_PARTS);
+                logger.debug("Max long: {} Max int: {}", Long.MAX_VALUE, Integer.MAX_VALUE);
+                logger.debug("DATA_SIZE: {} max size: {}", (link.getMaxDataSize()), (link.getMaxDataSize()) * UDPData.MAX_PARTS);
             }
 
             StringBuilder sb = new StringBuilder();
@@ -219,7 +219,7 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
                         sb.append("~");
                     }
                     //logger.debug("Message: "+ sb);
-                    if (i % 100 == 0) logger.debug("UnicastTest queueing message: " + (i + 1));
+                    if (i % 100 == 0) logger.debug("UnicastTest queueing message: {}", (i + 1));
                     link.queue(Utils.encode(sb.toString()));
                     if (i % nStep == 0 && nSleep > 0) Utils.sleepMillis(nSleep);
                 }
@@ -253,14 +253,14 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
      */
     private void logStats(UDPLink link)
     {
-        logger.debug("Stats: " + link.getStats());
+        logger.debug("Stats: {}", link.getStats());
         MovingAverage in = udp_.manager().getBytesInMovingAverage();
         MovingAverage out = udp_.manager().getBytesOutMovingAverage();
 
-        logger.debug("Bytes In: " + Utils.formatSizeBytes(in.getAverageLong()) + "/sec" +
-                     " (" + Utils.formatSizeBytes(in.getHigh()) + " high - " + Utils.formatSizeBytes(in.getPeak()) + " peak)" +
-                     ",  Bytes Out: " + Utils.formatSizeBytes(out.getAverageLong()) + "/sec" +
-                     " (" + Utils.formatSizeBytes(out.getHigh()) + " high - " + Utils.formatSizeBytes(out.getPeak()) + " peak)");
+        logger.debug("Bytes In: {}/sec" +
+            " ({} high - {} peak)" +
+            ",  Bytes Out: {}/sec" +
+            " ({} high - {} peak)", Utils.formatSizeBytes(in.getAverageLong()), Utils.formatSizeBytes(in.getHigh()), Utils.formatSizeBytes(in.getPeak()), Utils.formatSizeBytes(out.getAverageLong()), Utils.formatSizeBytes(out.getHigh()), Utils.formatSizeBytes(out.getPeak()));
     }
 
     /**
@@ -302,12 +302,12 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
         switch (event.getType())
         {
             case CREATED:
-                if (bDebug) logger.debug("Created: " + Utils.getAddressPort(link.getRemoteIP()));
+                if (bDebug) logger.debug("Created: {}", Utils.getAddressPort(link.getRemoteIP()));
                 link.addMonitor(this);
                 break;
 
             case DESTROYED:
-                if (bDebug) logger.debug("Destroyed: " + Utils.getAddressPort(link.getRemoteIP()));
+                if (bDebug) logger.debug("Destroyed: {}", Utils.getAddressPort(link.getRemoteIP()));
                 link.removeMonitor(this);
                 if (bSend)
                 {
@@ -343,31 +343,28 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
                 break;
 
             case ESTABLISHED:
-                if (bDebug) logger.debug("EVENT Established: " + Utils.getAddressPort(link.getRemoteIP()));
+                if (bDebug) logger.debug("EVENT Established: {}", Utils.getAddressPort(link.getRemoteIP()));
                 break;
 
             case CLOSING:
-                if (bDebug) logger.debug("EVENT Closing: " + Utils.getAddressPort(link.getRemoteIP()));
+                if (bDebug) logger.debug("EVENT Closing: {}", Utils.getAddressPort(link.getRemoteIP()));
                 break;
 
             case CLOSED:
-                if (bDebug) logger.debug("EVENT Closed: " + Utils.getAddressPort(link.getRemoteIP()));
+                if (bDebug) logger.debug("EVENT Closed: {}", Utils.getAddressPort(link.getRemoteIP()));
                 logStats(link);
                 break;
 
             case POSSIBLE_TIMEOUT:
-                if (bDebug) logger.debug("EVENT Possible timeout on " + Utils.getAddressPort(link.getRemoteIP()) +
-                                         " (no message in last " + elapsed + " millis)");
+                if (bDebug) logger.debug("EVENT Possible timeout on {} (no message in last {} millis)", Utils.getAddressPort(link.getRemoteIP()), elapsed);
                 break;
 
             case TIMEOUT:
-                if (bDebug) logger.debug("EVENT Timeout on " + Utils.getAddressPort(link.getRemoteIP()) +
-                                         " (no message in last " + elapsed + " millis)");
+                if (bDebug) logger.debug("EVENT Timeout on {} (no message in last {} millis)", Utils.getAddressPort(link.getRemoteIP()), elapsed);
                 break;
 
             case RESEND_FAILURE:
-                if (bDebug) logger.debug("EVENT Resend Failure on " + Utils.getAddressPort(link.getRemoteIP()) +
-                                         " (unable to send message " + data + ")");
+                if (bDebug) logger.debug("EVENT Resend Failure on {} (unable to send message {})", Utils.getAddressPort(link.getRemoteIP()), data);
                 break;
 
             case RECEIVED:
@@ -382,7 +379,7 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
 
                     }
 
-                    logger.debug("EVENT msg from " + Utils.getAddressPort(link.getRemoteIP()) + ": " + data.toString() + sMsg);
+                    logger.debug("EVENT msg from {}: {}{}", Utils.getAddressPort(link.getRemoteIP()), data.toString(), sMsg);
                 }
                 break;
         }

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanClientList.java
@@ -110,7 +110,7 @@ public class LanClientList
                 break;
                 
             default:
-                logger.warn("Received message with incorrect category: " + msg);
+                logger.warn("Received message with incorrect category: {}", msg);
                 return;
         }
     }

--- a/code/server/src/main/java/com/donohoedigital/p2p/LanManager.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/LanManager.java
@@ -110,11 +110,11 @@ public class LanManager implements DDMessageListener
             if (st.hasMoreTokens())
             {
                 sLocalHost_ = st.nextToken();
-                logger.warn("Unable to determine local host name, guessing it is: " + sLocalHost_);
+                logger.warn("Unable to determine local host name, guessing it is: {}", sLocalHost_);
             }
             else
             {
-                logger.warn("Unable to determine local host name: " + uhe.getMessage());
+                logger.warn("Unable to determine local host name: {}", uhe.getMessage());
                 sLocalHost_ = "[unknown]";
             }
 
@@ -141,7 +141,7 @@ public class LanManager implements DDMessageListener
                     }
                 }
 
-                logger.warn("Local ip set to: " + sLocalIP_);
+                logger.warn("Local ip set to: {}", sLocalIP_);
             }
             catch (Throwable ignored)
             {
@@ -170,17 +170,17 @@ public class LanManager implements DDMessageListener
             if (ae.getException() != null && ae.getException().getMessage() != null &&
                 ae.getException().getMessage().contains("error setting options"))
             {
-                logger.debug("Unable to start Peer2PeerMulticast (error setting options), local ip: " + sLocalIP_);
+                logger.debug("Unable to start Peer2PeerMulticast (error setting options), local ip: {}", sLocalIP_);
             }
             else
             {
-                logger.error("Unable to start Peer2PeerMulticast: " + Utils.formatExceptionText(ae));
+                logger.error("Unable to start Peer2PeerMulticast: {}", Utils.formatExceptionText(ae));
             }
             return;
         }
         catch (Throwable t)
         {
-            logger.error("Unable to start Peer2PeerMulticast: " + Utils.formatExceptionText(t));
+            logger.error("Unable to start Peer2PeerMulticast: {}", Utils.formatExceptionText(t));
             return;
         }
 
@@ -224,7 +224,7 @@ public class LanManager implements DDMessageListener
      */
     public void sendMessage(int nCategory)
     {
-        if (DEBUG) logger.debug("Sending message: " + LanClientList.toString(nCategory));
+        if (DEBUG) logger.debug("Sending message: {}", LanClientList.toString(nCategory));
 
         LanClientInfo info = new LanClientInfo(nCategory);
         info.setHostName(sLocalHost_);
@@ -240,11 +240,11 @@ public class LanManager implements DDMessageListener
         }
         catch (ApplicationError e)
         {
-            logger.error("Send error: " + e.toString());
+            logger.error("Send error: {}", e.toString());
         }
         catch (Throwable t)
         {
-            logger.error("Send error: " + Utils.formatExceptionText(t));
+            logger.error("Send error: {}", Utils.formatExceptionText(t));
         }
     }
 
@@ -258,7 +258,7 @@ public class LanManager implements DDMessageListener
         // validate key
         if (!controller_.isValid(info.getData()))
         {
-            logger.error("Invalid key: " + info);
+            logger.error("Invalid key: {}", info);
             return;
         }
 
@@ -266,7 +266,7 @@ public class LanManager implements DDMessageListener
         String guid = info.getGuid();
         if (guid == null)
         {
-            logger.error("Missing GUID: " + info);
+            logger.error("Missing GUID: {}", info);
             return;
         }
 
@@ -376,7 +376,7 @@ public class LanManager implements DDMessageListener
             {
                 nAliveCnt_ = ALIVE_REFRESH_CNT;
             }
-            if (DEBUG) logger.debug("Alive cnt reset to: " + nAliveCnt_);
+            if (DEBUG) logger.debug("Alive cnt reset to: {}", nAliveCnt_);
         }
 
         public void setContinous(boolean b)

--- a/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMessage.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMessage.java
@@ -352,7 +352,7 @@ public class Peer2PeerMessage implements DDMessageTransporter
             // if we read data, check out first read for invalid information
             if (count != 0)
             {
-                if (DEBUG) logger.debug("Read " + count);
+                if (DEBUG) logger.debug("Read {}", count);
                 //logger.debug("Read " + count + ": <" + Utils.decode(buffer_.array(), 0, buffer_.position())+">");
                              
                 // see if we are full
@@ -373,7 +373,7 @@ public class Peer2PeerMessage implements DDMessageTransporter
                 }
                 
                 nSleep += READ_WAIT_MILLIS;
-                if (DEBUG) logger.debug("Sleeping... position is " + buffer.position() + " capacity is " + buffer.capacity());
+                if (DEBUG) logger.debug("Sleeping... position is {} capacity is {}", buffer.position(), buffer.capacity());
                 Utils.sleepMillis(READ_WAIT_MILLIS);
             }
         }

--- a/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMulticast.java
+++ b/code/server/src/main/java/com/donohoedigital/p2p/Peer2PeerMulticast.java
@@ -79,7 +79,7 @@ public class Peer2PeerMulticast implements Runnable
         sIP_ = PropertyConfig.getRequiredStringProperty("settings.multicast.address");
 
 
-        logger.info("Multicast using " + sIP_ + ":"+nPort_);
+        logger.info("Multicast using {}:{}", sIP_, nPort_);
         try {   
             // multicast address we listen to
             ia_ = InetAddress.getByName(sIP_);
@@ -205,21 +205,18 @@ public class Peer2PeerMulticast implements Runnable
                 if (!bDone_)
                 {
                     String data = new String(dp.getData(), 0, dp.getLength());
-                    logger.error("receive() socket error: [" + Utils.getPrintableString(data, 1000) + "]; "
-                             + Utils.formatExceptionText(se));
+                    logger.error("receive() socket error: [{}]; {}", Utils.getPrintableString(data, 1000), Utils.formatExceptionText(se));
                 }
             }
             catch (IOException ioe)
             {
                 String data = new String(dp.getData(), 0, dp.getLength());
-                logger.error("receive() ioerror: [" + Utils.getPrintableString(data, 1000) + "]; "
-                             + Utils.formatExceptionText(ioe));
+                logger.error("receive() ioerror: [{}]; {}", Utils.getPrintableString(data, 1000), Utils.formatExceptionText(ioe));
             }        
             catch (Throwable t)
             {
                 String data = new String(dp.getData(), 0, dp.getLength());
-                logger.error("receive() error: [" + Utils.getPrintableString(data, 1000) + "]; "
-                             + Utils.formatExceptionText(t));
+                logger.error("receive() error: [{}]; {}", Utils.getPrintableString(data, 1000), Utils.formatExceptionText(t));
             }
         }
         

--- a/code/server/src/main/java/com/donohoedigital/server/BaseServlet.java
+++ b/code/server/src/main/java/com/donohoedigital/server/BaseServlet.java
@@ -168,7 +168,7 @@ public abstract class BaseServlet extends HttpServlet
         catch (ApplicationError ae)
         {
             String s = Utils.formatExceptionText(ae);
-            logger.error("Error processing message: " + received.toString(), ae);
+            logger.error("Error processing message: {}", received.toString(), ae);
             Throwable orig = ae.getException();
             
             ret = createNewMessage();
@@ -188,7 +188,7 @@ public abstract class BaseServlet extends HttpServlet
         catch (Throwable t)
         {
             String s = Utils.formatExceptionText(t);
-            logger.error("Error processing message: " + received.toString(), t);
+            logger.error("Error processing message: {}", received.toString(), t);
             
             ret = createNewMessage();
             ret.setCategory(DDMessage.CAT_ERROR);

--- a/code/server/src/main/java/com/donohoedigital/server/GameServer.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServer.java
@@ -239,7 +239,7 @@ public abstract class GameServer extends Thread
         }
 
         // log version
-        logger.info("Java version: " + System.getProperties().get("java.runtime.version"));
+        logger.info("Java version: {}", System.getProperties().get("java.runtime.version"));
     }
 
     /**
@@ -275,7 +275,7 @@ public abstract class GameServer extends Thread
         String sSocketThreadClass = PropertyConfig.getStringProperty("settings.server.thread.class", SocketThread.class.getName(), false);
 
         // display info
-        logger.info("Listening on port(s) " + sPort_ + ";  threads: " + nThreads);
+        logger.info("Listening on port(s) {};  threads: {}", sPort_, nThreads);
 
         // record current time
         nLastLogTime_ = System.currentTimeMillis();
@@ -322,7 +322,7 @@ public abstract class GameServer extends Thread
                     {
                         activeIPs.add(i);
                         configIPs.remove(i.getHostAddress());
-                        logger.info("Using specific address: " + i.getHostAddress());
+                        logger.info("Using specific address: {}", i.getHostAddress());
                     }
                 }
             }
@@ -345,7 +345,7 @@ public abstract class GameServer extends Thread
                 nPort = Integer.parseInt(port);
 
                 // set the port the server channel will listen to
-                logger.info("Processing port " + nPort + "...");
+                logger.info("Processing port {}...", nPort);
 
                 for (InetAddress i : activeIPs)
                 {
@@ -353,7 +353,7 @@ public abstract class GameServer extends Thread
                     channel = ServerSocketChannel.open();
                     socket = channel.socket();
 
-                    logger.info("Binding: " + i.getHostAddress() + ":" + nPort);
+                    logger.info("Binding: {}:{}", i.getHostAddress(), nPort);
 
                     try
                     {
@@ -361,7 +361,7 @@ public abstract class GameServer extends Thread
                     }
                     catch (SocketException be)
                     {
-                        logger.error("Unable to bind: " + Utils.getExceptionMessage(be));
+                        logger.error("Unable to bind: {}", Utils.getExceptionMessage(be));
                         continue;
                     }
 
@@ -383,7 +383,7 @@ public abstract class GameServer extends Thread
             }
             catch (NumberFormatException nfe)
             {
-                logger.error("Unable to parse: " + port);
+                logger.error("Unable to parse: {}", port);
             }
         }
 
@@ -397,7 +397,7 @@ public abstract class GameServer extends Thread
         // store first port as preferred
         if (!channels_.isEmpty())
         {
-            logger.info("Preferred TCP (online server) address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
+            logger.info("Preferred TCP (online server) address set to {}", Utils.getLocalAddressPort(getDefaultChannel()));
         }
 
         // create pool
@@ -421,7 +421,7 @@ public abstract class GameServer extends Thread
             catch (IOException e2)
             {
                 if (!bBindFailover_) throw e2;
-                logger.info("Failed binding to " + ia.getHostAddress() + ":" + nPort + ", trying port " + (nPort + 1));
+                logger.info("Failed binding to {}:{}, trying port {}", ia.getHostAddress(), nPort, (nPort + 1));
                 nPort++;
                 e = e2;
             }
@@ -516,7 +516,7 @@ public abstract class GameServer extends Thread
                 // in particular on Linux
                 if (!bDone_ && !Utils.getExceptionMessage(t).contains("Interrupted system call"))
                 {
-                    logger.error("selector.select() error: " + Utils.formatExceptionText(t));
+                    logger.error("selector.select() error: {}", Utils.formatExceptionText(t));
                 }
                 continue;
             }
@@ -542,7 +542,7 @@ public abstract class GameServer extends Thread
                         }
                         catch (IOException ioe)
                         {
-                            logger.error("registerChannel error: " + Utils.formatExceptionText(ioe));
+                            logger.error("registerChannel error: {}", Utils.formatExceptionText(ioe));
                         }
 
                     }
@@ -550,7 +550,7 @@ public abstract class GameServer extends Thread
             }
             catch (Throwable t)
             {
-                logger.error("processing error: " + Utils.formatExceptionText(t));
+                logger.error("processing error: {}", Utils.formatExceptionText(t));
             }
         }
 
@@ -609,7 +609,7 @@ public abstract class GameServer extends Thread
         {
             try
             {
-                logger.info("GameServer closing " + Utils.getLocalAddressPort(channel));
+                logger.info("GameServer closing {}", Utils.getLocalAddressPort(channel));
                 channel.socket().close();
             }
             catch (Throwable ignore)
@@ -644,7 +644,7 @@ public abstract class GameServer extends Thread
                 // Is a new connection coming in?
                 if (key.isAcceptable())
                 {
-                    if (DEBUG_ONLINE) logger.debug("[" + nNum_ + "] ACCEPTING NEW CONNECTION");
+                    if (DEBUG_ONLINE) logger.debug("[{}] ACCEPTING NEW CONNECTION", nNum_);
 
                     ServerSocketChannel server = (ServerSocketChannel) key.channel();
                     SocketChannel channel = server.accept();
@@ -655,13 +655,13 @@ public abstract class GameServer extends Thread
                     channel.socket().setSendBufferSize(64 * 1024);
                     channel.socket().setReceiveBufferSize(64 * 1024);
 
-                    if (DEBUG_ONLINE) logger.debug("[" + nNum_ + "] ACCEPTED " + Utils.getIPAddress(channel));
+                    if (DEBUG_ONLINE) logger.debug("[{}] ACCEPTED {}", nNum_, Utils.getIPAddress(channel));
 
                     // register for read; no need to wake since this in
                     // same thread that select() is called
                     registerChannel(channel, SelectionKey.OP_READ);
 
-                    if (DEBUG_ONLINE) logger.debug("[" + nNum_ + "] REGISTERED " + Utils.getIPAddress(channel));
+                    if (DEBUG_ONLINE) logger.debug("[{}] REGISTERED {}", nNum_, Utils.getIPAddress(channel));
                 }
                 // is there data to read on this channel?
                 else if (key.isReadable())
@@ -675,12 +675,12 @@ public abstract class GameServer extends Thread
                 //}
                 else
                 {
-                    logger.debug("[" + nNum_ + "] NOTHING TO DO: key ready ops are " + key.readyOps());
+                    logger.debug("[{}] NOTHING TO DO: key ready ops are {}", nNum_, key.readyOps());
                 }
             }
             catch (IOException ioe)
             {
-                logger.error("processSelection error: " + Utils.formatExceptionText(ioe));
+                logger.error("processSelection error: {}", Utils.formatExceptionText(ioe));
             }
 
             // remove key from selected set, as it has been handled
@@ -704,9 +704,7 @@ public abstract class GameServer extends Thread
     {
         if (!isLogStatus()) return;
 
-        logger.info("STATUS:  available workers: " + pool_.getNumIdleWorkers() +
-                    ",  hits: " + nHits_ +
-                    ",  misses: " + nRunningNoWorkerCnt_);
+        logger.info("STATUS:  available workers: {},  hits: {},  misses: {}", pool_.getNumIdleWorkers(), nHits_, nRunningNoWorkerCnt_);
         nRunningNoWorkerCnt_ = 0;
         nHits_ = 0;
     }
@@ -794,7 +792,7 @@ public abstract class GameServer extends Thread
         }
         catch (Throwable notUsed)
         {
-            logger.warn("Ignored exception: " + Utils.formatExceptionText(notUsed));
+            logger.warn("Ignored exception: {}", Utils.formatExceptionText(notUsed));
         }
 
         // showdown output so remote client gets socket closed
@@ -850,8 +848,8 @@ public abstract class GameServer extends Thread
             // to allow time for another thread to finish
             if (nElapsedNoWorkerTime_ >= LOG_UNAVAIL)
             {
-                logger.warn("*** NO worker thread available for " + nElapsedNoWorkerTime_ + " millis " +
-                            "(sleep is " + SLEEP_UNAVAIL + "), current ip=" + Utils.getIPAddress(channel));
+                logger.warn("*** NO worker thread available for {} millis " +
+                    "(sleep is {}), current ip={}", nElapsedNoWorkerTime_, SLEEP_UNAVAIL, Utils.getIPAddress(channel));
                 nElapsedNoWorkerTime_ = 0;
             }
 
@@ -870,7 +868,7 @@ public abstract class GameServer extends Thread
         nHits_++;
 
         // we have a worker, so process it
-        if (DEBUG_ONLINE) logger.debug("[" + nNum + "] READING " + Utils.getIPAddress(channel));
+        if (DEBUG_ONLINE) logger.debug("[{}] READING {}", nNum, Utils.getIPAddress(channel));
 
         // need to cancel key otherwise can't change blocking for replies
         key.cancel();

--- a/code/server/src/main/java/com/donohoedigital/server/GameServletRequest.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServletRequest.java
@@ -98,7 +98,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public Object getAttribute(String str)
     {
-        logger.warn("getAttribute called " + str);
+        logger.warn("getAttribute called {}", str);
 		return null;
     }
     
@@ -150,7 +150,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public long getDateHeader(String str)
     {
-        logger.warn("getDateHeader called " + str);
+        logger.warn("getDateHeader called {}", str);
 		return 0;
     }
     
@@ -204,7 +204,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public int getIntHeader(String str)
     {
-        logger.warn("getIntHeader called " + str);
+        logger.warn("getIntHeader called {}", str);
 		return 0;
     }
     
@@ -227,7 +227,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public String getParameter(String str)
     {
-        logger.warn("geParameter called " + str);
+        logger.warn("geParameter called {}", str);
 		return null;
     }
     
@@ -245,7 +245,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public String[] getParameterValues(String str)
     {
-        logger.warn("getParameterValues called " + str);
+        logger.warn("getParameterValues called {}", str);
 		return null;
     }
     
@@ -281,7 +281,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public String getRealPath(String str)
     {
-        logger.warn("getRealPath called " + str);
+        logger.warn("getRealPath called {}", str);
 		return null;
     }
     
@@ -307,7 +307,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public jakarta.servlet.RequestDispatcher getRequestDispatcher(String str)
     {
-        logger.warn("getRequestDispatcher called " + str);
+        logger.warn("getRequestDispatcher called {}", str);
 		return null;
     }
     
@@ -359,7 +359,7 @@ public class GameServletRequest implements HttpServletRequest
     
     public jakarta.servlet.http.HttpSession getSession(boolean param)
     {
-        logger.warn("getSession called " + param);
+        logger.warn("getSession called {}", param);
 		return null;
     }
     
@@ -401,23 +401,23 @@ public class GameServletRequest implements HttpServletRequest
     
     public boolean isUserInRole(String str)
     {
-        logger.warn("isUserInRole called " + str);
+        logger.warn("isUserInRole called {}", str);
 		return false;
     }
     
     public void removeAttribute(String str)
     {
-		logger.warn("removeAttribute called " + str);
+		logger.warn("removeAttribute called {}", str);
     }
     
     public void setAttribute(String str, Object obj)
     {
-		logger.warn("setAttribute called " + str);
+		logger.warn("setAttribute called {}", str);
     }
     
     public void setCharacterEncoding(String str) throws java.io.UnsupportedEncodingException
     {
-		logger.warn("setCharacterEncoding called " + str);
+		logger.warn("setCharacterEncoding called {}", str);
     }
     
     public String getLocalAddr() 

--- a/code/server/src/main/java/com/donohoedigital/server/GameServletResponse.java
+++ b/code/server/src/main/java/com/donohoedigital/server/GameServletResponse.java
@@ -151,12 +151,12 @@ public class GameServletResponse implements HttpServletResponse
     
     public void setBufferSize(int param)
     {
-        logger.warn("setBufferSize called " + param);
+        logger.warn("setBufferSize called {}", param);
     }
     
     public void setContentLength(int param)
     {
-        logger.warn("setContentLength called " + param);
+        logger.warn("setContentLength called {}", param);
     }
     
     public void setContentType(String str)
@@ -176,46 +176,46 @@ public class GameServletResponse implements HttpServletResponse
     
     public void addDateHeader(String str, long param)
     {
-        logger.warn("addDateHeader called " + str + '=' + param);
+        logger.warn("addDateHeader called {}={}", str, param);
     }
     
     public void addHeader(String str, String str1)
     {
-        logger.warn("addHeader called " + str + '=' + str1);
+        logger.warn("addHeader called {}={}", str, str1);
     }
     
     public void addIntHeader(String str, int param)
     {
-        logger.warn("addIntHeader called " + str + '=' + param);
+        logger.warn("addIntHeader called {}={}", str, param);
     }
     
     public boolean containsHeader(String str)
     {
-        logger.warn("containsHeader called " + str);
+        logger.warn("containsHeader called {}", str);
         return false;
     }
     
     public String encodeRedirectURL(String str)
     {
-        logger.warn("encodeRedirectURL called " + str);
+        logger.warn("encodeRedirectURL called {}", str);
         return str;
     }
     
     public String encodeRedirectUrl(String str)
     {
-        logger.warn("encodeRedirectUrl called " + str);
+        logger.warn("encodeRedirectUrl called {}", str);
         return str;
     }
     
     public String encodeURL(String str)
     {
-        logger.warn("encodeURL called " + str);
+        logger.warn("encodeURL called {}", str);
         return str;
     }
     
     public String encodeUrl(String str)
     {
-        logger.warn("encodeUrl called " + str);
+        logger.warn("encodeUrl called {}", str);
         return str;
     }
     
@@ -266,32 +266,32 @@ public class GameServletResponse implements HttpServletResponse
     
     public void sendRedirect(String str) throws IOException
     {
-        logger.warn("sendRedirect called " + str);
+        logger.warn("sendRedirect called {}", str);
     }
     
     public void setDateHeader(String str, long param)
     {
-        logger.warn("setDateHeader called " + str);
+        logger.warn("setDateHeader called {}", str);
     }
     
     public void setHeader(String str, String str1)
     {
-        logger.warn("setHeader called " + str+ '=' +str1);
+        logger.warn("setHeader called {}={}", str, str1);
     }
     
     public void setIntHeader(String str, int param)
     {
-        logger.warn("setIntHeader called " + str+ '=' +param);
+        logger.warn("setIntHeader called {}={}", str, param);
     }
     
     public void setStatus(int param)
     {
-        logger.warn("setStatus called " + param);
+        logger.warn("setStatus called {}", param);
     }
     
     public void setStatus(int param, String str)
     {
-        logger.warn("setStatus called " + param+ '=' +str);
+        logger.warn("setStatus called {}={}", param, str);
     }
     
     public String getContentType() 
@@ -302,7 +302,7 @@ public class GameServletResponse implements HttpServletResponse
     
     public void setCharacterEncoding(String str) 
     {
-        logger.warn("setCharacterEncoding called "+str);
+        logger.warn("setCharacterEncoding called {}", str);
     }
 
     // Servlet API 3.1 additions

--- a/code/server/src/main/java/com/donohoedigital/server/ServerSecurityProvider.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ServerSecurityProvider.java
@@ -65,8 +65,7 @@ public class ServerSecurityProvider extends com.donohoedigital.base.SecurityProv
         }
         catch (UnknownHostException e)
         {
-            LogManager.getLogger(ServerSecurityProvider.class).warn("ServerSecurityProvider unable to determine ip address: " +
-                                                                e.getMessage());
+            LogManager.getLogger(ServerSecurityProvider.class).warn("ServerSecurityProvider unable to determine ip address: {}", e.getMessage());
             id = Utils.encode("0.0.0.0");
         }
         ID = id;

--- a/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/ThreadPool.java
@@ -88,7 +88,7 @@ public class ThreadPool
     {
         if (bInfo)
         {
-            logger.info("Growing thread pool by " + nWorkers + " to " + (nWorkers + workers_.size()) + " workers.");
+            logger.info("Growing thread pool by {} to {} workers.", nWorkers, (nWorkers + workers_.size()));
         }
         SocketThread thread;
         for (int i = 0; i < nWorkers; i++)

--- a/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
+++ b/code/server/src/main/java/com/donohoedigital/server/WorkerPool.java
@@ -86,7 +86,7 @@ public class WorkerPool
     {
         if (bInfo)
         {
-            logger.info("Growing worker pool by " + nWorkers + " to " + (nWorkers + workers_.size()) + " workers.");
+            logger.info("Growing worker pool by {} to {} workers.", nWorkers, (nWorkers + workers_.size()));
         }
         WorkerThread thread;
         for (int i = 0; i < nWorkers; i++)

--- a/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
@@ -133,11 +133,11 @@ public class DDMailer extends BaseCommandLineApp
         // get key
         sKey_ = htOptions_.getString("key");
         sFrom_ = htOptions_.getString("from");
-        logger.info("Message key: " + sKey_);
-        logger.info("From: " + sFrom_);
+        logger.info("Message key: {}", sKey_);
+        logger.info("From: {}", sFrom_);
 
         // debug?
-        if (DEBUG && TESTTO != null) logger.debug("DEBUG:  all mail goes to " + TESTTO);
+        if (DEBUG && TESTTO != null) logger.debug("DEBUG:  all mail goes to {}", TESTTO);
 
         // load params file
         String sFile = htOptions_.getString("file");
@@ -204,13 +204,13 @@ public class DDMailer extends BaseCommandLineApp
 
             if (bProcess)
             {
-                logger.debug("SENDING to " + sEmail);
+                logger.debug("SENDING to {}", sEmail);
                 sendEmail(sEmail, PropertyConfig.getMessage("email." + sKey_ + ".sub", o),
                           PropertyConfig.getMessage("email." + sKey_, o));
             }
             else
             {
-                logger.debug("SKIPPING " + sEmail);
+                logger.debug("SKIPPING {}", sEmail);
             }
 
             if (DEBUG && (i + 1) == LIMIT) break;

--- a/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/ProxySocketThread.java
@@ -112,9 +112,8 @@ public class ProxySocketThread extends SocketThread implements PostWriter, DDMes
         DDMessenger.ReturnData data = msg.getURL(proxy_, this, null, null, this, options_);
         
         // debug output
-        logger.debug("DATA: " + data.getOut().size() + " bytes ->"+
-                    "\n========= OUTPUT =========\n" + Utils.decodeBasic(data.getOut().getBuffer(), 0, data.getOut().size()) +
-                      "=========  END   =========");
+        logger.debug("DATA: {} bytes ->" +
+            "\n========= OUTPUT =========\n{}=========  END   =========", data.getOut().size(), Utils.decodeBasic(data.getOut().getBuffer(), 0, data.getOut().size()));
         
         // return results to client
         OutputStream out = response_.getOutputStream3();
@@ -138,14 +137,13 @@ public class ProxySocketThread extends SocketThread implements PostWriter, DDMes
         }
         
         // we send the entire buffer
-        logger.debug("Sending DATA to " + proxy_ + " ->\n========= INPUT =========\n" + sData +
-                       "=========  END  =========");
+        logger.debug("Sending DATA to {} ->\n========= INPUT =========\n{}=========  END  =========", proxy_, sData);
         writer.write(sData.getBytes(StandardCharsets.UTF_8));
     }
 
     /** DDMessageListener - output progress **/
     public void updateStep(int nStep) {
-        logger.debug("Step: " + ProxyServlet.getSteps()[nStep]);
+        logger.debug("Step: {}", ProxyServlet.getSteps()[nStep]);
     }
     
     /** DDMessageListener not used **/

--- a/code/udp/src/main/java/com/donohoedigital/udp/AckList.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/AckList.java
@@ -378,7 +378,7 @@ public class AckList
             for (int i = 0; i < acks.length; i++)
             {
                 ack(acks[i]);
-                logger.debug("Added " + acks[i] + ": "+ this);
+                logger.debug("Added {}: {}", acks[i], this);
             }
         }
         else
@@ -392,7 +392,7 @@ public class AckList
                 ack(nNum);
                 //logger.debug("Added " + nNum + ": "+ list);
             }
-            logger.debug("After " + size +": "+ this);
+            logger.debug("After {}: {}", size, this);
             StringBuilder missed = new StringBuilder();
             for (int i = 1; i < (size+1); i++)
             {
@@ -402,7 +402,7 @@ public class AckList
                     missed.append(i);
                 }
             }
-            logger.debug("Missed: " + missed);
+            logger.debug("Missed: {}", missed);
         }
     }
 }

--- a/code/udp/src/main/java/com/donohoedigital/udp/DispatchQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/DispatchQueue.java
@@ -87,7 +87,7 @@ public class DispatchQueue extends Thread
             }
             catch (Throwable t)
             {
-                logger.error("DispatchQueue error: " + Utils.formatExceptionText(t));
+                logger.error("DispatchQueue error: {}", Utils.formatExceptionText(t));
             }
         }
         logger.info("DispatchQueue Done.");

--- a/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/IncomingQueue.java
@@ -225,7 +225,7 @@ public class IncomingQueue
                 // debug
                 if (UDPServer.DEBUG_INCOMING)
                 {
-                    logger.debug("  *** dispatching " + data.toStringShort());
+                    logger.debug("  *** dispatching {}", data.toStringShort());
                 }
 
                 // pass completed message on to handlers

--- a/code/udp/src/main/java/com/donohoedigital/udp/OutgoingQueue.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/OutgoingQueue.java
@@ -114,7 +114,7 @@ public class OutgoingQueue extends Thread
             }
             catch (Throwable t)
             {
-                logger.error("OutgoingQueue error: " + Utils.formatExceptionText(t));                
+                logger.error("OutgoingQueue error: {}", Utils.formatExceptionText(t));                
             }
         }
         logger.info("OutgoingQueue Done.");

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPManager.java
@@ -176,7 +176,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
             monitor.monitorEvent(event);
         } catch (Throwable t)
         {
-            logger.error("Monitor error on event "+event+ ": "+ Utils.formatExceptionText(t));
+            logger.error("Monitor error on event {}: {}", event, Utils.formatExceptionText(t));
         }
     }
 
@@ -212,7 +212,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
             }
             catch (Throwable t)
             {
-                logger.error("UDPManager error: " + Utils.formatExceptionText(t));
+                logger.error("UDPManager error: {}", Utils.formatExceptionText(t));
             }
         }
         logger.info("UDPManager Done.");
@@ -453,14 +453,14 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
                         if (!id.isUnknown())
                         {
                             link.setID(id);
-                            if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("ID updated " + link);
+                            if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("ID updated {}", link);
                         }
                     }
                     // if the id is not unknown, it changed for some reason, so update (shouldn't really occur)
                     else if (!id.isUnknown())
                     {
                         // TODO: what to do if ID changes?  Will this actually occur?
-                        logger.warn("ID changed at addr " + Utils.getAddressPort(remote) + " from " + link.getID() + " to " + id);
+                        logger.warn("ID changed at addr {} from {} to {}", Utils.getAddressPort(remote), link.getID(), id);
                         link.setID(id);
                     }
                     return link;
@@ -480,7 +480,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
 
 
                 // notify of creation
-                if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("New Link " + link);
+                if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("New Link {}", link);
                 fireEvent(new UDPManagerEvent(UDPManagerEvent.Type.CREATED, link));
             }
 
@@ -512,7 +512,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
             }
             else
             {
-                logger.warn("Link remove requested, but not found: "+ cl.link);
+                logger.warn("Link remove requested, but not found: {}", cl.link);
             }
         }
     }
@@ -539,7 +539,7 @@ public class UDPManager extends Thread implements Comparator<UDPLink>
      */
     private void notifyRemoved(UDPLink link)
     {
-        if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("Link removed: "+ link);
+        if (UDPServer.DEBUG_CREATE_DESTROY) logger.debug("Link removed: {}", link);
         fireEvent(new UDPManagerEvent(UDPManagerEvent.Type.DESTROYED, link));
     }
 

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPMessage.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPMessage.java
@@ -399,7 +399,7 @@ public class UDPMessage
         }
         catch (UnknownHostException uhe) // only thrown if addr incorrect size, but log something just in case
         {
-            logger.warn("Error getting address: " + Utils.formatExceptionText(uhe));
+            logger.warn("Error getting address: {}", Utils.formatExceptionText(uhe));
             return new InetSocketAddress("0.0.0.0", nPort);
         }
     }
@@ -450,7 +450,7 @@ public class UDPMessage
         for (UDPData data : data_)
         {
             if (data.getType() == UDPData.Type.MTU_TEST) continue;
-            logger.debug("  OUT "+data.toStringShort() + " " + link.toStringNameIP());
+            logger.debug("  OUT {} {}", data.toStringShort(), link.toStringNameIP());
         }
     }
 

--- a/code/udp/src/main/java/com/donohoedigital/udp/UDPServer.java
+++ b/code/udp/src/main/java/com/donohoedigital/udp/UDPServer.java
@@ -187,7 +187,7 @@ public class UDPServer extends Thread
         nFailoverAttempts_ = PropertyConfig.getIntegerProperty("settings.udp.failover.attempts", 3);
 
         // display info
-        logger.info("Config port(s): " + sPort_);
+        logger.info("Config port(s): {}", sPort_);
 
         // create a new Selector for use below
         selector_ = Selector.open();
@@ -231,7 +231,7 @@ public class UDPServer extends Thread
                     {
                         activeIPs.add(i);
                         configIPs.remove(i.getHostAddress());
-                        logger.info("Using specific address: " + i.getHostAddress());
+                        logger.info("Using specific address: {}", i.getHostAddress());
                     }
                 }
             }
@@ -253,7 +253,7 @@ public class UDPServer extends Thread
                 nPort = Integer.parseInt(port);
 
                 // set the port the server channel will listen to
-                logger.info("Processing port " + nPort + "...");
+                logger.info("Processing port {}...", nPort);
 
                 for (InetAddress i : activeIPs)
                 {
@@ -263,9 +263,7 @@ public class UDPServer extends Thread
                     socket.setReceiveBufferSize(32 * 1024);
                     socket.setSendBufferSize(32 * 1024);
 
-                    logger.info("Binding: " + i.getHostAddress() + ":" + nPort +
-                                " (send=" + socket.getSendBufferSize() +
-                                ", rcv=" + socket.getReceiveBufferSize() + ")");
+                    logger.info("Binding: {}:{} (send={}, rcv={})", i.getHostAddress(), nPort, socket.getSendBufferSize(), socket.getReceiveBufferSize());
 
                     InetSocketAddress ip;
                     try
@@ -274,7 +272,7 @@ public class UDPServer extends Thread
                     }
                     catch (SocketException be)
                     {
-                        logger.error("Unable to bind: " + Utils.getExceptionMessage(be));
+                        logger.error("Unable to bind: {}", Utils.getExceptionMessage(be));
                         continue;
                     }
 
@@ -299,7 +297,7 @@ public class UDPServer extends Thread
             }
             catch (NumberFormatException nfe)
             {
-                logger.error("Unable to parse: " + port);
+                logger.error("Unable to parse: {}", port);
             }
         }
 
@@ -313,7 +311,7 @@ public class UDPServer extends Thread
         // store first port as preferred
         if (!channels_.isEmpty())
         {
-            logger.info("Preferred UDP (chat) address set to " + Utils.getLocalAddressPort(getDefaultChannel()));
+            logger.info("Preferred UDP (chat) address set to {}", Utils.getLocalAddressPort(getDefaultChannel()));
         }
 
         // create dispatch queue
@@ -339,11 +337,11 @@ public class UDPServer extends Thread
             RandomGUID guid = new RandomGUID(ConfigUtils.getLocalHost(true), true);
             pGUID = guid.toString();
             pref.put(sKey, pGUID);
-            logger.info("Created new UDP GUID: " + pGUID + " (port " + nPort + ")");
+            logger.info("Created new UDP GUID: {} (port {})", pGUID, nPort);
         }
         else
         {
-            logger.info("Using existing UDP GUID: " + pGUID + " (port " + nPort + ")");
+            logger.info("Using existing UDP GUID: {} (port {})", pGUID, nPort);
         }
         return new UDPID(pGUID);
     }
@@ -366,7 +364,7 @@ public class UDPServer extends Thread
             catch (SocketException e2)
             {
                 if (!bBindFailover_) throw e2;
-                logger.info("Failed binding to " + ia.getHostAddress() + ":" + nPort + ", trying port " + (nPort - 1));
+                logger.info("Failed binding to {}:{}, trying port {}", ia.getHostAddress(), nPort, (nPort - 1));
                 nPort--;
                 e = e2;
             }
@@ -506,7 +504,7 @@ public class UDPServer extends Thread
                 // in particular on Linux
                 if (!bDone_ && !Utils.getExceptionMessage(t).contains("Interrupted system call"))
                 {
-                    logger.error("selector.select() error: " + Utils.formatExceptionText(t));
+                    logger.error("selector.select() error: {}", Utils.formatExceptionText(t));
                 }
                 continue;
             }
@@ -521,7 +519,7 @@ public class UDPServer extends Thread
             }
             catch (Throwable t)
             {
-                logger.error("UDPServer error: " + Utils.formatExceptionText(t));
+                logger.error("UDPServer error: {}", Utils.formatExceptionText(t));
             }
         }
     }
@@ -589,7 +587,7 @@ public class UDPServer extends Thread
             {
                 if (channel.socket() != null)
                 {
-                    logger.info("UDPServer closing " + Utils.getLocalAddressPort(channel));
+                    logger.info("UDPServer closing {}", Utils.getLocalAddressPort(channel));
                     channel.socket().close();
                 }
             }
@@ -619,7 +617,7 @@ public class UDPServer extends Thread
         {
             if (!bDone_)
             {
-                logger.error("processSelection error: " + Utils.formatExceptionText(cse));
+                logger.error("processSelection error: {}", Utils.formatExceptionText(cse));
             }
             return;
         }
@@ -638,7 +636,7 @@ public class UDPServer extends Thread
             }
             catch (IOException ioe)
             {
-                logger.error("processSelection error: " + Utils.formatExceptionText(ioe));
+                logger.error("processSelection error: {}", Utils.formatExceptionText(ioe));
             }
             finally
             {

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -154,8 +154,41 @@ displayName: Parameterized logging
 description: >
   Rewrite log.debug("x " + y) as log.debug("x {}", y) so the concatenation no longer
   happens when the level is disabled.
+  ParameterizedLogging is not zero-config - it requires a methodPattern, and silently
+  does nothing without one (it logs a validation error but still reports BUILD SUCCESS).
+  This code base logs exclusively through log4j2 (org.apache.logging.log4j.Logger,
+  239 imports), so one entry per level.
+
+  THIS RECIPE CANNOT BE RUN BARE.  It throws IndexOutOfBoundsException from
+  JavaTemplateParser on any call whose concatenation starts with a non-literal, e.g.
+  logger.info(search + " GOODBYE") - the format string begins empty.  120 such calls in
+  43 files, and one crash aborts the whole run.  Present in 3.32.0, the newest published
+  version.  Exclude those files, computing the list rather than hardcoding it:
+
+    cd "$DDHOME"
+    EXCL=$(grep -rlE '\.(trace|debug|info|warn|error|fatal)\(\s*[^"; ][^;]{0,120}\+' \
+             --include=*.java code | paste -sd, -)
+    cd code && mvn rewrite:run \
+      -Drewrite.activeRecipes=com.donohoedigital.ParameterizedLogging \
+      -Drewrite.exclusions="$EXCL"
+
+  Note exclusion paths are relative to the repo root and must keep the "code/" prefix.
+  ALWAYS audit placeholder arity afterwards: a wrong {} count compiles, passes tests and
+  silently produces a malformed log line.  A trailing Throwable is not a placeholder
+  argument - log4j2 renders it as a stack trace - so {}=1 with 2 args is correct there.
 recipeList:
-  - org.openrewrite.java.logging.ParameterizedLogging
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger trace(..)
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger debug(..)
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger info(..)
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger warn(..)
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger error(..)
+  - org.openrewrite.java.logging.ParameterizedLogging:
+      methodPattern: org.apache.logging.log4j.Logger fatal(..)
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
PR 9 of the modernization series.

```diff
-logger.debug("Player " + name + " folded");
+logger.debug("Player {} folded", name);
```

**106 files, +392/−404.** 345 calls converted. The concatenation no longer runs when the level
is disabled.

## Correctness here does not come from the compiler

Every previous PR had the build as a backstop. This one doesn't — a wrong `{}` count
**compiles, passes every test, and silently emits a malformed log line**.

So I audited placeholder arity across **all 421 parameterized log calls in the tree**, not just
the ones this PR touched. **Zero mismatches.**

Three calls look like mismatches and aren't — a trailing `Throwable` is not a placeholder
argument, log4j2 renders it as a stack trace:

```java
logger.fatal("Uncaught exception in thread {}", t.getName(), e);   // {}=1, args=2, correct
```

## Running this recipe takes care — all recorded in rewrite.yml

**It is not zero-config.** Without a `methodPattern` it logs a validation error, changes
nothing, and still reports `BUILD SUCCESS`. An empty PR that looks like a successful one. This
code base logs entirely through log4j2 (`org.apache.logging.log4j.Logger`, 239 imports), so
there's one entry per level.

**It cannot be run bare.** It throws `IndexOutOfBoundsException` from `JavaTemplateParser` on
any call whose concatenation starts with a non-literal:

```java
logger.info(search + " GOODBYE");        // format string begins empty → crash
```

That's **120 calls in 43 files**, and one crash aborts the entire run. Present in 3.32.0, the
newest published version, so there's no upstream fix to take. Those files are excluded, and
`rewrite.yml` carries a command that *computes* the exclusion list rather than hardcoding it,
so it won't go stale:

```shell
EXCL=$(grep -rlE '\.(trace|debug|info|warn|error|fatal)\(\s*[^"; ][^;]{0,120}\+' \
         --include=*.java code | paste -sd, -)
```

Exclusion paths are relative to the repo root and must keep the `code/` prefix.

## Known gap

**The 120 excluded calls remain as concatenation.** Converting them by hand is possible but
it's 120 rewrites in exactly the failure mode nothing catches, so it's deliberately not
attempted here. Worth revisiting if a later `rewrite-logging-frameworks` fixes the crash.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- Arity audited across all 421 parameterized calls in the tree — 0 mismatches
- Throwable-argument convention verified on the 3 apparent outliers