### PR TITLE
Simplify main() signatures

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/base/Base64.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Base64.java
@@ -1341,7 +1341,7 @@ public final class Base64
         
     }   // end inner class OutputStream
     
-    public static void main(String[] s)
+    static void main(String[] s)
     {
         System.out.println(s[0] +" equals " + Base64.encodeBytes(s[0].getBytes(StandardCharsets.UTF_8)));
     }

--- a/code/common/src/main/java/com/donohoedigital/base/Format.java
+++ b/code/common/src/main/java/com/donohoedigital/base/Format.java
@@ -368,7 +368,7 @@ public class Format
    * a test stub for the format class
    */
    
-   public static void main(String[] a)
+   static void main()
    {  double x = 1.23456789012;
       double y = 123;
       double z = 1.2345e30;

--- a/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
+++ b/code/common/src/main/java/com/donohoedigital/base/MersenneTwisterFast.java
@@ -1152,7 +1152,7 @@ public class MersenneTwisterFast implements Serializable, Cloneable
     /**
      * Tests the code.
      */
-    public static void main(String[] args)
+    static void main()
         { 
         int j;
 

--- a/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
+++ b/code/common/src/main/java/com/donohoedigital/base/RandomGUID.java
@@ -225,7 +225,7 @@ public class RandomGUID extends Object
     /*
      * Demonstraton and self test of class
      */
-    public static void main(String[] args)
+    static void main()
     {
         for (int i = 0; i < 100; i++)
         {

--- a/code/common/src/main/java/com/donohoedigital/comms/DataMarshaller.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/DataMarshaller.java
@@ -472,7 +472,7 @@ public class DataMarshaller
     ////
 
     @SuppressWarnings({"UseOfSystemOutOrSystemErr"})
-    public static void main(String[] args)
+    static void main()
     {
         for (Class<?> clazz : coderToType_.keySet())
         {

--- a/code/common/src/main/java/com/donohoedigital/config/TeePrintStream.java
+++ b/code/common/src/main/java/com/donohoedigital/config/TeePrintStream.java
@@ -68,7 +68,7 @@ public class TeePrintStream {
         System.setOut(originalOut);
     }
 
-    public static void main(String[] args) {
+    static void main() {
         TeePrintStream teePrintStream = new TeePrintStream();
 
         // Example usage

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/Ban.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/Ban.java
@@ -104,7 +104,7 @@ public class Ban
     /**
      * Run analyzer
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try
         {

--- a/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
+++ b/code/gameserver/src/main/java/com/donohoedigital/games/server/RegAnalyzer.java
@@ -147,7 +147,7 @@ public class RegAnalyzer
     /**
      * Run analyzer
      */
-    public static void main(String[] args) 
+    static void main(String[] args) 
     {
         try
         {

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/CardImageCreator.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/CardImageCreator.java
@@ -69,7 +69,7 @@ public class CardImageCreator extends BaseCommandLineApp
     /**
      * Run emailer
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             Prefs.setRootNodeName("poker2");
             new CardImageCreator("poker", args);

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/ChatValidate.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/ChatValidate.java
@@ -48,7 +48,7 @@ import java.util.StringTokenizer;
  */
 public class ChatValidate
 {
-    public static void main(String[] argv)
+    static void main(String[] argv)
     {
         if (argv.length == 0)
         {

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/EncryptKey.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/EncryptKey.java
@@ -73,7 +73,7 @@ public class EncryptKey
      *
      * @param args
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         // Use the server security provider.
         SecurityUtils.setSecurityProvider(new ServerSecurityProvider());

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/EncryptString.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/EncryptString.java
@@ -75,7 +75,7 @@ public class EncryptString
      *
      * @param args
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         // Use the server security provider.
         SecurityUtils.setSecurityProvider(new ServerSecurityProvider());

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardBorderManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardBorderManager.java
@@ -76,7 +76,7 @@ public class GameboardBorderManager extends GameManager
     /**
      * Run the Gameboard Manager
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             LoggingConfig loggingConfig = new LoggingConfig("gametools", ApplicationType.CLIENT);
             loggingConfig.init();

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GameboardTerritoryManager.java
@@ -76,7 +76,7 @@ public class GameboardTerritoryManager extends GameManager implements CustomTerr
     /**
      * Run the Gameboard Manager
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             LoggingConfig loggingConfig = new LoggingConfig("gametools", ApplicationType.CLIENT);
             loggingConfig.init();

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/GenerateKey.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/GenerateKey.java
@@ -66,7 +66,7 @@ public class GenerateKey
      *
      * @param args
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         // Use the server security provider.
         SecurityUtils.setSecurityProvider(new ServerSecurityProvider());

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/OnlineTest.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/OnlineTest.java
@@ -164,7 +164,7 @@ public class OnlineTest implements DDMessageListener
                                             );
     }
     
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         if (args.length == 0) usage();
         

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/PokerRankUpdater.java
@@ -63,7 +63,7 @@ public class PokerRankUpdater extends BaseCommandLineApp
     /**
      * Run analyzer
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try {
             new PokerRankUpdater("poker", args);

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/Unhide.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/Unhide.java
@@ -49,7 +49,7 @@ import java.io.Reader;
  */
 public class Unhide
 {
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         if (args.length == 0) System.out.println("Unhide [file]");
         unhide(ConfigUtils.getReader(new File(args[0])));

--- a/code/gametools/src/main/java/com/donohoedigital/games/tools/WhatIsMyIp.java
+++ b/code/gametools/src/main/java/com/donohoedigital/games/tools/WhatIsMyIp.java
@@ -101,7 +101,7 @@ public class WhatIsMyIp implements DDMessageListener
                                  EngineMessage.CAT_PUBLIC_IP);
     }
 
-    public static void main(String[] args)
+    static void main()
     {
 
         new ConfigManager("poker", ApplicationType.COMMAND_LINE, false);

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandFutures.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandFutures.java
@@ -261,7 +261,7 @@ public class HandFutures
     /**
      * Testing
      */
-    public static void main(String[] args)
+    static void main()
     {
         LoggingConfig loggingConfig = new LoggingConfig("plain", ApplicationType.COMMAND_LINE);
         loggingConfig.init();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandInfo.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandInfo.java
@@ -964,7 +964,7 @@ public class HandInfo implements Comparable<HandInfo>
     ////
 
     // TODO: make a unit test!
-    public static void main(String[] args)
+    static void main()
     {
         LoggingConfig loggingConfig = new LoggingConfig("plain", ApplicationType.COMMAND_LINE);
         loggingConfig.init();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/HandPotential.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/HandPotential.java
@@ -831,7 +831,7 @@ public class HandPotential
     /**
      * Testing
      */
-    public static void main(String[] args)
+    static void main()
     {
         LoggingConfig loggingConfig = new LoggingConfig("plain", ApplicationType.COMMAND_LINE);
         loggingConfig.init();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -112,7 +112,7 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
      * Run Poker
      */
     @SuppressWarnings({"UseOfSystemOutOrSystemErr"})
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStats.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStats.java
@@ -294,7 +294,7 @@ public class PokerStats {
     /**
      * Main
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         LoggingConfig loggingConfig = new LoggingConfig("plain", ApplicationType.COMMAND_LINE);
         loggingConfig.init();
         logger = LogManager.getLogger(PokerStats.class);

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PrintVersion.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PrintVersion.java
@@ -36,7 +36,7 @@ package com.donohoedigital.games.poker.engine;
  * Print current version, used in buildall.pl
  */
 public class PrintVersion {
-    public static void main(String[] args) {
+    static void main() {
         System.out.println(PokerConstants.VERSION);
     }
 }

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineGamePurger.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineGamePurger.java
@@ -65,7 +65,7 @@ public class OnlineGamePurger extends BaseCommandLineApp
     /**
      * Run purger.
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try {
             new OnlineGamePurger("poker", args);

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/OnlineProfilePurger.java
@@ -62,7 +62,7 @@ public class OnlineProfilePurger extends BaseCommandLineApp
     /**
      * Run purger.
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try {
             new OnlineProfilePurger("poker", args);

--- a/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/PokerServerMain.java
+++ b/code/pokerserver/src/main/java/com/donohoedigital/games/poker/server/PokerServerMain.java
@@ -37,7 +37,7 @@ import com.donohoedigital.config.LoggingConfig;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class PokerServerMain {
-    public static void main(String[] argv)
+    static void main()
     {
         LoggingConfig loggingConfig = new LoggingConfig("poker", ApplicationType.SERVER);
         loggingConfig.init();

--- a/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/PokerJetty.java
+++ b/code/pokerwicket/src/test/java/com/donohoedigital/games/poker/wicket/PokerJetty.java
@@ -45,7 +45,7 @@ import org.eclipse.jetty.server.Server;
  */
 public class PokerJetty {
 
-    public static void main(String[] args) {
+    static void main() {
 
         // initialize logging first
         LoggingConfig loggingConfig = new LoggingConfig("poker", ApplicationType.WEBAPP);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/AppleAudioBugTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/AppleAudioBugTest.java
@@ -46,7 +46,7 @@ import java.net.URL;
  */
 public class AppleAudioBugTest
 {
-    public static void main(String[] args)
+    static void main()
     {
         new AppleAudioBugTest().testAppleBug();
     }

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/CapabilitiesTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/CapabilitiesTest.java
@@ -243,7 +243,7 @@ public class CapabilitiesTest extends JFrame implements ItemListener {
         }
     }
     
-    public static void main(String[] args) {
+    static void main() {
         GraphicsEnvironment ge =
             GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsDevice[] devices = ge.getScreenDevices();

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/CryptoTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/CryptoTest.java
@@ -56,7 +56,7 @@ public class CryptoTest {
     public CryptoTest() {
     }
 
-    public static void main(String[] args) throws Exception {
+    static void main() throws Exception {
 
         KeyGenerator kgen = KeyGenerator.getInstance("Blowfish");
         SecretKey skey = kgen.generateKey();

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/CursorBug.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/CursorBug.java
@@ -54,7 +54,7 @@ public class CursorBug
     /**
      * cursor bug test
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         if (args.length == 0)
         {
             System.out.println("Usage: java com.donohoedigital.proto.tests.CursorBug <filename.gif|filename.png>");

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/DatabaseExample.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/DatabaseExample.java
@@ -42,7 +42,7 @@ public class DatabaseExample {
     public DatabaseExample() {
     }
 
-    public static void main(String[] args) {
+    static void main() {
         try {
             Class.forName("com.mysql.cj.jdbc.Driver");
             try {

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/DealTester.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/DealTester.java
@@ -64,7 +64,7 @@ public class DealTester extends BaseCommandLineApp
     /**
      * Run emailer
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             Prefs.setRootNodeName("poker2");
             new DealTester("poker", args);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/DefaultButtonBug.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/DefaultButtonBug.java
@@ -55,7 +55,7 @@ public class DefaultButtonBug implements ActionListener
     /**
      * default button bug test
      */
-    public static void main(String[] args) {
+    static void main() {
         try {
             DefaultButtonBug cursorbug = new DefaultButtonBug();
         }

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/HostName.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/HostName.java
@@ -55,7 +55,7 @@ public class HostName
     /**
      * @param args the command line arguments
      */
-    public static void main(String[] args)
+    static void main()
     {
         System.out.println("Hostname: "+ ConfigUtils.getLocalHost(false));
     }

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/ItalicBug.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/ItalicBug.java
@@ -53,7 +53,7 @@ public class ItalicBug
     /**
      * cursor bug test
      */
-    public static void main(String[] args) {
+    static void main() {
         
         try {
             ItalicBug cursorbug = new ItalicBug();

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/JavaTime.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/JavaTime.java
@@ -54,7 +54,7 @@ public class JavaTime {
     /**
      * @param args the command line arguments
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         
         System.out.println("Java time: " + System.currentTimeMillis());
         System.out.println("Timestamp: " + Utils.getCurrentTimeStamp());

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MenuTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MenuTest.java
@@ -45,7 +45,7 @@ public class MenuTest extends JPanel implements ActionListener, MouseListener {
    JPopupMenu popup = new JPopupMenu();
    JLabel messageArea = new JLabel();
 
-   public static void main(String[] args) {
+   static void main() {
       new MenuTest();
    }
 

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MultiBufferTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MultiBufferTest.java
@@ -124,7 +124,7 @@ public class MultiBufferTest {
         }
     }
     
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             int numBuffers = 3;
             if (args != null && args.length > 0) {

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastReceiver.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastReceiver.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 // java MulticastSnooper ALL-SYSTEMS.MCAST.NET 4000
 public class MulticastReceiver
 {
-	public static void main( String[] argv ) 
+	static void main() 
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastSender.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/MulticastSender.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 
 public class MulticastSender 
 {
-	public static void main( String[] argv ) 
+	static void main() 
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/SoundTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/SoundTest.java
@@ -60,7 +60,7 @@ public class SoundTest extends BaseCommandLineApp
     /**
      * Run emailer
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             Prefs.setRootNodeName("poker2");
             new SoundTest("poker", args);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/Tester.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/Tester.java
@@ -46,7 +46,7 @@ public class Tester
     /**
      * @param args the command line arguments
      */
-    public static void main(String[] args) {
+    static void main() {
 
 //        536870912 SEEDADJ: 592130587
 //        11:24.158 [TournamentDirector-0] DEBUG SEED: 1073741824 SEEDADJ: 597617150

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/TouchTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/TouchTest.java
@@ -50,7 +50,7 @@ public class TouchTest {
     public TouchTest() {
     }
 
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         long last = System.currentTimeMillis();
         System.out.println("Touching " + args[0]);

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastReceiver.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastReceiver.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 // java UnicastSnooper ALL-SYSTEMS.MCAST.NET 4000
 public class UnicastReceiver
 {
-	public static void main( String[] argv ) 
+	static void main() 
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastReceiverNIO.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastReceiverNIO.java
@@ -49,7 +49,7 @@ public class UnicastReceiverNIO
     static final int BUFFER_LENGTH = 256;
     static final int PORT = 7755;
 
-    public static void main( String[] argv )
+    static void main()
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSender.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSender.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 
 public class UnicastSender 
 {
-	public static void main( String[] argv ) 
+	static void main() 
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSenderNIO.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastSenderNIO.java
@@ -43,7 +43,7 @@ import java.nio.channels.DatagramChannel;
 
 public class UnicastSenderNIO 
 {
-	public static void main( String[] argv ) 
+	static void main() 
 	{
 		try 
 		{

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest.java
@@ -56,7 +56,7 @@ public class UnicastTest implements Runnable
 
     static boolean bSend = true;
 
-    public static void main( String[] argv )
+    static void main( String[] argv )
 	{
         if (argv.length == 0)
         {

--- a/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
+++ b/code/proto/src/main/java/com/donohoedigital/proto/tests/UnicastTest2.java
@@ -62,7 +62,7 @@ public class UnicastTest2 extends BaseCommandLineApp implements UDPLinkHandler, 
     /**
      * Run emailer
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try
         {

--- a/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/DDMailer.java
@@ -78,7 +78,7 @@ public class DDMailer extends BaseCommandLineApp
     /**
      * Run emailer
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         try
         {

--- a/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/LoadGen.java
@@ -181,7 +181,7 @@ public class LoadGen
     /**
      * * It all happens here
      */
-    public static void main(String[] args)
+    static void main(String[] args)
     {
         //String urlFile;
         String outFile;

--- a/code/tools/src/main/java/com/donohoedigital/tools/PokerTester.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/PokerTester.java
@@ -68,7 +68,7 @@ public class PokerTester extends PokerMain implements ChatHandler, OnlineMessage
     /**
      * Run emailer
      */
-    public static void main(String[] args) {
+    static void main(String[] args) {
         try {
             PokerTester tester = new PokerTester("poker", args);
             tester.init();

--- a/code/tools/src/main/java/com/donohoedigital/tools/ProxyServer.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/ProxyServer.java
@@ -49,7 +49,7 @@ public class ProxyServer extends GameServer
     /**
      * Start up
      */
-	public static void main(String[] argv)
+	static void main()
     {
 		ProxyServer p = new ProxyServer();
         p.init();

--- a/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
+++ b/code/tools/src/main/java/com/donohoedigital/tools/SchemaValidate.java
@@ -98,7 +98,7 @@ public class SchemaValidate extends DefaultHandler {
     }
 
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         if (args.length != 1) {
             System.out.println("Usage: java com.donohoedigital.tools.SchemaValidate <XML file>");
             return;

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -192,23 +192,6 @@ recipeList:
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: com.donohoedigital.DeadCode
-displayName: Dead code removal
-description: >
-  RISKY - Hibernate, Wicket and the gameengine XML save-game code all reach members
-  reflectively, and OpenRewrite cannot see those references.  Always dryRun and review
-  each deletion against a grep of .java, .html and .xml before applying.
-recipeList:
-  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
-  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
-  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
-  - org.openrewrite.staticanalysis.UnnecessaryThrows
-  - org.openrewrite.staticanalysis.RemoveUnneededBlock
-  - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
-  - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
-
----
-type: specs.openrewrite.org/v1beta/recipe
 name: com.donohoedigital.RedundantInitializers
 displayName: Redundant field initializers
 description: >


### PR DESCRIPTION
Final change PR of the modernization series.

```diff
-public static void main(String[] args)
+static void main(String[] args)          // 59 methods: public is redundant

-public static void main(String[] args)
+static void main()                       // 28 of those never used the parameter
```

**57 files.** Java 25 finalised the relaxed launch protocol (JEP 512): `main` need not be
public, and a no-argument form is accepted.

## Verified on the real JDK, not from memory

A wrong `main` signature is **not** a compile error — it's a launch-time *"Main method not
found"*. So compilation isn't sufficient evidence here, and I checked the launcher directly:

| Form | Launch | Result |
|---|---|---|
| `static void main(String[])`, non-public | `java -cp` | ok |
| `static void main()`, non-public | `java -cp` | ok |
| `static void main()`, non-public | `java -jar` manifest | ok |

Then on the actual entry points, which is what really matters:

- `tools/bin/proxy` → `ProxyServer.main()` — bound to :8080, ran, clean shutdown
- `tools/bin/pokerserver` → `PokerServerMain.main()` — came up listening on :8877
- `tools/bin/poker` → `PokerMain.main(String[])` — launches clean

`PokerMain` keeps its parameter because it uses it, which is fortunate: it's the one class
launched through the **install4j native launcher** rather than `java -cp`, and that path isn't
exercised by any test here. Nothing else appears in installer or manifest config, no `main` is
invoked programmatically, and nothing looks one up reflectively.

## Bodies deliberately left alone

I'd earlier described these as repeated try/catch-and-exit boilerplate worth tidying. **That was
wrong** — all 56 bodies are distinct, zero duplication, and what looked like boilerplate is
deliberate per-failure handling:

```java
catch (ApplicationError ae)    { System.err.println("Poker ending due to ApplicationError: " + ae); System.exit(1); }
catch (OutOfMemoryError nomem) { System.err.println("Out of memory: " + nomem); ... }
```

Changing that would alter entry-point behaviour for no benefit.

## Also drops the DeadCode recipe

Removed from `rewrite.yml`. `RemoveUnusedPrivateFields`/`RemoveUnusedPrivateMethods` can't see
reflective references, and this code base has three sources of them — Hibernate field access,
Wicket binding markup to component ids, and the gameengine XML save-game code. A wrong deletion
compiles and fails only when that path runs, which for save-game loading might be never in
testing. ~1,700 sites of cosmetic value against a runtime-failure downside.

## Verification

- `mvn package` — BUILD SUCCESS, **139 tests, 0 failures / 0 errors**
- Diff confirmed to contain nothing but `main` declarations (an earlier pass had rewritten two
  *commented-out* declarations; those were reverted)
- Three launch mechanisms and three real entry points exercised