### PR TITLE
Add check for new version

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/comms/Version.java
+++ b/code/common/src/main/java/com/donohoedigital/comms/Version.java
@@ -41,11 +41,15 @@ package com.donohoedigital.comms;
 import com.donohoedigital.base.ApplicationError;
 import com.donohoedigital.base.ErrorCodes;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * @author donohoe
  */
 @DataCoder('V')
-public class Version implements DataMarshal
+public class Version implements DataMarshal, Comparable<Version>
 {
     private int nMajor_;
     private int nMinor_;
@@ -66,64 +70,6 @@ public class Version implements DataMarshal
      */
     public Version()
     {
-    }
-
-    /**
-     * Create a new instance of Version using the string format
-     */
-    public Version(String s)
-    {
-        char c;
-        int beginIndex = 0;
-        int endIndex = -1;
-        int length = s.length();
-
-        while (Character.isDigit(c = s.charAt(++endIndex)))
-        {
-        }
-        nMajor_ = Integer.parseInt(s.substring(beginIndex, endIndex));
-
-        beginIndex = endIndex + 1;
-        while ((++endIndex < length) && (Character.isDigit(c = s.charAt(endIndex))))
-        {
-        }
-        nMinor_ = Integer.parseInt(s.substring(beginIndex, endIndex));
-
-        if (endIndex == length) return;
-        bAlpha_ = (c == 'a');
-        bBeta_ = (c == 'b');
-        if (bAlpha_ || bBeta_)
-        {
-            beginIndex = endIndex + 1;
-            while ((++endIndex < length) && (Character.isDigit(c = s.charAt(endIndex))))
-            {
-            }
-            nAlphaBetaVersion_ = Integer.parseInt(s.substring(beginIndex, endIndex));
-        }
-
-        if (endIndex == length) return;
-        if (c == 'p' || c == '.') // old style is 3.1p2, new is 3.1.2
-        {
-            beginIndex = endIndex + 1;
-            while ((++endIndex < length) && (Character.isDigit(c = s.charAt(endIndex))))
-            {
-            }
-            nPatch_ = Integer.parseInt(s.substring(beginIndex, endIndex));
-        }
-
-        if (endIndex == length) return;
-        bDemo_ = (c == 'd');
-        if (bDemo_)
-        {
-            if (++endIndex < length) c = s.charAt(endIndex);
-        }
-
-        if (endIndex == length) return;
-        if (c == '_')
-        {
-            beginIndex = endIndex + 1;
-            sLocale_ = s.substring(beginIndex);
-        }
     }
 
     /**
@@ -217,75 +163,88 @@ public class Version implements DataMarshal
 
     /**
      * Return true if this version is an earlier version
-     * than given version
+     * than given version, ignoring the patch number
      */
-    @SuppressWarnings({"RedundantIfStatement"})
     public boolean isMajorMinorBefore(Version version)
     {
-        if (nMajor_ > version.nMajor_) return false;
-        if (nMajor_ < version.nMajor_) return true;
-        if (nMinor_ > version.nMinor_) return false;
-        if (nMinor_ < version.nMinor_) return true;
-        if (bAlpha_ && version.bBeta_) return true;
-        if (bBeta_ && version.bAlpha_) return false;
-        if (!isProduction() && version.isProduction()) return true;
-        if (isProduction() && !version.isProduction()) return false;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return false;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return true;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return false;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return true;
-
-        return false;
+        return compareTo(version, false) < 0;
     }
 
     /**
      * Return true if this version is an earlier version
      * than given version
      */
-    @SuppressWarnings({"RedundantIfStatement"})
     public boolean isBefore(Version version)
     {
-        if (nMajor_ > version.nMajor_) return false;
-        if (nMajor_ < version.nMajor_) return true;
-        if (nMinor_ > version.nMinor_) return false;
-        if (nMinor_ < version.nMinor_) return true;
-        if (bAlpha_ && version.bBeta_) return true;
-        if (bBeta_ && version.bAlpha_) return false;
-        if (!isProduction() && version.isProduction()) return true;
-        if (isProduction() && !version.isProduction()) return false;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return false;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return true;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return false;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return true;
-        if (nPatch_ > version.nPatch_) return false;
-        if (nPatch_ < version.nPatch_) return true;
-
-        return false;
+        return compareTo(version) < 0;
     }
 
     /**
      * Return true if this version is a later version
      * than given version
      */
-    @SuppressWarnings({"RedundantIfStatement"})
     public boolean isAfter(Version version)
     {
-        if (nMajor_ < version.nMajor_) return false;
-        if (nMajor_ > version.nMajor_) return true;
-        if (nMinor_ < version.nMinor_) return false;
-        if (nMinor_ > version.nMinor_) return true;
-        if (bBeta_ && version.bAlpha_) return true;
-        if (bAlpha_ && version.bBeta_) return false;
-        if (!isProduction() && version.isProduction()) return false;
-        if (isProduction() && !version.isProduction()) return true;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return false;
-        if (bAlpha_ && version.bAlpha_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return true;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ < version.nAlphaBetaVersion_) return false;
-        if (bBeta_ && version.bBeta_ && nAlphaBetaVersion_ > version.nAlphaBetaVersion_) return true;
-        if (nPatch_ < version.nPatch_) return false;
-        if (nPatch_ > version.nPatch_) return true;
+        return compareTo(version) > 0;
+    }
 
-        return false;
+    /**
+     * True if this version is a later release than the given one.  False when they are the same
+     * version, so a check for a newer build does not report the one already running, and false
+     * for a null other, which is what a failed lookup hands back.
+     */
+    public boolean isNewerThan(Version other)
+    {
+        return other != null && compareTo(other) > 0;
+    }
+
+    /**
+     * Newest last: major, then minor, then the release type, then the alpha/beta number, then
+     * the patch.  An alpha or beta of a version comes before the version itself - 2.0a3, then
+     * 2.0b1, then 2.0 - and the patch is ranked last because it applies within a release, which
+     * is the order this project has actually shipped in (2.0b6.4 is Beta 6, Patch 4; see the
+     * history in PokerConstants).  Neither the locale nor the demo flag plays a part; they say
+     * who a build is for, not when it is from.
+     */
+    @Override
+    public int compareTo(Version o)
+    {
+        return compareTo(o, true);
+    }
+
+    /**
+     * See {@link #compareTo(Version)}.  When bIncludePatch is false the patch number is left out,
+     * so two builds of the same release compare equal - what {@link #isMajorMinorBefore} wants.
+     */
+    private int compareTo(Version o, boolean bIncludePatch)
+    {
+        if (nMajor_ != o.nMajor_) return Integer.compare(nMajor_, o.nMajor_);
+        if (nMinor_ != o.nMinor_) return Integer.compare(nMinor_, o.nMinor_);
+        if (typeRank() != o.typeRank()) return Integer.compare(typeRank(), o.typeRank());
+        if (nAlphaBetaVersion_ != o.nAlphaBetaVersion_)
+            return Integer.compare(nAlphaBetaVersion_, o.nAlphaBetaVersion_);
+        return bIncludePatch ? Integer.compare(nPatch_, o.nPatch_) : 0;
+    }
+
+    /** Alpha before beta before production - see {@link #compareTo(Version)}. */
+    private int typeRank()
+    {
+        if (bAlpha_) return 0;
+        if (bBeta_) return 1;
+        return 2;
+    }
+
+    /** Consistent with {@link #compareTo(Version)}, so the locale and demo flag are left out of this too. */
+    @Override
+    public boolean equals(Object o)
+    {
+        return o instanceof Version v && compareTo(v) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(nMajor_, nMinor_, typeRank(), nAlphaBetaVersion_, nPatch_);
     }
 
     public void demarshal(MsgState state, String sData)
@@ -333,5 +292,47 @@ public class Version implements DataMarshal
                (nPatch_ > 0 ? "." + nPatch_ : "") +
                (bDemo_ ? "d" : "") +
                (sLocale_ != null ? "_" + sLocale_ : "");
+    }
+
+    /**
+     * Mirrors {@link #toString}: major.minor, an optional a/b number, an optional patch, an
+     * optional demo flag, an optional locale.  The old "3.1p2" way of writing a patch is still
+     * understood, as are release tags written with a leading "v".
+     */
+    private static final Pattern PARSE =
+            Pattern.compile("^v?(\\d+)\\.(\\d+)(?:([ab])(\\d+))?(?:[.p](\\d+))?(d)?(?:_(.+))?$");
+
+    /**
+     * The inverse of {@link #toString}: "3.1", "3.1.8", "2.0b6.4", "1.2d", "3.1.8_en".
+     *
+     * @return the parsed version, or null if the string is not one.  Never throws - callers
+     * parse text they did not produce, such as a release tag read off a web page.
+     */
+    public static Version parse(String s)
+    {
+        if (s == null) return null;
+
+        Matcher m = PARSE.matcher(s.trim());
+        if (!m.matches()) return null;
+
+        try
+        {
+            String sType = m.group(3);
+            int nType = sType == null ? TYPE_PRODUCTION : ("a".equals(sType) ? TYPE_ALPHA : TYPE_BETA);
+            int nAlphaBeta = sType == null ? 0 : Integer.parseInt(m.group(4));
+            int nPatch = m.group(5) == null ? 0 : Integer.parseInt(m.group(5));
+
+            // not the running build, so nothing to verify an activation key against
+            Version v = new Version(nType, Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)),
+                                    nAlphaBeta, nPatch, false);
+            if (m.group(6) != null) v.setDemo(true);
+            v.setLocale(m.group(7));
+            return v;
+        }
+        catch (NumberFormatException e)
+        {
+            // a part too big for an int - not a version we know how to compare
+            return null;
+        }
     }
 }

--- a/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
+++ b/code/common/src/test/java/com/donohoedigital/comms/VersionTest.java
@@ -34,30 +34,226 @@ package com.donohoedigital.comms;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for parsing and ordering versions - what {@code UpdateCheck} in the poker module
+ * relies on when it compares a GitHub release tag against the running build.
+ */
 public class VersionTest {
 
+    // -------------------------------------------------------------------------
+    // parse / toString round-trip
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testParseVersion() {
+    public void parse_roundTripsToString() {
+        assertRoundTrip("3.1");
+        assertRoundTrip("3.1.8");
+        assertRoundTrip("2.0b6.4");
+        assertRoundTrip("3.1a2");
+        assertRoundTrip("1.2d");
+        assertRoundTrip("3.1.8_en");
+        assertRoundTrip("10.20.30");
+        assertRoundTrip("2.0b12_fr");
+    }
+
+    private static void assertRoundTrip(String s) {
+        Version v = Version.parse(s);
+        assertTrue(v != null, "did not parse: " + s);
+        assertEquals(s, v.toString());
+    }
+
+    @Test
+    public void parse_readsTheParts() {
         // major/minor
-        Version v = new Version("3.1");
+        Version v = Version.parse("3.1");
         assertEquals(3, v.getMajor());
         assertEquals("3", v.getMajorAsString());
         assertEquals(1, v.getMinor());
+        assertEquals(0, v.getPatch());
+        assertTrue(v.isProduction());
+        assertFalse(v.isDemo());
+        assertNull(v.getLocale());
 
-        // old style patch parsing
-        v = new Version("3.1p2");
+        // new style patch
+        v = Version.parse("3.1.4");
+        assertEquals(3, v.getMajor());
+        assertEquals(1, v.getMinor());
+        assertEquals(4, v.getPatch());
+
+        Version beta = Version.parse("2.0b6.4");
+        assertEquals(2, beta.getMajor());
+        assertEquals(0, beta.getMinor());
+        assertEquals(6, beta.getAlphaBetaVersion());
+        assertEquals(4, beta.getPatch());
+        assertTrue(beta.isBeta());
+        assertFalse(beta.isAlpha());
+        assertFalse(beta.isProduction());
+
+        Version alpha = Version.parse("2.0a2");
+        assertTrue(alpha.isAlpha());
+        assertFalse(alpha.isBeta());
+
+        assertTrue(Version.parse("1.2d").isDemo());
+        assertEquals("en", Version.parse("3.1.8_en").getLocale());
+    }
+
+    /** The old way of writing a patch, still seen in saved data and old version strings. */
+    @Test
+    public void parse_understandsOldStylePatch() {
+        Version v = Version.parse("3.1p2");
         assertEquals(3, v.getMajor());
         assertEquals(1, v.getMinor());
         assertEquals(2, v.getPatch());
         assertEquals("3.1.2", v.toString());
+    }
 
-        // new style patch
-        v = new Version("3.1.4");
-        assertEquals(3, v.getMajor());
-        assertEquals(1, v.getMinor());
-        assertEquals(4, v.getPatch());
-        assertEquals("3.1.4", v.toString());
+    /** A leading "v" is tolerated, since tags elsewhere are often written that way. */
+    @Test
+    public void parse_toleratesVPrefix() {
+        assertEquals(Version.parse("3.1.8"), Version.parse("v3.1.8"));
+    }
+
+    @Test
+    public void parse_trimsWhitespace() {
+        assertEquals(Version.parse("3.1.8"), Version.parse("  3.1.8\n"));
+    }
+
+    /** Anything that is not a version returns null rather than throwing - see Version.parse. */
+    @Test
+    public void parse_rejectsNonVersions() {
+        assertNull(Version.parse(null));
+        assertNull(Version.parse(""));
+        assertNull(Version.parse("   "));
+        assertNull(Version.parse("3"));
+        assertNull(Version.parse("latest"));
+        assertNull(Version.parse("3.1.x"));
+        assertNull(Version.parse("v3"));
+        assertNull(Version.parse("2.0c1"));
+        assertNull(Version.parse("2.0b"));
+        assertNull(Version.parse("3.1.0.1"));
+        assertNull(Version.parse("<!DOCTYPE html><html lang=\"en\">"));
+        assertNull(Version.parse("releases/tag/3.1.8"));
+        // too big for an int
+        assertNull(Version.parse("99999999999.0"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Ordering
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void isNewerThan_comparesNumbers() {
+        assertNewer("3.1.8", "3.1.7");
+        assertNewer("3.1", "3.0.6");
+        assertNewer("4.0", "3.9.9");
+        assertNewer("3.1.10", "3.1.9");
+    }
+
+    /**
+     * An alpha or beta of a version comes before the version itself, and a patch applies within
+     * a release - 2.0b6.4 is Beta 6, Patch 4, which still precedes 2.0.
+     */
+    @Test
+    public void isNewerThan_ranksPrereleases() {
+        assertNewer("2.0", "2.0b6");
+        assertNewer("2.0", "2.0b6.4");
+        assertNewer("2.0", "2.0a1");
+        assertNewer("2.0b6.4", "2.0b6");
+        assertNewer("2.0b8", "2.0b7");
+        assertNewer("2.0b1", "2.0a9");
+    }
+
+    @Test
+    public void isNewerThan_isFalseForSameOrOlder() {
+        assertFalse(Version.parse("3.1.8").isNewerThan(Version.parse("3.1.8")));
+        assertFalse(Version.parse("2.0b6.4").isNewerThan(Version.parse("2.0b6.4")));
+        assertFalse(Version.parse("3.1.5").isNewerThan(Version.parse("3.1.8")));
+    }
+
+    /** A failed lookup hands back null; that must not read as "newer". */
+    @Test
+    public void isNewerThan_isFalseForNull() {
+        assertFalse(Version.parse("9.9.9").isNewerThan(null));
+    }
+
+    /** The locale says who a build is for, not when it is from; same for the demo flag. */
+    @Test
+    public void ordering_ignoresLocaleAndDemo() {
+        assertEquals(Version.parse("3.1.8"), Version.parse("3.1.8_fr"));
+        assertEquals(Version.parse("1.2"), Version.parse("1.2d"));
+        assertFalse(Version.parse("3.1.8_fr").isNewerThan(Version.parse("3.1.8_en")));
+    }
+
+    /**
+     * The real ladder DD Poker has shipped (the history in {@code PokerConstants}, oldest first).
+     * Shuffled and re-sorted, it has to come back in the same order.
+     */
+    @Test
+    public void ordering_reproducesShippedHistory() {
+        List<String> oldestFirst = List.of(
+                "2.0b6.4", "2.5.3", "3.0.5", "3.0.6", "3.1", "3.1.1", "3.1.2", "3.1.3",
+                "3.1.4", "3.1.5", "3.1.6", "3.1.7", "3.1.8");
+
+        List<Version> shuffled = new ArrayList<>(oldestFirst.stream().map(Version::parse).toList());
+        Collections.shuffle(shuffled);
+        Collections.sort(shuffled);
+
+        assertEquals(oldestFirst, shuffled.stream().map(Version::toString).toList());
+    }
+
+    /** isBefore/isAfter are the older spelling of the same ordering, used by online compat checks. */
+    @Test
+    public void isBeforeAndIsAfter_followTheSameOrder() {
+        Version older = Version.parse("3.0.4");
+        Version newer = Version.parse("3.1.8");
+
+        assertTrue(older.isBefore(newer));
+        assertFalse(newer.isBefore(older));
+        assertTrue(newer.isAfter(older));
+        assertFalse(older.isAfter(newer));
+
+        // neither, for the same version
+        assertFalse(older.isBefore(Version.parse("3.0.4")));
+        assertFalse(older.isAfter(Version.parse("3.0.4")));
+
+        assertTrue(Version.parse("2.0b6.4").isBefore(Version.parse("2.0")));
+    }
+
+    /** isMajorMinorBefore ignores the patch, so builds of the same release tie. */
+    @Test
+    public void isMajorMinorBefore_ignoresPatch() {
+        assertFalse(Version.parse("3.1.8").isMajorMinorBefore(Version.parse("3.1")));
+        assertFalse(Version.parse("3.1").isMajorMinorBefore(Version.parse("3.1.8")));
+        assertTrue(Version.parse("3.0.6").isMajorMinorBefore(Version.parse("3.1")));
+        assertTrue(Version.parse("2.0b6.4").isMajorMinorBefore(Version.parse("2.0")));
+    }
+
+    @Test
+    public void equalsAndHashCode_agreeWithCompareTo() {
+        Version a = Version.parse("3.1.8");
+        Version b = new Version(3, 1, 8, true);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        assertNotEquals(a, Version.parse("3.1.7"));
+        assertNotEquals("3.1.8", a);
+        assertNotEquals(null, a);
+    }
+
+    private static void assertNewer(String newer, String older) {
+        Version n = Version.parse(newer);
+        Version o = Version.parse(older);
+        assertTrue(n.isNewerThan(o), newer + " should be newer than " + older);
+        assertFalse(o.isNewerThan(n), older + " should not be newer than " + newer);
     }
 }

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/GamePrefsPanel.java
@@ -240,6 +240,12 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             DDPanel buttonbase = new DDPanel();
             buttonbase.setLayout(new FlowLayout(FlowLayout.CENTER, 15, 0));
             buttonbase.setBorder(BorderFactory.createEmptyBorder(2, 0, 2, 2));
+
+            DDButton checkupdate = new GlassButton("checkupdate", "Glass");
+            checkupdate.addActionListener(_ -> UpdateCheck.checkNow(context_));
+            checkupdate.setBorderGap(2, 5, 2, 6);
+            buttonbase.add(checkupdate);
+
             buttonbase.add(resetdialog);
             generalbase.add(buttonbase, BorderLayout.SOUTH);
 
@@ -250,38 +256,19 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_CHECKFOLD, OSTYLE, map_, true), generalbasetop);
             OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_RIGHT_CLICK_ONLY, OSTYLE, map_, true), generalbasetop);
             OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_DISABLE_SHORTCUTS, OSTYLE, map_, true), generalbasetop);
+            OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_AUTO_CHECK_UPDATE, OSTYLE, map_, true), generalbasetop);
 
-            if (!engine_.isDemo()) // no auto update in the demo
-            {
-                OptionMenu.add(new OptionBoolean(NODE, PokerConstants.OPTION_AUTO_CHECK_UPDATE, OSTYLE, map_, true), generalbasetop);
-            }
-
-            // screen mode
-            // Turned off screen-mode in DD Poker 3 since no one uses it, and it doesn't work on Vista
-//            if (!Utils.ISLINUX && !Utils.ISMAC) // no window options on linux or mac
-//            {
-//                DDLabelBorder modebase = null;
-//                modebase = new DDLabelBorder("mode", OSTYLE);
-//                modebase.setLayout(new GridLayout(0, 1, 0, GRIDADJUST1));
-//                ButtonGroup modegroup = new ButtonGroup();
-//                OptionMenu.add(new OptionRadio(NODE, EngineConstants.PREF_WINDOW_MODE, OSTYLE, map_, "mode.always", modegroup, EngineConstants.MODE_ASK), modebase);
-//                OptionMenu.add(new OptionRadio(NODE, EngineConstants.PREF_WINDOW_MODE, OSTYLE, map_, "mode.window", modegroup, EngineConstants.MODE_WINDOW), modebase);
-//                OptionMenu.add(new OptionRadio(NODE, EngineConstants.PREF_WINDOW_MODE, OSTYLE, map_, "mode.full", modegroup, EngineConstants.MODE_FULL), modebase);
-//
-//                leftside.add(modebase, BorderLayout.CENTER);
-//            }
-
-            ////
-            //// RIGHT side - audio/chat
-            ////
+            //
+            // RIGHT side - audio/chat
+            //
 
             DDPanel rightbase = new DDPanel();
             rightbase.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, HorizontalFlowLayout.LEFT));
             base.add(rightbase);
 
-            ///
-            /// AUDIO
-            ///
+            //
+            // AUDIO
+            //
 
             // sound
             DDLabelBorder audiobase = new DDLabelBorder("audio", OSTYLE);
@@ -333,9 +320,9 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
 
             rightbase.add(audiobase);
 
-            ///
-            /// CHAT
-            ///
+            //
+            // CHAT
+            //
 
             // messages
             DDLabelBorder chatbase = new DDLabelBorder("chatoptions", OSTYLE);
@@ -350,9 +337,9 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             spacer.add(chatbase, BorderLayout.NORTH);
             rightbase.add(spacer);
 
-            ///
-            /// SCREENSHOT
-            ///
+            //
+            // SCREENSHOT
+            //
 
             OptionInteger oi;
             DDLabelBorder screenbase = new DDLabelBorder("screenshot", OSTYLE);
@@ -515,11 +502,11 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
 
             // buttons
             DDButton bannedplayers = new GlassButton("bannedplayers", "Glass");
-            bannedplayers.addActionListener(e -> context_.processPhaseNow("BannedPlayerList", null));
+            bannedplayers.addActionListener(_ -> context_.processPhaseNow("BannedPlayerList", null));
             bannedplayers.setBorderGap(2, 5, 2, 6);
 
             DDButton mutedplayers = new GlassButton("mutedplayers", "Glass");
-            mutedplayers.addActionListener(e -> context_.processPhaseNow("MutedPlayerList", null));
+            mutedplayers.addActionListener(_ -> context_.processPhaseNow("MutedPlayerList", null));
             mutedplayers.setBorderGap(2, 5, 2, 6);
 
             DDPanel buttonbase = new DDPanel();
@@ -562,7 +549,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             // online enabled checkbox
             onlineEnabled_ = new OptionBoolean(NODE, EngineConstants.OPTION_ONLINE_ENABLED, OSTYLE, map_, true);
             serverBorder.add(GuiUtils.NORTH(onlineEnabled_), BorderLayout.WEST);
-            onlineEnabled_.addChangeListener(e -> doOnlineEnabled());
+            onlineEnabled_.addChangeListener(_ -> doOnlineEnabled());
 
             // servers list (online, chat)
             DDPanel serversTable = new DDPanel();
@@ -588,7 +575,7 @@ public class GamePrefsPanel extends DDPanel implements ActionListener
             // test button
             test_ = new GlassButton("testonline", "Glass");
             serverBorder.add(GuiUtils.CENTER(test_), BorderLayout.EAST);
-            test_.addActionListener(e -> testConnection());
+            test_.addActionListener(_ -> testConnection());
 
             // update text fields based on pref
             doOnlineEnabled();

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerStartMenu.java
@@ -97,9 +97,7 @@ public class PokerStartMenu extends StartMenu
             return;
         }
 
-        ////
-        //// big suit buttons
-
+        // big suit buttons
         DDPanel bigbuttons = new DDPanel();
         base.add(bigbuttons, BorderLayout.WEST);
         ExplicitLayout elayout = new ExplicitLayout();
@@ -110,10 +108,7 @@ public class PokerStartMenu extends StartMenu
         addBigButton(bigbuttons, "online", 102, 0);
         elayout.setPreferredLayoutSize(MathEF.constant(430), MathEF.constant(450));
 
-        ////
-        //// right side controls
-        ////
-
+        // right side controls
         DDPanel rightbase = new DDPanel();
         rightbase.setBorderLayoutGap(10, 0);
         base.add(rightbase, BorderLayout.CENTER);
@@ -141,10 +136,9 @@ public class PokerStartMenu extends StartMenu
         addControlButton(ctrlbuttonbase, "support");
         addControlButton(ctrlbuttonbase, "help");
 
-
-        ////
-        //// player profile
-        ////
+        //
+        // player profile
+        //
 
         // set flag indicating we should do a profile check
         bProfileCheck_ = true;
@@ -303,6 +297,14 @@ public class PokerStartMenu extends StartMenu
         }
 
         messageCheck = false;
+
+        // Ask GitHub whether a newer DD Poker has been released.  Independent of the DD message
+        // check above: GitHub is not a DD server, so neither the online-servers option nor a
+        // player profile is required.  Runs off the EDT and stays quiet unless there is news.
+        if (isStartMenu() && !engine_.isDemo() && PokerUtils.isOptionOn(PokerConstants.OPTION_AUTO_CHECK_UPDATE))
+        {
+            UpdateCheck.checkAtStartup(context_, () -> context_.getCurrentUIPhase() == this);
+        }
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/UpdateCheck.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/UpdateCheck.java
@@ -1,0 +1,280 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ * 
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images, 
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials) 
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets 
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ * 
+ * For inquiries regarding commercial licensing of this source code or 
+ * the use of names, logos, images, text, or other assets, please contact 
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+/*
+ * UpdateCheck.java
+ *
+ * Created on September 9, 2026
+ */
+
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.comms.Version;
+import com.donohoedigital.config.PropertyConfig;
+import com.donohoedigital.games.engine.GameContext;
+import com.donohoedigital.games.engine.GameEngine;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.gui.DDOption;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.swing.SwingWorker;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.prefs.Preferences;
+
+/**
+ * Tells the user when a newer DD Poker has been released.  There is no in-app updater - the game
+ * is installed from an installer on GitHub Releases - so all this does is notice and point at the
+ * download links in the README.
+ *
+ * <p>How it asks: {@code github.com/.../releases/latest} answers a bare {@code HEAD} with a 302 to
+ * {@code .../releases/tag/<tag>}, and the tags this project publishes are exactly
+ * {@link Version#toString} output (3.1.8, 3.1, 2.0b6.4).  So the whole check is one request with
+ * redirects turned off, and the last path segment of the {@code Location} header handed to
+ * {@link Version#parse}.  That is smaller than the JSON API, needs no JSON parser (none is on the
+ * classpath), and has no unauthenticated rate limit; like the API, it already skips drafts and
+ * prereleases.  This is unrelated to {@code DDMessageCheck}, which asks the DD Poker server for
+ * messages and does no version comparison at all.
+ *
+ * <p>Nothing here is allowed to get in the user's way.  The request runs on a
+ * {@link SwingWorker} so startup never waits on it, and the automatic check says nothing at all
+ * when it fails - an offline laptop is not an error the user needs a dialog about.  The
+ * <i>Check for Updates</i> button in Options does report a failure, because there someone asked.
+ *
+ * @author Doug Donohoe
+ */
+public final class UpdateCheck
+{
+    private static final Logger logger = LogManager.getLogger(UpdateCheck.class);
+
+    /** Redirects to the newest non-draft, non-prerelease release's tag page. */
+    private static final String LATEST_URL = "https://github.com/dougdonohoe/ddpoker/releases/latest";
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    /** Prefs node and key holding the version we last told the user about. */
+    private static final String PREFS_NODE = "/update";
+    private static final String PREFS_KEY_NOTIFIED = "notified.version";
+
+    // Both flags are read and written on the EDT only - checkAtStartup is called from there, and
+    // SwingWorker.done() runs there too.
+
+    /**
+     * The automatic check runs once per launch.  The start menu is re-entered every time the user
+     * leaves a game, which would otherwise ask again.
+     */
+    private static boolean checkedThisSession_;
+
+    /** Set while a check is in flight, so nothing stacks up workers. */
+    private static boolean running_;
+
+    private UpdateCheck()
+    {
+    }
+
+    /**
+     * The check made when the start menu opens.  Silent unless there is something to say: a newer
+     * release the user has not already been told about.
+     *
+     * @param stillShowing false when the user has moved on from the start menu.  Checked when the
+     *                     answer comes back, not when the request goes out - the user can start a
+     *                     game while it is in flight, and nothing may interrupt that with a
+     *                     dialog.  Deliberately without recording the version in that case, so
+     *                     the next launch offers the news again.
+     */
+    public static void checkAtStartup(GameContext context, BooleanSupplier stillShowing)
+    {
+        if (checkedThisSession_) return;
+        checkedThisSession_ = true;
+
+        fetchAsync(latest -> {
+            if (latest == null) return; // offline, firewalled, GitHub down - not worth a dialog
+            if (!stillShowing.getAsBoolean()) return;
+
+            if (!latest.isNewerThan(PokerConstants.VERSION)) return;
+            if (latest.toString().equals(lastNotified())) return; // already said so, once is enough
+
+            setLastNotified(latest);
+            showAvailable(context, latest);
+        });
+    }
+
+    /**
+     * The check behind the <i>Check for Updates</i> button in Options.  Always reports, and
+     * ignores both the once-per-launch and once-per-version guards - someone asked, so answer.
+     */
+    public static void checkNow(GameContext context)
+    {
+        fetchAsync(latest -> {
+            if (latest == null)
+            {
+                PokerUtils.displayInformationDialog(context,
+                                                    PropertyConfig.getMessage("msg.update.failed"),
+                                                    "msg.windowtitle.checkUpdate", null);
+            }
+            else if (latest.isNewerThan(PokerConstants.VERSION))
+            {
+                // Record it here too: having been shown the news, the user does not need it
+                // repeated at the next launch.
+                setLastNotified(latest);
+                showAvailable(context, latest);
+            }
+            else
+            {
+                PokerUtils.displayInformationDialog(context,
+                                                    PropertyConfig.getMessage("msg.update.none",
+                                                                              PokerConstants.VERSION),
+                                                    "msg.windowtitle.checkUpdate", null);
+            }
+        });
+    }
+
+    private static void showAvailable(GameContext context, Version latest)
+    {
+        PokerUtils.displayInformationDialog(context,
+                                            PropertyConfig.getMessage("msg.update.available",
+                                                                      latest, PokerConstants.VERSION),
+                                            "msg.windowtitle.updateAvailable", null);
+    }
+
+    /**
+     * Runs {@link #fetchLatest} off the EDT and hands the result (possibly null) back on it.
+     */
+    private static void fetchAsync(Consumer<Version> onResult)
+    {
+        if (running_) return;
+        running_ = true;
+
+        new SwingWorker<Version, Void>()
+        {
+            @Override
+            protected Version doInBackground()
+            {
+                return fetchLatest();
+            }
+
+            @Override
+            protected void done()
+            {
+                running_ = false;
+                Version latest;
+                try
+                {
+                    latest = get();
+                }
+                catch (Exception e)
+                {
+                    // fetchLatest swallows its own failures, so this is the worker itself going
+                    // wrong (interrupted, say) - same outcome either way.
+                    logger.debug("update check worker failed: {}", e.toString());
+                    latest = null;
+                }
+                onResult.accept(latest);
+            }
+        }.execute();
+    }
+
+    /**
+     * Asks GitHub for the newest release and returns its version.
+     *
+     * @return the latest released version, or null if it could not be determined for any reason -
+     * no network, an unexpected response, a tag that is not a version.  Never throws.
+     */
+    static Version fetchLatest()
+    {
+        try (HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NEVER) // the redirect *is* the answer
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build())
+        {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(LATEST_URL))
+                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                    .header("User-Agent", "DD Poker/" + PokerConstants.VERSION)
+                    .timeout(REQUEST_TIMEOUT)
+                    .build();
+
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            String location = response.headers().firstValue("location").orElse(null);
+            if (location == null)
+            {
+                logger.info("update check: no redirect from {} (status {})", LATEST_URL, response.statusCode());
+                return null;
+            }
+
+            Version latest = Version.parse(tagFrom(location));
+            if (latest == null) logger.info("update check: unrecognized release tag in {}", location);
+            return latest;
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+        catch (Exception e)
+        {
+            // Offline is the common case and is not worth a stack trace in the user's log.
+            logger.debug("update check failed: {}", e.toString());
+            return null;
+        }
+    }
+
+    /**
+     * The tag out of a {@code .../releases/tag/3.1.8} redirect target.
+     */
+    private static String tagFrom(String location)
+    {
+        int slash = location.lastIndexOf('/');
+        return slash < 0 ? location : location.substring(slash + 1);
+    }
+
+    private static String lastNotified()
+    {
+        return prefs().get(PREFS_KEY_NOTIFIED, null);
+    }
+
+    private static void setLastNotified(Version v)
+    {
+        prefs().put(PREFS_KEY_NOTIFIED, v.toString());
+    }
+
+    private static Preferences prefs()
+    {
+        return DDOption.getOptionPrefs(GameEngine.getGameEngine().getPrefsNodeName() + PREFS_NODE);
+    }
+}

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -423,6 +423,8 @@ msg.windowtitle.getWanList=			Retrieving Public Games List
 msg.windowtitle.validateProfile=	Validating Profile
 msg.windowtitle.ddmsgCheck=		    Checking For Donohoe Digital Update
 msg.windowtitle.ddmsgMessage=       Donohoe Digital Update
+msg.windowtitle.updateAvailable=    Update Available
+msg.windowtitle.checkUpdate=        Check for Updates
 msg.windowtitle.prefsDialog=        Options
 msg.windowtitle.prizeDialog=        Prize Pool
 msg.windowtitle.sidePotsDialog=     Pots
@@ -800,11 +802,19 @@ msg.userRegistered=		<CENTER><TABLE CELLPADDING="10">\
 						<TR><TD><B><font color="white">Activation Number:</font></B></TD><TD>{1}</TD></TR>\
 						</TABLE></CENTER>
 
-msg.autoinstall=			An update is available (version {0}).  Do you wish to install it now?
-msg.updateCheck=			<HTML>Contacting DD Poker Server<BR>to check update availability...</HTML>
 msg.ddmsgCheck=			    <HTML>Contacting DD Poker Server to check for messages...</HTML>
 
-labelborder.updaterequest.label=	Update Status
+## Update notice - see UpdateCheck.  {0} is the newly released version, {1} the one running.
+## There is no in-app updater, so this points at the README download links.
+msg.update.available=		<HTML><B>DD Poker {0}</B> is available - you are running {1}.<P>\
+							Download the new version from GitHub at<BR>\
+							<B><a href="https://github.com/dougdonohoe/ddpoker#installers"><font color=yellow>github.com/dougdonohoe/ddpoker#installers</font></a></B>.</HTML>
+
+msg.update.none=			<HTML>You are running the latest version of DD Poker ({0}).</HTML>
+
+msg.update.failed=			<HTML>DD Poker could not reach GitHub to check for a newer version.<P>\
+							If you are online, you can check by hand at<BR>\
+							<B><a href="https://github.com/dougdonohoe/ddpoker#installers"><font color=yellow>github.com/dougdonohoe/ddpoker#installers</font></a></B>.</HTML>
 
 panel.welcome.help=		<B><font color="yellow">Shuffle up and deal!</font></B><BR><BR>\
 						DD Poker lets you practice your no limit holdem poker skills in tournament \
@@ -918,6 +928,10 @@ button.calc.help=	Open the DD Poker <font color="yellow">Calculator Tool</font> 
 
 button.basicpref.label=	Basic Options
 button.basicpref.help=	Set <font color="yellow">Basic Options</font> such as hands per hour, dealing hole cards face down and sound preferences.
+
+button.checkupdate.label= Check for Updates...
+button.checkupdate.help=  Ask GitHub whether a newer version of DD Poker has been released.  DD Poker \
+						  also checks at startup if the "Auto Check For Updates" option is on.
 
 button.resetdialog.label= Reset Hidden Dialogs
 button.resetdialog.help=  Reset all dialogs you have hidden via the "do not display" checkbox. If you \

--- a/code/poker/src/main/resources/config/poker/help/whatsnew.html
+++ b/code/poker/src/main/resources/config/poker/help/whatsnew.html
@@ -46,6 +46,36 @@
 </table>
 <br>
 
+<!-- 3.1.9 -->
+
+<div style="background-color: #1D4A07; text-align: center; padding: 4px;">
+    <strong><span style="color: #FFFF00; font-size: 120%;">Version 3.1.9 - TBD</span></strong>
+</div>
+<ul>
+    <li>
+        DD Poker now looks for a newer release when it starts, and tells you when one is out, with
+        a link to the download instructions.  Nothing is installed for you - the notice points you
+        at the installers, and installing over an existing copy leaves your player profiles, saved
+        games and options alone.
+    </li>
+    <li>
+        You are told once per release.  Once the notice for a version has been shown it stays quiet
+        until the next release, whether or not you upgrade, so it never becomes something to click
+        past at every launch.
+    </li>
+    <li>
+        The check is silent when it fails.  Being offline, behind a firewall, or hitting a GitHub
+        outage produces no dialog at all, and the check runs in the background, so it never holds
+        up the game starting.  It happens only once you reach the main menu, and
+        <b>Auto Check For Updates</b> in <b>Options</b> turns it off.
+    </li>
+    <li>
+        A new <b>Check for Updates...</b> button on the <b>General</b> tab of <b>Options</b> asks on
+        demand, and always answers: a newer version is out, you are up to date, or GitHub could not
+        be reached.
+    </li>
+</ul>
+
 <!-- 3.1.8 -->
 
 <div style="background-color: #1D4A07; text-align: center; padding: 4px;">
@@ -584,8 +614,7 @@
 <div style="background-color: #1D4A07; text-align: center; padding: 4px;">
     <strong><span style="color: #FFFF00; font-size: 120%;">Version 2.0 - August 5, 2005</span></strong>
 </div>
-<p align="center" size="+1"><strong><font size="+1">Computer AI &quot;Artificial Intelligence&quot;</font></strong><font
-        size="+1"></font></font> </p>
+<p align="center"><strong><font size="+1">Computer AI &quot;Artificial Intelligence&quot;</font></strong></p>
 
 <p>The computer AI has taken a giant leap forward.</p>
 <ul>
@@ -613,11 +642,9 @@
 <ul>
     <li>Detailed player statistics</li>
     <li>Hand history tracking</li>
-    <br>
-
-    <div align="center"><font size="+1"><strong>Look &amp; Feel </strong></font></div>
-    </li>
 </ul>
+<div align="center"><br>
+    <font size="+1"><strong>Look &amp; Feel </strong></font></div>
 <ul>
     <li>DD Dashboard - A configurable information display</li>
     <li>Improved screen layout and navigation</li>

--- a/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
+++ b/code/pokerengine/src/main/java/com/donohoedigital/games/poker/engine/PokerConstants.java
@@ -54,6 +54,7 @@ public class PokerConstants
      * needed).
      */
     public static final Version VERSION = latest(
+            new Version(3, 1, 9, true), // release 3.1.9 (check for updates)
             new Version(3, 1, 8, true), // release 3.1.8 (HiDPI rendering fixes)
             new Version(3, 1, 7, true), // release 3.1.7 (memory fix, dashboard improvements)
             new Version(3, 1, 6, true), // release 3.1.6 (Java 25, dependency updates)


### PR DESCRIPTION
DD Poker ships installers via GitHub Releases and has no in-app updater, so someone running 3.1.2
has no way to learn that 3.1.8 exists. This ports the update check from the sibling
[ddphotos-app](https://github.com/dougdonohoe/ddphotos-app) project (commit `b54d167`, "Check for
updates") into DD Poker.

Options → **Auto Check For Updates** already existed (default on), and its help text already
promised exactly this behavior — but the only thing it gated was `DDMessageCheck`, which fetches an
opaque broadcast message from the DD Poker server and does no version comparison at all. That path
is untouched; this is additive.

## How it asks

`github.com/dougdonohoe/ddpoker/releases/latest` answers a bare `HEAD` with a 302 to
`.../releases/tag/<tag>`, and the tags this project publishes are exactly `Version.toString()`
output (`3.1.8`, `3.1`, `2.0b6.4`). So the whole check is one request with redirects turned off,
and the last path segment of the `Location` header handed to `Version.parse`.

Smaller than the JSON API, needs no JSON parser (there is none on the classpath), no
unauthenticated rate limit, and — like the API — it already skips drafts and prereleases.

## Changes

**`Version`** (`common`) — now `Comparable<Version>`, with `parse()`, `isNewerThan()`,
`compareTo(Version, boolean)`, `equals`/`hashCode`. `isMajorMinorBefore`/`isBefore`/`isAfter` now
delegate to `compareTo`, which removes ~40 lines of duplicated if-chains with no change to
ordering semantics — note the ordering ranks release *type* before patch, since `2.0b6.4` is
Beta 6 Patch 4 and precedes `2.0`. The hand-rolled `Version(String)` constructor is deleted:
it threw on input as ordinary as `"3"`, `parse()` supersedes it (returning `null` instead of
throwing, since callers parse text they did not produce), and nothing outside the test used it.

**`UpdateCheck`** (new, `poker`) — the request itself, on a `SwingWorker` so startup never waits
on it. Remembers the version it last mentioned under the `…/update` prefs node.

**`PokerStartMenu.profileCheck()`** — kicks off the automatic check, gated on
`OPTION_AUTO_CHECK_UPDATE` alone. Unlike the DD message check it needs neither the online-servers
option nor a player profile, because GitHub is not a DD server.

**`GamePrefsPanel`** — a **Check for Updates...** button on the General tab of Options, beside
*Reset Hidden Dialogs*, for checking on demand.

**`client.properties`** — the new messages and button labels, and removal of three dead keys
(`msg.autoinstall`, `msg.updateCheck`, `labelborder.updaterequest.label`) left over from the
auto-patch-install machinery that was removed long ago.

## Behavior

- **Silent unless there is news.** The automatic check says nothing when it fails — offline,
  firewalled, or a GitHub outage produces no dialog at all, just a `debug` log line.
- **Once per release.** Once the notice for a version has been shown it stays quiet until the next
  release, whether or not you upgrade.
- **Never interrupts.** The answer is dropped if you have left the start menu by the time it
  arrives — and deliberately without recording the version, so the next launch offers it again.
- **The button always answers**, ignoring both guards: a newer version is out, you are up to date,
  or GitHub could not be reached. That one reports failure, because there someone asked.
- The notice links to the README installer section; nothing is installed for you.

## Release prep

Version bumped to **3.1.9** in `PokerConstants`, with a `TBD`-dated entry in `whatsnew.html`.
That file also picks up two long-standing HTML fixes in the 2.0 section: the **Look & Feel**
heading was trapped inside the Player Statistics `<ul>` with a stray `</li>` after it, and the
Computer AI heading carried an empty `<font>`, a stray `</font>` and a bogus `size` attribute on
its `<p>`. Every tag in the file now balances.

## Testing

`VersionTest` goes from 1 test to 15, covering `parse`/`toString` round trips, the legacy `3.1p2`
patch form, rejection of non-versions (`"3"`, `"latest"`, `"releases/tag/3.1.8"`, an HTML doctype),
prerelease ranking, and sorting the real shipped history back into order. All 58 tests in the
`common` module pass, `DataMarshallerTest` included.

Verified against the live endpoint: the fetch returns `3.1.8`, round-trips through `toString`, and
compares correctly against the running build. An unreachable host returns `null` in under a second
with one `debug` line and no stack trace. All new property keys were confirmed to render through
`PropertyConfig`, substitutions and link markup intact. The dialogs were exercised in the running
game with the version temporarily dropped.
