### PR TITLE
UDP/chat bug fixes plus testing foundation start

### DIFF
--- a/code/common/src/main/java/com/donohoedigital/config/MemoryPreferencesFactory.java
+++ b/code/common/src/main/java/com/donohoedigital/config/MemoryPreferencesFactory.java
@@ -1,0 +1,135 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.config;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.prefs.AbstractPreferences;
+import java.util.prefs.Preferences;
+import java.util.prefs.PreferencesFactory;
+
+/**
+ * Preferences that live in memory and disappear with the JVM.
+ * <p/>
+ * Selected with -Djava.util.prefs.PreferencesFactory=com.donohoedigital.config.MemoryPreferencesFactory,
+ * which the build sets for tests.  Without it a test run reads and writes the developer's
+ * real preferences - and on a Mac that is not something -Duser.home can redirect, because
+ * MacOSXPreferences writes to ~/Library/Preferences regardless.
+ * <p/>
+ * This lives in main rather than test because the system property is set for every
+ * module's test JVM, so the class has to be on every module's classpath.
+ */
+public class MemoryPreferencesFactory implements PreferencesFactory
+{
+    private static final Preferences USER = new MemoryPreferences(null, "");
+    private static final Preferences SYSTEM = new MemoryPreferences(null, "");
+
+    @Override
+    public Preferences userRoot()
+    {
+        return USER;
+    }
+
+    @Override
+    public Preferences systemRoot()
+    {
+        return SYSTEM;
+    }
+
+    private static class MemoryPreferences extends AbstractPreferences
+    {
+        private final Map<String, String> values = new ConcurrentHashMap<>();
+        private final Map<String, MemoryPreferences> children = new ConcurrentHashMap<>();
+
+        MemoryPreferences(MemoryPreferences parent, String name)
+        {
+            super(parent, name);
+        }
+
+        @Override
+        protected void putSpi(String key, String value)
+        {
+            values.put(key, value);
+        }
+
+        @Override
+        protected String getSpi(String key)
+        {
+            return values.get(key);
+        }
+
+        @Override
+        protected void removeSpi(String key)
+        {
+            values.remove(key);
+        }
+
+        @Override
+        protected void removeNodeSpi()
+        {
+            MemoryPreferences parent = (MemoryPreferences) parent();
+            if (parent != null) parent.children.remove(name());
+            values.clear();
+        }
+
+        @Override
+        protected String[] keysSpi()
+        {
+            return values.keySet().toArray(new String[0]);
+        }
+
+        @Override
+        protected String[] childrenNamesSpi()
+        {
+            return children.keySet().toArray(new String[0]);
+        }
+
+        @Override
+        protected AbstractPreferences childSpi(String name)
+        {
+            return children.computeIfAbsent(name, n -> new MemoryPreferences(this, n));
+        }
+
+        // nothing to sync or flush - there is no backing store
+
+        @Override
+        protected void syncSpi()
+        {
+        }
+
+        @Override
+        protected void flushSpi()
+        {
+        }
+    }
+}

--- a/code/common/src/test/java/com/donohoedigital/config/TestIsolationTest.java
+++ b/code/common/src/test/java/com/donohoedigital/config/TestIsolationTest.java
@@ -1,0 +1,103 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.prefs.Preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A test run must not read or write the developer's real DD Poker data.
+ * <p/>
+ * Both halves of that are set up in the surefire configuration in code/pom.xml, and both
+ * are easy to lose in a build change without anyone noticing until a test has scribbled
+ * on a real profile or preference.  These assertions fail loudly instead.
+ */
+public class TestIsolationTest
+{
+    /**
+     * Everything the client writes - logs, saved games, profiles, the database - hangs
+     * off user.home, which the build points at target/test-home.
+     */
+    @Test
+    public void userHomeIsRedirectedIntoTheBuildDirectory()
+    {
+        String home = System.getProperty("user.home");
+
+        assertTrue(home.contains("test-home"),
+                   "user.home should point into the build directory, but was: " + home);
+        assertTrue(new File(home).getAbsolutePath().contains("target"),
+                   "user.home should be under target/ so 'mvn clean' discards it: " + home);
+    }
+
+    /**
+     * user.home does not cover java.util.prefs - on a Mac the backing store is
+     * ~/Library/Preferences no matter what user.home says - so the build also swaps in
+     * an in-memory factory.
+     */
+    @Test
+    public void preferencesAreInMemory()
+    {
+        assertEquals("com.donohoedigital.config.MemoryPreferencesFactory",
+                     System.getProperty("java.util.prefs.PreferencesFactory"),
+                     "the build should select the in-memory preferences factory");
+
+        // the real store would be MacOSXPreferences / FileSystemPreferences
+        String impl = Preferences.userRoot().getClass().getName();
+        assertTrue(impl.startsWith("com.donohoedigital.config.MemoryPreferencesFactory"),
+                   "preferences should be in memory, but the root was: " + impl);
+    }
+
+    /**
+     * And they really are a scratch store - a value written here is gone next JVM, so it
+     * cannot leak into the developer's preferences or between builds.
+     */
+    @Test
+    public void preferencesStartEmptyAndRoundTrip() throws Exception
+    {
+        Preferences node = Preferences.userRoot().node("dd-isolation-check");
+
+        assertNull(node.get("written-by-a-previous-run", null),
+                   "preferences should not survive from an earlier JVM");
+
+        node.put("key", "value");
+        assertEquals("value", node.get("key", null));
+
+        node.removeNode();
+    }
+}

--- a/code/gui/src/main/java/com/donohoedigital/gui/BaseApp.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/BaseApp.java
@@ -46,7 +46,8 @@ import java.util.Locale;
 
 public abstract class BaseApp
 {
-    private final Logger logger = LogManager.getLogger(BaseApp.class);
+    // assigned in the constructor, not here - see the note there
+    private final Logger logger;
 
     static Thread mainThread_ = null;
     protected static BaseApp app_ = null;
@@ -58,7 +59,7 @@ public abstract class BaseApp
     protected String sAppName;
 
     private boolean bReady_ = false;
-    private String sVersionString;
+    private final String sVersionString;
     private final String[] args;
 
     public BaseApp(String sAppName, String sVersionString, String[] args)
@@ -69,9 +70,25 @@ public abstract class BaseApp
     @SuppressWarnings({"AssignmentToStaticFieldFromInstanceMethod", "ThisEscapedInObjectConstruction"})
     public BaseApp(String sAppName, String sVersionString, String[] args, boolean bHeadless)
     {
+        bHeadless_ = bHeadless;
+        this.sAppName = sAppName;
+        this.sVersionString = (sVersionString == null) ? "" : sVersionString;
+        this.args = args;
+
+        // Initialize logging before anything else.  LoggingConfig shuts log4j down and
+        // replaces its configuration, so any logger obtained before this point is left
+        // disabled - which is why this does not live in a static initializer, and why our
+        // own logger is assigned here rather than in its declaration.  Subclass loggers
+        // are safe: instance initializers run after this constructor body.
+        //
+        // The version string picks the log directory, so it has to be set first.
+        Utils.setVersionString(this.sVersionString); // keep in sync with FileCleanup
+        new LoggingConfig(sAppName, bHeadless ? ApplicationType.HEADLESS_CLIENT
+                                              : ApplicationType.CLIENT).init();
+        logger = LogManager.getLogger(BaseApp.class);
+
         mainThread_ = Thread.currentThread();
         app_ = this;
-        bHeadless_ = bHeadless;
 
         //
         // If Mac, we need to instantiate by name the Mac application class
@@ -82,10 +99,6 @@ public abstract class BaseApp
             setupMac();
             Utils.sleepMillis(500); // BUG 266 - allow for this to register so we can get app events
         }
-
-        this.sAppName = sAppName;
-        this.sVersionString = sVersionString;
-        this.args = args;
     }
 
     private void setupMac() {
@@ -165,9 +178,8 @@ public abstract class BaseApp
         // set locale
         Locale.setDefault(PropertyConfig.getLocale(sLocale_));
 
-        // set version string items
-        if (sVersionString == null) sVersionString = "";
-        Utils.setVersionString(sVersionString); // keep in sync with FileCleanup
+        // set version string items (Utils.setVersionString() was done in the constructor,
+        // since logging needs it to pick the log directory)
         Prefs.setRootNodeName(sAppName + sVersionString); // keep in sync with FileCleanup
 
         // preinit

--- a/code/gui/src/main/java/com/donohoedigital/gui/BaseApp.java
+++ b/code/gui/src/main/java/com/donohoedigital/gui/BaseApp.java
@@ -44,7 +44,6 @@ import java.awt.Desktop;
 import java.awt.Graphics;
 import java.util.Locale;
 
-@SuppressWarnings("CommentedOutCode")
 public abstract class BaseApp
 {
     private final Logger logger = LogManager.getLogger(BaseApp.class);
@@ -75,7 +74,7 @@ public abstract class BaseApp
         bHeadless_ = bHeadless;
 
         //
-        // If mac, we need to instantiate by name the mac application class
+        // If Mac, we need to instantiate by name the Mac application class
         // we do this so we can compile this on all platforms
         //
         if (Utils.ISMAC && !bHeadless)
@@ -94,23 +93,23 @@ public abstract class BaseApp
         if (Desktop.isDesktopSupported()) {
             Desktop desktop = Desktop.getDesktop();
 
-            desktop.setAboutHandler(e -> {
+            desktop.setAboutHandler(_ -> {
                 if (!app_.isReady()) return;
                 app_.showAbout();
             });
 
             desktop.setOpenFileHandler(e -> {
                 if (!e.getFiles().isEmpty()) {
-                    CommandLine.setMacFileArg(e.getFiles().get(0).getAbsolutePath());
+                    CommandLine.setMacFileArg(e.getFiles().getFirst().getAbsolutePath());
                 }
             });
 
-            desktop.setPreferencesHandler(e -> {
+            desktop.setPreferencesHandler(_ -> {
                 if (!app_.isReady()) return;
                 app_.showPrefs();
             });
 
-            desktop.setQuitHandler((e, response) -> {
+            desktop.setQuitHandler((_, response) -> {
                 if (app_.isReady()) {
                     app_.quit();
                     response.cancelQuit();  // Indicates that app handles quit
@@ -140,7 +139,6 @@ public abstract class BaseApp
      */
     private void setupStandardCommandLineOptions()
     {
-
         CommandLine.setUsage(getClass().getName() + " [options]");
 
         CommandLine.addStringOption("module", null);
@@ -336,26 +334,4 @@ public abstract class BaseApp
     {
         return getBaseApp().frame_.getGraphics();
     }
-
-//    ////
-//    //// Debugging help
-//    ////
-//    private void printAllModes()
-//    {
-//        DisplayMode mode = frame_.getDisplayMode();
-//        printMode("Current", mode);
-//        DisplayMode modes[] = frame_.getDisplayModes();
-//        for (int i = 0; i < modes.length; i++)
-//        {
-//            if (modes[i].getRefreshRate() != mode.getRefreshRate()) continue;
-//            if (modes[i].getBitDepth() != mode.getBitDepth()) continue;
-//            printMode("#"+i,modes[i]);
-//        }
-//    }
-//
-//    private void printMode(String sName, DisplayMode mode)
-//    {
-//        logger.debug("Mode " + sName + ": " + mode.getWidth() + "x" + mode.getHeight() +
-//                    " " + mode.getRefreshRate() + "mhz " + mode.getBitDepth() + "bits");
-//    }
 }

--- a/code/poker/pom.xml
+++ b/code/poker/pom.xml
@@ -104,7 +104,6 @@
           <executable>${java.home}/bin/java</executable>
           <arguments>
             <argument>-Dfile.encoding=UTF-8</argument>
-            <argument>-Dsun.java2d.noddraw=true</argument>
             <argument>-Dlog4j.rootLogger=DEBUG, Console</argument>
             <argument>-Xms32m</argument>
             <argument>-Xmx512m</argument>

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -84,29 +84,23 @@ import static com.donohoedigital.config.DebugConfig.TESTING;
 public class PokerMain extends GameEngine implements Peer2PeerControllerInterface, LanControllerInterface,
                                                      UDPLinkHandler, UDPManagerMonitor, UDPLinkMonitor
 {
-    private static final Logger logger;
+    // assigned in the constructor, after BaseApp has configured logging
+    private static Logger logger;
 
     private static final String APP_NAME = "poker";
     private String sFileParam_ = null;
     private final boolean bLoadNames;
 
     static {
-        // forget why I set this
-        System.setProperty("sun.java2d.noddraw", "true");
-
         // Mac: Menu Name
-        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "DD Poker"); // TODO + version?
-        System.setProperty("apple.awt.application.name", "DD Poker"); // TODO + version?
+        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "DD Poker");
+        System.setProperty("apple.awt.application.name", "DD Poker");
 
-        // avoid java.lang.NullPointerException
-        //	at javax.swing.plaf.metal.MetalSliderUI.installUI(MetalSliderUI.java:110)
+        // Selects our look and feel - nothing calls UIManager.setLookAndFeel(), so this
+        // property is what installs Metal.  Load-bearing beyond appearance: DDSliderUI
+        // extends MetalSliderUI and the title pane code reads MetalLookAndFeel theme
+        // colors, so without Metal installed MetalSliderUI.installUI() throws NPE.
         System.setProperty("swing.defaultlaf", "javax.swing.plaf.metal.MetalLookAndFeel");
-
-        // initialize logging before anything else (need version string for log file directory)
-        Utils.setVersionString(PokerConstants.VERSION.getMajorAsString());
-        LoggingConfig loggingConfig = new LoggingConfig(APP_NAME, ApplicationType.CLIENT);
-        loggingConfig.init();
-        logger = LogManager.getLogger(PokerMain.class);
     }
 
     /**
@@ -165,6 +159,7 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
             throws ApplicationError
     {
         super(sConfigName, sMainModule, PokerConstants.VERSION.getMajorAsString(), args, bHeadless);
+        logger = LogManager.getLogger(PokerMain.class); // super() configured logging
         this.bLoadNames = bLoadNames;
     }
 

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -68,6 +68,7 @@ import javax.swing.SwingUtilities;
 import java.awt.Dimension;
 import java.awt.DisplayMode;
 import java.io.*;
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.channels.SocketChannel;
 import java.sql.SQLException;
@@ -670,8 +671,26 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
      */
     public PokerConnectionServer getPokerConnectionServer(PokerConnection connection)
     {
-        if (connection == null) return p2p_;
-        return connection.isUDP() ? udp_ : tcp_;
+        if (connection == null) return gameServer();
+        return connection.isUDP() ? udpServer() : tcpServer();
+    }
+
+    // the three servers, read through methods so a test can supply them without binding
+    // a socket.  The routing above is the part worth testing and stays here.
+
+    PokerConnectionServer udpServer()
+    {
+        return udp_;
+    }
+
+    PokerConnectionServer tcpServer()
+    {
+        return tcp_;
+    }
+
+    PokerConnectionServer gameServer()
+    {
+        return p2p_;
     }
 
     /**
@@ -757,6 +776,11 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
         public DDMessageTransporter newMessage(DDMessage msg)
         {
             return new Peer2PeerMessage(Peer2PeerMessage.P2P_MSG, msg);
+        }
+
+        public boolean isUDP()
+        {
+            return false;
         }
     }
 
@@ -993,11 +1017,16 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
                     {
                         if (chatHandler_ != null) chatHandler_.chatReceived(new OnlineMessage(msg.getMessage()));
                     }
-                    // a hello is something we send to the chat server, never something we
-                    // receive - a stray one has no business reaching game code
+                    // a hello is something we send to a chat server, never something we
+                    // receive.  Say so rather than leaving the sender to time out - this
+                    // happens when someone's chat server address points at a game client.
                     else if (data.getUserType() == PokerConstants.USERTYPE_HELLO)
                     {
-                        logger.warn("Ignoring unexpected hello from {}: {}", link.toStringNameIP(), data.toStringShort());
+                        logger.warn("Hello received from {} - this client is not a chat lobby: {}",
+                                    link.toStringNameIP(), data.toStringShort());
+                        link.queue(notChatLobbyReply(link.getLocalIP()).getData(), PokerConstants.USERTYPE_CHAT);
+                        link.send(); // send right away
+                        link.close();
                     }
                     else
                     {
@@ -1025,6 +1054,27 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
                 }
                 break;
         }
+    }
+
+    /**
+     * Reply telling a sender that this client is not a chat lobby server.
+     * <p/>
+     * Same shape as ChatServer.sendError(): an admin chat tagged CHAT_ADMIN_ERROR, which
+     * the receiving client already knows how to handle - OnlineLobby.chatReceived()
+     * displays the text and removes the chat input controls.  No new message type needed.
+     * <p/>
+     * The address named is the local one the datagram arrived on - which is the value the
+     * sender has wrong in their options, so it is the one worth showing them.  It tells
+     * them nothing they did not already have, since they just sent a packet to it.  Use
+     * the link's own local address rather than getPreferredIP(), which reports the first
+     * bound channel and would name the wrong port on anything that binds more than one.
+     */
+    static PokerUDPTransporter notChatLobbyReply(InetSocketAddress local)
+    {
+        OnlineMessage omsg = new OnlineMessage(OnlineMessage.CAT_CHAT_ADMIN);
+        omsg.setChat(PropertyConfig.getMessage("msg.chat.notlobby", Utils.getAddressPort(local)));
+        omsg.setChatType(PokerConstants.CHAT_ADMIN_ERROR);
+        return new PokerUDPTransporter(omsg.getData());
     }
 
     /**

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -661,6 +661,20 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
     }
 
     /**
+     * Get the connection server matching the transport a message arrived on.  Unlike
+     * {@link #getPokerConnectionServer(boolean)}, this never creates or shuts down a
+     * server - it just names the one the message came in on.  A message can arrive on a
+     * transport other than the one the game is using (the chat lobby is always UDP, while
+     * a hosted game is usually TCP), so replies must be built with the transport they are
+     * going back out on.  Returns null if that server no longer exists.
+     */
+    public PokerConnectionServer getPokerConnectionServer(PokerConnection connection)
+    {
+        if (connection == null) return p2p_;
+        return connection.isUDP() ? udp_ : tcp_;
+    }
+
+    /**
      * get chat server
      */
     public PokerUDPServer getChatServer()
@@ -788,21 +802,23 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
         // if no online manager, return error
         if (mgr == null)
         {
-            // possibly disappeared in the interim
-            if (p2p_ == null) return null;
+            // reply on the transport the message arrived on, which is not necessarily
+            // the one the game is using - possibly disappeared in the interim
+            PokerConnectionServer p2p = getPokerConnectionServer(connection);
+            if (p2p == null) return null;
 
-            OnlineMessage omsg = new OnlineMessage(msg.getMessage());
+            OnlineMessage omsg = new OnlineMessage(msg.getMessage(), connection);
 
             // reply like Online Manager, but with bogus guid
             // so server test responds with appropriate message
             if (omsg.getCategory() == OnlineMessage.CAT_TEST) {
-                return OnlineManager.getTestReply(p2p_, "guid-no-online-game", omsg);
+                return OnlineManager.getTestReply(p2p, "guid-no-online-game", omsg);
             }
 
             // respond to any other type of message with same response,
             // as if someone was trying to join
             //logger.warn("Message received with no OnlineManager: " + msg);
-            return OnlineManager.getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.nogame"), false);
+            return OnlineManager.getAppErrorReply(p2p, omsg, PropertyConfig.getMessage("msg.nojoin.nogame"), false);
         }
         else
         {
@@ -827,9 +843,9 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
     }
 
 
-    ////
-    //// Peer2PeerControllerInterface (TCP)
-    ////
+    //
+    // Peer2PeerControllerInterface (TCP)
+    //
 
     /**
      * Handle p2p message received - hand off to OnlineManager
@@ -879,7 +895,6 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
     public void monitorEvent(UDPLinkEvent event)
     {
         PokerUDPTransporter msg;
-        PokerUDPTransporter reply;
 
         UDPLink link = event.getLink();
         long elapsed = event.getElapsed();
@@ -978,10 +993,16 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
                     {
                         if (chatHandler_ != null) chatHandler_.chatReceived(new OnlineMessage(msg.getMessage()));
                     }
+                    // a hello is something we send to the chat server, never something we
+                    // receive - a stray one has no business reaching game code
+                    else if (data.getUserType() == PokerConstants.USERTYPE_HELLO)
+                    {
+                        logger.warn("Ignoring unexpected hello from {}: {}", link.toStringNameIP(), data.toStringShort());
+                    }
                     else
                     {
-                        reply = (PokerUDPTransporter) messageReceived(new PokerConnection(link.getID()), msg);
-                        if (reply != null)
+                        DDMessageTransporter received = messageReceived(new PokerConnection(link.getID()), msg);
+                        if (received instanceof PokerUDPTransporter reply)
                         {
                             link.queue(reply.getData());
                             link.send(); // send right away
@@ -989,6 +1010,11 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
                             {
                                 link.close();
                             }
+                        }
+                        else if (received != null)
+                        {
+                            logger.warn("Reply to UDP message from {} was built with the wrong transport ({}), dropping it",
+                                        link.toStringNameIP(), received.getClass().getName());
                         }
                     }
                 }
@@ -1061,10 +1087,8 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
         }
     }
 
-    ////
-    //// LanControllerInterface methods
-    ////
-
+    //
+    // LanControllerInterface methods
     //
     // Interface methods implemented by super class:
     //

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerMain.java
@@ -1010,7 +1010,18 @@ public class PokerMain extends GameEngine implements Peer2PeerControllerInterfac
 
                     if (data.getUserType() == PokerConstants.USERTYPE_CHAT)
                     {
-                        if (chatHandler_ != null) chatHandler_.chatReceived(new OnlineMessage(msg.getMessage()));
+                        // only the chat server we connected to may put text in the lobby.
+                        // Without this, anything that can reach us can inject chat - which
+                        // is how one game client ended up acting as another client's chat
+                        // server, and why that looked like a chat bug for so long.
+                        if (link != udp_.getChatLink())
+                        {
+                            logger.warn("Ignoring chat from {} - not the chat server link", link.toStringNameIP());
+                        }
+                        else if (chatHandler_ != null)
+                        {
+                            chatHandler_.chatReceived(new OnlineMessage(msg.getMessage()));
+                        }
                     }
                     // a hello is something we send to a chat server, never something we
                     // receive.  Say so rather than leaving the sender to time out - this

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerUDPServer.java
@@ -148,6 +148,11 @@ public class PokerUDPServer extends UDPServer implements PokerConnectionServer, 
         return new PokerUDPTransporter(msg);
     }
 
+    public boolean isUDP()
+    {
+        return true;
+    }
+
     public void sendChat(PlayerProfile profile, String sMessage)
     {
         OnlineMessage omsg;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
@@ -77,7 +77,6 @@ import java.util.List;
 import java.util.Set;
 
 import static com.donohoedigital.config.DebugConfig.TESTING;
-import static com.donohoedigital.config.DebugConfig.isTestingOn;
 
 /**
  * @author donohoe
@@ -194,12 +193,7 @@ public class OnlineManager implements ChatManager
             // log socket closing
             if (game_.getOnlineMode() != PokerGame.MODE_CANCELLED)
             {
-                logger.info("Connection closed for " +
-                            player.getName() + " [id #" + player.getID() + "] " +
-                            (player.isHost() ? " (host)" : "") +
-                            (player.isObserver() ? " (observer)" : "") +
-                            ": " +
-                            connection);
+                logger.info("Connection closed for {} [id #{}] {}{}: {}", player.getName(), player.getID(), player.isHost() ? " (host)" : "", player.isObserver() ? " (observer)" : "", connection);
             }
 
             // set socket null
@@ -246,7 +240,7 @@ public class OnlineManager implements ChatManager
         OnlineMessage omsg = new OnlineMessage(msg.getMessage(), channel); // received
         final DDMessageTransporter reply;
 
-        if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** RECEIVED **: " + msg);
+        if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** RECEIVED **: {}", msg);
 
         try
         {
@@ -254,12 +248,12 @@ public class OnlineManager implements ChatManager
         }
         catch (OnlineError error)
         {
-            if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** ERROR REPLY **: " + error.getReply());
+            if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** ERROR REPLY **: {}", error.getReply());
             return error.getReply();
         }
 
         // debug
-        if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** REPLY **: " + reply);
+        if (TESTING(EngineConstants.TESTING_P2P)) logger.debug("** REPLY **: {}", reply);
 
         // no exception, so notify listeners
         fireAction(omsg);
@@ -299,10 +293,9 @@ public class OnlineManager implements ChatManager
         {
             //noinspection AssignmentToStaticFieldFromInstanceMethod
             RCNT++;
-            if (DEBUG || omsg.getCategory() != OnlineMessage.CAT_CHAT)
+            if (omsg.getCategory() != OnlineMessage.CAT_CHAT)
             {
-                logger.debug(RCNT + " received from " + (from == null ? "[unknown]" : from.getName()) +
-                             ": " + omsg.toStringCategorySize());
+                logger.debug("{} received from {}: {}", RCNT, from == null ? "[unknown]" : from.getName(), omsg.toStringCategorySize());
             }
         }
 
@@ -310,7 +303,7 @@ public class OnlineManager implements ChatManager
         switch (omsg.getCategory())
         {
             case OnlineMessage.CAT_TEST:
-                reply = getTestReply(p2p_, main_.getGUID(), omsg);
+                reply = getTestReply(replyServer(omsg), main_.getGUID(), omsg);
                 break;
 
             case OnlineMessage.CAT_ALIVE:
@@ -382,15 +375,15 @@ public class OnlineManager implements ChatManager
                 break;
 
             case DDMessage.CAT_APPL_ERROR:
-                logger.warn("OnlineManager app error: " + omsg.getApplicationErrorMessage());
+                logger.warn("OnlineManager app error: {}", omsg.getApplicationErrorMessage());
                 break;
 
             case DDMessage.CAT_ERROR:
-                logger.warn("OnlineManager error: " + omsg.toStringNoData());
+                logger.warn("OnlineManager error: {}", omsg.toStringNoData());
                 break;
 
             default:
-                throw new OnlineError(getAppErrorReply(p2p_, omsg,
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg,
                                                        PropertyConfig.getMessage("msg.p2p.unhandled",
                                                                                  omsg.getCategory()), false));
         }
@@ -416,8 +409,8 @@ public class OnlineManager implements ChatManager
         if (!gpass.equals(mpass) || !gid.equals(mid))
         {
             String data = "Validation failed gid=" + gid + " gpass=" + gpass + " msg-gid=" + mid + " msg-gpass=" + mpass;
-            logger.info(data + " omsg: " + omsg.toStringNoData());
-            DDMessageTransporter reply = getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.p2p.validate"), false);
+            logger.info("{} omsg: {}", data, omsg.toStringNoData());
+            DDMessageTransporter reply = getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.p2p.validate"), false);
             reply.getMessage().setString("x-validation-data", data);
             throw new OnlineError(reply);
         }
@@ -437,7 +430,7 @@ public class OnlineManager implements ChatManager
         Version msgVersion = omsg.getData().getVersion();
         if (msgVersion.isBefore(PokerConstants.VERSION_LAST_COMPAT))
         {
-            throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.version",
+            throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.version",
                                                                                          msgVersion.toString(),
                                                                                          PokerConstants.VERSION_LAST_COMPAT.toString()),
                                                    false));
@@ -447,16 +440,15 @@ public class OnlineManager implements ChatManager
         switch (nMode)
         {
             case PokerGame.MODE_INIT:
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.init"),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.init"),
                                                        false));
 
             case PokerGame.MODE_REG:
             case PokerGame.MODE_PLAY:
                 break; // handle below
 
-
             default:
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.nomore"),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.nomore"),
                                                        false));
         }
 
@@ -471,7 +463,7 @@ public class OnlineManager implements ChatManager
             // host can't join again
             if (player.isHost())
             {
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.dup", player.getName()),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.dup", player.getName()),
                                                        false));
             }
 
@@ -488,7 +480,7 @@ public class OnlineManager implements ChatManager
                 // set (from HostStatus)
                 // 2.5 - added reg, same connect logic
                 if (nMode == PokerGame.MODE_PLAY || omsg.isReconnect() ||
-                    (nMode == PokerGame.MODE_REG && bSameConnect))
+                        /* PokerGame.MODE_REG */ bSameConnect)
                 {
                     // if connection is different, close it
                     //
@@ -496,7 +488,7 @@ public class OnlineManager implements ChatManager
                     // TCP: use of equals check doesn't change functionality since sockets aren't re-used
                     if (!bSameConnect)
                     {
-                        logger.info("Player rejoining: " + player.getName() + ", closing existing, likely bad, connection");
+                        logger.info("Player rejoining: {}, closing existing, likely bad, connection", player.getName());
                         PokerConnection c = player.getConnection();
 
                         // synchronize with sends so we don't kill
@@ -511,12 +503,12 @@ public class OnlineManager implements ChatManager
                     else
                     {
                         player.addDisconnect(); // disconnection perceived on players end
-                        logger.info("Player rejoining: " + player.getName() + ", on existing connection");
+                        logger.info("Player rejoining: {}, on existing connection", player.getName());
                     }
                 }
                 else
                 {
-                    throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.dup", player.getName()),
+                    throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.dup", player.getName()),
                                                            false));
                 }
             }
@@ -533,7 +525,7 @@ public class OnlineManager implements ChatManager
             // See SAFETY check below.
             if (player.isObserver())
             {
-                logger.warn("processJoin() found existing player who is observer: " + player.getName());
+                logger.warn("processJoin() found existing player who is observer: {}", player.getName());
                 bObs = true; // and in case it does happen, need to set this flag
             }
             else if (player.isEliminated())
@@ -572,7 +564,7 @@ public class OnlineManager implements ChatManager
                 game_.addObserver(player);
             }
 
-            logger.info("Player rejoined: " + player.getName() + (bObs ? " [obs]" : ""));
+            logger.info("Player rejoined: {}{}", player.getName(), bObs ? " [obs]" : "");
             rejoin = true;
         }
         // new player coming in
@@ -589,7 +581,7 @@ public class OnlineManager implements ChatManager
             // if player is demo, check if profile allows demo players
             if (omsg.isPlayerDemo() && !profile.isAllowDemo())
             {
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.demo"),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.demo"),
                                                        false));
             }
 
@@ -597,7 +589,7 @@ public class OnlineManager implements ChatManager
             if ((banned_.containsPlayer(sPlayerName) || banned_.containsKey(omsg.getKey())) && !bAllowObsSpecial)
             {
                 sendRejectMessage(sPlayerName, "msg.chat.bannedrejected");
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.banned"),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.banned"),
                                                        false));
             }
 
@@ -605,7 +597,7 @@ public class OnlineManager implements ChatManager
             if (!bObs && profile.isInviteOnly() && !profile.getInvitees().containsPlayer(sPlayerName) && !bAllowObsSpecial)
             {
                 sendRejectMessage(sPlayerName, "msg.chat.uninvitedrejected");
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage(
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage(
                         profile.isInviteObserversPublic() ?
                         "msg.nojoin.inviteonly.obs" : "msg.nojoin.inviteonly"),
                                                        false));
@@ -616,7 +608,7 @@ public class OnlineManager implements ChatManager
                 !profile.getInvitees().containsPlayer(sPlayerName) && !bAllowObsSpecial)
             {
                 sendRejectMessage(sPlayerName, "msg.chat.uninvitedrejected");
-                throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.inviteonly"),
+                throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.inviteonly"),
                                                        false));
             }
 
@@ -630,7 +622,7 @@ public class OnlineManager implements ChatManager
                     exist = game_.getPokerPlayerAt(i);
                     if (exist.isOnlineActivated() && exist.getName().equals(sPlayerName))
                     {
-                        throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.duponline",
+                        throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.duponline",
                                                                                                      Utils.encodeHTML(exist.getName())),
                                                                false));
                     }
@@ -641,7 +633,7 @@ public class OnlineManager implements ChatManager
                     exist = game_.getPokerObserverAt(i);
                     if (exist.isOnlineActivated() && exist.getName().equals(sPlayerName))
                     {
-                        throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.duponline",
+                        throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.duponline",
                                                                                                      Utils.encodeHTML(exist.getName())),
                                                                false));
                     }
@@ -653,7 +645,7 @@ public class OnlineManager implements ChatManager
                 if (profile.isOnlineActivatedPlayersOnly())
                 {
                     sendRejectMessage(sPlayerName, "msg.chat.impostorrejected");
-                    throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.onlineactivatedonly"),
+                    throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.onlineactivatedonly"),
                                                            false));
                 }
             }
@@ -661,21 +653,21 @@ public class OnlineManager implements ChatManager
             // player
             if (!bObs)
             {
-                ////
-                //// NOTE: CHANGES HERE MUST BE REFLECTED IN switchPlayer() below
-                ////
+                //
+                // NOTE: CHANGES HERE MUST BE REFLECTED IN switchPlayer() below
+                //
 
                 // if no existing player in PLAY mode, then don't allow new join (already playing)
                 if (nMode == PokerGame.MODE_PLAY)
                 {
-                    throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.started"),
+                    throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.started"),
                                                            false));
                 }
 
                 // check max players
                 if (!isSpaceForPlayer())
                 {
-                    throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.nomore",
+                    throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.nomore",
                                                                                                  profile.getMaxOnlinePlayers()),
                                                            false));
                 }
@@ -696,14 +688,14 @@ public class OnlineManager implements ChatManager
             // observer
             else
             {
-                ////
-                //// NOTE: CHANGES HERE MUST BE REFLECTED IN switchPlayer() below
-                ////
+                //
+                // NOTE: CHANGES HERE MUST BE REFLECTED IN switchPlayer() below
+                //
 
                 // check max observers - subtract busted players from the count
                 if (!isSpaceForObserver() && !bAllowObsSpecial)
                 {
-                    throw new OnlineError(getAppErrorReply(p2p_, omsg, PropertyConfig.getMessage("msg.nojoin.nomore.obs",
+                    throw new OnlineError(getAppErrorReply(replyServer(omsg), omsg, PropertyConfig.getMessage("msg.nojoin.nomore.obs",
                                                                                                  profile.getMaxObservers()),
                                                            false));
                 }
@@ -1097,9 +1089,9 @@ public class OnlineManager implements ChatManager
         EngineUtils.cancelCancelables();
     }
 
-    ////
-    //// game update
-    ////
+    //
+    // game update
+    //
 
     /**
      * send player/observer list to all
@@ -1297,9 +1289,9 @@ public class OnlineManager implements ChatManager
         }
     }
 
-    ////
-    //// client-side join
-    ////
+    //
+    // client-side join
+    //
 
     /**
      * Send message to host to join game - assumes the 'parent' PokerGame has
@@ -1319,8 +1311,8 @@ public class OnlineManager implements ChatManager
         msg.setPlayerProfilePath(local.getProfilePath());
         msg.setObserve(bObserve);
 
-        boolean bOK = false;
-        OnlineMessage reply = null;
+        boolean bOK;
+        OnlineMessage reply;
         DDMessage error = null;
 
         Peer2PeerMessenger msgr = null;
@@ -1451,7 +1443,7 @@ public class OnlineManager implements ChatManager
         }
         else
         {
-            game_.getLastGameState().getFile().delete();
+            boolean ignore = game_.getLastGameState().getFile().delete();
         }
 
         // close all sockets
@@ -1566,7 +1558,7 @@ public class OnlineManager implements ChatManager
         // upon re-join (TD clears last timeout in start()).
         if (timeSinceLastMsg > ALIVE_TIMEOUT_MILLIS && last != 0 && player.getConnection() != null)
         {
-            logger.info("Alive timeout for " + player.getName() + ", forcing socket closed.");
+            logger.info("Alive timeout for {}, forcing socket closed.", player.getName());
             connectionClosing(player.getConnection());
         }
     }
@@ -1625,7 +1617,7 @@ public class OnlineManager implements ChatManager
     /**
      * Received on client from host when join is accepted
      */
-    private DDMessageTransporter processClientJoin(OnlineMessage omsg)
+    private void processClientJoin(OnlineMessage omsg)
     {
         // load game from data (this replaces temp player)
         loadGame(omsg, game_);
@@ -1649,13 +1641,11 @@ public class OnlineManager implements ChatManager
         // if reconnect, this sends ready message and causes resync
         // on initial connect, does nothing (waits for setTournamentDirector to be set)
         sendReadyMessage(true);
-
-        return null;
     }
 
-    ////
-    //// TournamentDirector related methods
-    ////
+    //
+    // TournamentDirector related methods
+    //
 
     /**
      * Set the TournamentDirector in use.  If game updates
@@ -1709,9 +1699,8 @@ public class OnlineManager implements ChatManager
             int nNum = tdQueue_.size();
             if (td_ != null && nNum > 0)
             {
-                for (int i = 0; i < nNum; i++)
-                {
-                    _processGameUpdate(tdQueue_.get(i));
+                for (OnlineMessage onlineMessage : tdQueue_) {
+                    _processGameUpdate(onlineMessage);
                 }
                 tdQueue_.clear();
             }
@@ -1754,7 +1743,7 @@ public class OnlineManager implements ChatManager
         // poker table display)
         synchronized (tdQueue_)
         {
-            if (td_ != null || (td_ == null && !omsg.isRunProcessTable()))
+            if (td_ != null || !omsg.isRunProcessTable())
             {
                 _processGameUpdate(omsg);
             }
@@ -1797,11 +1786,9 @@ public class OnlineManager implements ChatManager
         if (events != null)
         {
             PokerTableEvent event;
-            int nNum = events.size();
-            for (int i = 0; i < nNum; i++)
-            {
-                event = events.get(i);
-                if (TournamentDirector.DEBUG_EVENT) logger.debug("Firing event: " + event);
+            for (PokerTableEvent pokerTableEvent : events) {
+                event = pokerTableEvent;
+                if (TournamentDirector.DEBUG_EVENT) logger.debug("Firing event: {}", event);
                 event.getTable().firePokerTableEvent(event);
             }
         }
@@ -2018,9 +2005,9 @@ public class OnlineManager implements ChatManager
         td_.doRebuy(player, omsg.getLevel(), omsg.getCash(), omsg.getChips(), omsg.isPending());
     }
 
-    ////
-    //// save/load game utility
-    ////
+    //
+    // save/load game utility
+    //
 
     /**
      * Marshal the game into a string and store it with this message.
@@ -2045,9 +2032,9 @@ public class OnlineManager implements ChatManager
         game.loadGame(state, false);
     }
 
-    ////
-    //// chat
-    ////
+    //
+    // chat
+    //
 
     /**
      * Send chat (called from ChatPanel).  If table is specified,
@@ -2261,8 +2248,7 @@ public class OnlineManager implements ChatManager
                 PokerTable table = game_.getTableByNumber(nTableNum);
                 if (table == null)
                 {
-                    logger.warn("No table found for table num (" + nTableNum + ") to deliver chat: " + chat.getChat() + ", from-id: " +
-                                chat.getFromPlayerID() + ", chat-type: " + chat.getChatType());
+                    logger.warn("No table found for table num ({}) to deliver chat: {}, from-id: {}, chat-type: {}", nTableNum, chat.getChat(), chat.getFromPlayerID(), chat.getChatType());
                     return;
                 }
                 if (!table.isCurrent()) return;
@@ -2293,21 +2279,12 @@ public class OnlineManager implements ChatManager
 
             if (chat_ != null && nNum > 0)
             {
-                for (int i = 0; i < nNum; i++)
-                {
-                    chat_.chatReceived(chatQueue_.get(i));
+                for (OnlineMessage onlineMessage : chatQueue_) {
+                    chat_.chatReceived(onlineMessage);
                 }
                 chatQueue_.clear();
             }
         }
-    }
-
-    /**
-     * display dealer chat local
-     */
-    public void sendDealerChatLocal(int nType, String sMessage)
-    {
-        deliverChatLocal(nType, sMessage, OnlineMessage.CHAT_DEALER_MSG_ID);
     }
 
     /**
@@ -2327,9 +2304,9 @@ public class OnlineManager implements ChatManager
         }
     }
 
-    ////
-    //// Helper methods
-    ////
+    //
+    // Helper methods
+    //
 
     /**
      * Get player from id in message
@@ -2346,7 +2323,7 @@ public class OnlineManager implements ChatManager
             }
             else
             {
-                logger.warn("No player found for id in message: " + omsg);
+                logger.warn("No player found for id in message: {}", omsg);
             }
         }
         return player;
@@ -2388,7 +2365,7 @@ public class OnlineManager implements ChatManager
      */
     private void sendMessageAll(OnlineMessage omsg)
     {
-        sendMessageAllExcept(omsg, null, false);
+        sendMessageAll(omsg, false);
     }
 
     /**
@@ -2482,7 +2459,7 @@ public class OnlineManager implements ChatManager
         {
             if (pTo.isHost() && pTo == getLocalPlayer())
             {
-                logger.warn("Attempting to send message from host to host " + omsg.toStringNoData());
+                logger.warn("Attempting to send message from host to host {}", omsg.toStringNoData());
             }
             else if (pTo.isEliminated())
             {
@@ -2516,6 +2493,19 @@ public class OnlineManager implements ChatManager
                 udp.closeConnection(pc);
             }
         }
+    }
+
+    /**
+     * Connection server to build a reply to the given message with.  A message does not
+     * always arrive on the transport the game is using - the chat lobby is always UDP,
+     * while a hosted game is TCP unless testing turns UDP on - so a reply built from
+     * p2p_ can be of a type the arriving link cannot send.  Falls back to p2p_ for
+     * messages we created ourselves, which carry no connection.
+     */
+    private PokerConnectionServer replyServer(OnlineMessage omsg)
+    {
+        PokerConnectionServer p2p = main_.getPokerConnectionServer(omsg.getConnection());
+        return p2p != null ? p2p : p2p_;
     }
 
     /**
@@ -2651,16 +2641,16 @@ public class OnlineManager implements ChatManager
         }
     }
 
-    ////
-    //// For handling errors
-    ////
+    //
+    // For handling errors
+    //
 
     /**
      * Methods throw this error with the message to return
      */
     private static final class OnlineError extends RuntimeException
     {
-        private DDMessageTransporter reply;
+        private final DDMessageTransporter reply;
 
         private OnlineError(DDMessageTransporter reply)
         {

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/online/OnlineManager.java
@@ -114,17 +114,30 @@ public class OnlineManager implements ChatManager
      */
     public OnlineManager(PokerGame game)
     {
+        this(game, PokerMain.getPokerMain(), null, game.getLocalPlayer());
+    }
+
+    /**
+     * Test seam - takes the engine, the transport and the local player rather than
+     * resolving them through the GameEngine singleton and the license key.  A null p2p
+     * means "ask main_", which is what the production constructor above does.
+     * <p/>
+     * Follows the PokerDatabase.init(profile, saveDir) precedent: a parameterised form of
+     * what the real constructor looks up for itself.
+     */
+    OnlineManager(PokerGame game, PokerMain main, PokerConnectionServer p2p, PokerPlayer local)
+    {
         //logger.debug("Starting online manager");
         game_ = game;
         context_ = game_.getGameContext();
-        main_ = PokerMain.getPokerMain();
-        p2p_ = main_.getPokerConnectionServer(game.isUDP());
+        main_ = main;
+        p2p_ = (p2p != null) ? p2p : main_.getPokerConnectionServer(game.isUDP());
 
         // note that we don't store the local player since that can get
         // reloaded with game updates.  However, the "host" status will
         // not change from inception (TODO: if we allow host migration,
         // this will obviously change)
-        bHost_ = getLocalPlayer().isHost();
+        bHost_ = local.isHost();
         if (bHost_) banned_ = PokerPrefsPlayerList.getSharedList(PokerPrefsPlayerList.LIST_BANNED);
 
         // online queue for sending messages (TCP only)
@@ -160,7 +173,7 @@ public class OnlineManager implements ChatManager
      */
     public boolean isUDP()
     {
-        return p2p_ instanceof UDPServer;
+        return p2p_ != null && p2p_.isUDP();
     }
 
     // listener for host connection
@@ -2539,7 +2552,7 @@ public class OnlineManager implements ChatManager
         omsg.setInReplyTo(in.getMessageID());
 
         // sleep briefly in udp mode so connection shows up on UDPStatus
-        if (p2p instanceof UDPServer)
+        if (p2p.isUDP())
         {
             Utils.sleepMillis(100);
         }

--- a/code/poker/src/main/resources/config/poker/client.properties
+++ b/code/poker/src/main/resources/config/poker/client.properties
@@ -1657,6 +1657,9 @@ msg.chat.lobby.notbound=	Unable to create UDP connection to DD Poker Chat Server
 msg.chat.lobby.lost=		Connection to the DD Poker Chat Server was lost.
 msg.chat.lobby.timeout=		Timed out connecting to the DD Poker Chat Server.
 
+msg.chat.notlobby=			<font color=blue>{0}</font> is a DD Poker game client, not a chat server.  Check \
+							the chat server address in Options -> Online -> Public Online Servers.
+
 msg.chat.lobby.unavail=		{0}  This can happen if:<BR><BR>\
 									<TABLE CELLSPACING=0 CELLPADDING=0>\
 									<TR><TD WIDTH=25 ALIGN=CENTER><B>+</B></TD><TD>A firewall is preventing outbound UDP connections on port {1}</TD></TR>\

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/AbstractPokerTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/AbstractPokerTest.java
@@ -1,0 +1,150 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.config.ApplicationType;
+import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.comms.DDMessage;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.model.TournamentProfile;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Shared setup for tests that need a tournament with players in it.
+ * <p/>
+ * Everything here runs headless: no GUI, no GameContext, no filesystem, no database.
+ * PokerGame's GameContext constructor accepts null, which is what keeps it that way -
+ * the no-arg constructor would reach for GameEngine.getGameEngine().getDefaultContext().
+ * <p/>
+ * The factory methods carry comments explaining the non-obvious calls.  They were learned
+ * the hard way; leave them in place.
+ */
+public abstract class AbstractPokerTest
+{
+    protected PokerGame game_;
+
+    /**
+     * One per JVM.  GameEngine's constructor sets its engine_ singleton and nothing ever
+     * clears it, so building a second one would leave the first unreachable but still
+     * "current" for anything that already captured it.
+     */
+    private static TestPokerMain engine_;
+
+    @BeforeEach
+    public void setUpGame()
+    {
+        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
+        game_ = new PokerGame(null);
+        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
+    }
+
+    /**
+     * The headless engine, with fake transports in place of real servers.  Constructing it
+     * also satisfies PokerMain.getPokerMain() for anything that reaches for the singleton.
+     */
+    protected static synchronized TestPokerMain engine()
+    {
+        if (engine_ == null)
+        {
+            // DDMessage stamps every message with this; it is null until someone sets it,
+            // and the join path reads it back with getVersion().isBefore(...)
+            if (DDMessage.getDefaultVersion() == null)
+            {
+                DDMessage.setDefaultVersion(PokerConstants.VERSION);
+            }
+            engine_ = new TestPokerMain();
+        }
+        engine_.reset();
+        return engine_;
+    }
+
+    /**
+     * Put a player in the tournament without seating them anywhere - which is also what a
+     * busted player looks like, once OtherTables.cleanTable() has removed them.
+     */
+    protected PokerPlayer add(int nId, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
+        p.setChipCount(nChips);
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * A table in this game.
+     */
+    protected PokerTable table(int nNum)
+    {
+        PokerTable t = new PokerTable(game_, nNum);
+        t.setMinChip(1); // HoldemHand.addToPot() divides by this
+        return t;
+    }
+
+    /**
+     * Seat a player, snapshotting their chips as the count at the start of the hand.
+     */
+    protected PokerPlayer seat(PokerTable table, int nSeat, int nId, int nChips)
+    {
+        return seat(table, nSeat, nId, "P" + nId, nChips);
+    }
+
+    /**
+     * Seat a named player, snapshotting their chips as the count at the start of the hand.
+     */
+    protected PokerPlayer seat(PokerTable table, int nSeat, int nId, String sName, int nChips)
+    {
+        PokerPlayer p = new PokerPlayer(nId, sName, true);
+        p.setChipCount(nChips);
+        p.newSimulatedHand(); // snapshots nChipsAtStart_
+        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
+        game_.addPlayer(p);
+        return p;
+    }
+
+    /**
+     * Put a hand in progress at the table, far enough along that chips can be committed.
+     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
+     * needs it before any bet is recorded.
+     * <p/>
+     * The button, and with it the blinds, has to land somewhere - which seat ends up
+     * posting depends on how many are seated, so callers that care say so for themselves.
+     */
+    protected HoldemHand startHand(PokerTable table)
+    {
+        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
+        HoldemHand hhand = new HoldemHand(table);
+        table.setHoldemHand(hhand);
+        hhand.deal();
+        return hhand;
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/ChatHelloTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/ChatHelloTest.java
@@ -1,0 +1,134 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.config.ApplicationType;
+import com.donohoedigital.config.ConfigManager;
+import com.donohoedigital.games.poker.engine.PokerConstants;
+import com.donohoedigital.games.poker.network.OnlineMessage;
+import com.donohoedigital.games.poker.network.PokerUDPTransporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A game client that receives a chat-lobby hello says so, instead of dropping it.
+ * <p/>
+ * This happens when someone's chat server address points at a game client rather than at
+ * the chat server - which is easy to do, because a client that fails to bind its
+ * configured UDP port drifts to the next one and can land on an address another client is
+ * pointed at.  Dropping the hello left that sender waiting out a timeout with no clue why.
+ * <p/>
+ * The reply reuses the chat server's own "go away" protocol rather than inventing one:
+ * ChatServer.sendError() sends a CHAT_ADMIN_ERROR admin chat and closes the link, and
+ * OnlineLobby.chatReceived() already displays it and removes the chat input controls.
+ */
+public class ChatHelloTest
+{
+    /** the address the stray hello arrived on - what the sender has wrong in their options */
+    private static final InetSocketAddress LOCAL = new InetSocketAddress("192.168.64.1", 11888);
+
+    @BeforeEach
+    public void setUp()
+    {
+        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
+    }
+
+    private OnlineMessage reply()
+    {
+        return new OnlineMessage(PokerMain.notChatLobbyReply(LOCAL).getMessage());
+    }
+
+    @Test
+    public void replyIsAnAdminErrorChat()
+    {
+        PokerUDPTransporter reply = PokerMain.notChatLobbyReply(LOCAL);
+        assertNotNull(reply);
+
+        OnlineMessage omsg = new OnlineMessage(reply.getMessage());
+        assertEquals(OnlineMessage.CAT_CHAT_ADMIN, omsg.getCategory(),
+                     "must be an admin chat so OnlineLobby routes it to the error branch");
+        assertEquals(PokerConstants.CHAT_ADMIN_ERROR, omsg.getChatType(),
+                     "CHAT_ADMIN_ERROR is what removes the sender's chat input controls");
+    }
+
+    /**
+     * The text has to actually say something - it is the only thing the sender sees.
+     */
+    @Test
+    public void replyExplainsWhatIsWrong()
+    {
+        String chat = reply().getChat();
+
+        assertNotNull(chat, "msg.chat.notlobby must resolve");
+        assertFalse(chat.isBlank(), "msg.chat.notlobby must not be empty");
+        assertFalse(chat.contains("{0}"), "no unsubstituted parameters: " + chat);
+    }
+
+    /**
+     * It names the address the hello arrived on, because that is the value the sender has
+     * wrong.  This discloses nothing - they just sent a packet to it.
+     */
+    @Test
+    public void replyNamesTheAddressTheSenderGotWrong()
+    {
+        String chat = reply().getChat();
+
+        assertTrue(chat.contains("192.168.64.1:11888"),
+                   "should name the address the sender used: " + chat);
+    }
+
+    /**
+     * It must say nothing about the game or the player - the sender is unauthenticated and
+     * all they are entitled to know is that they have the wrong address.
+     */
+    @Test
+    public void replyCarriesNoGameOrPlayerDetail()
+    {
+        OnlineMessage omsg = reply();
+
+        assertNull(omsg.getGameID(), "must not name the game");
+        assertNull(omsg.getPlayerName(), "must not name the player");
+        // getPlayerList() builds a list and would throw if the key were absent, so ask the
+        // underlying data instead - the real chat server only sets this on a welcome
+        assertNull(omsg.getData().getList(OnlineMessage.ON_PLAYER_LIST),
+                   "must not list who is online");
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/FakePokerConnectionServer.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/FakePokerConnectionServer.java
@@ -1,0 +1,117 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.comms.DDMessage;
+import com.donohoedigital.comms.DDMessageTransporter;
+import com.donohoedigital.games.poker.network.PokerConnection;
+import com.donohoedigital.games.poker.network.PokerConnectionServer;
+import com.donohoedigital.games.poker.network.PokerUDPTransporter;
+import com.donohoedigital.p2p.Peer2PeerMessage;
+
+/**
+ * A PokerConnectionServer that builds messages of one transport without binding a socket
+ * or starting a thread.
+ * <p/>
+ * newMessage() mirrors the real implementations exactly - PokerUDPServer.newMessage()
+ * returns a PokerUDPTransporter, PokerMain.PokerTCPServer.newMessage() returns a
+ * Peer2PeerMessage - which is what lets a test tell the two transports apart by the
+ * concrete type of reply.
+ */
+public class FakePokerConnectionServer implements PokerConnectionServer
+{
+    private final boolean bUDP_;
+
+    private FakePokerConnectionServer(boolean bUDP)
+    {
+        bUDP_ = bUDP;
+    }
+
+    public static FakePokerConnectionServer udp()
+    {
+        return new FakePokerConnectionServer(true);
+    }
+
+    public static FakePokerConnectionServer tcp()
+    {
+        return new FakePokerConnectionServer(false);
+    }
+
+    //
+    // PokerConnectionServer
+    //
+
+    public boolean isUDP()
+    {
+        return bUDP_;
+    }
+
+    public DDMessageTransporter newMessage(DDMessage msg)
+    {
+        return bUDP_ ? new PokerUDPTransporter(msg)
+                     : new Peer2PeerMessage(Peer2PeerMessage.P2P_MSG, msg);
+    }
+
+    public int send(PokerConnection connection, DDMessageTransporter message)
+    {
+        return 0;
+    }
+
+    public void init() {}
+
+    public boolean isBound()
+    {
+        return true;
+    }
+
+    public void start() {}
+
+    public void shutdown() {}
+
+    public String getPreferredIP()
+    {
+        return "127.0.0.1";
+    }
+
+    public int getPreferredPort()
+    {
+        return bUDP_ ? 11889 : 11880;
+    }
+
+    public String getConfigPort()
+    {
+        return Integer.toString(getPreferredPort());
+    }
+
+    public void closeConnection(PokerConnection connection) {}
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameRankTest.java
@@ -33,13 +33,9 @@
 package com.donohoedigital.games.poker;
 
 import com.donohoedigital.base.ApplicationError;
-import com.donohoedigital.config.ApplicationType;
-import com.donohoedigital.config.ConfigManager;
-import com.donohoedigital.games.poker.model.TournamentProfile;
 
 import java.util.List;
 import java.util.Random;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,60 +47,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  * previous sort-based implementation gave.  Rank is one more than the number of players
  * holding strictly more chips, so players holding equal chips share a rank.
  */
-public class PokerGameRankTest
+public class PokerGameRankTest extends AbstractPokerTest
 {
-    private PokerGame game_;
-
-    @BeforeEach
-    public void setUp()
-    {
-        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
-        game_ = new PokerGame(null);
-        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
-    }
-
-    private PokerPlayer add(int nId, int nChips)
-    {
-        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
-        p.setChipCount(nChips);
-        game_.addPlayer(p);
-        return p;
-    }
-
-    private PokerTable table(int nNum)
-    {
-        PokerTable t = new PokerTable(game_, nNum);
-        t.setMinChip(1); // HoldemHand.addToPot() divides by this
-        return t;
-    }
-
-    /**
-     * Put a hand in progress at the table, far enough along that chips can be committed.
-     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
-     * needs it before any bet is recorded.
-     */
-    private HoldemHand startHand(PokerTable table)
-    {
-        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
-        HoldemHand hhand = new HoldemHand(table);
-        table.setHoldemHand(hhand);
-        hhand.deal();
-        return hhand;
-    }
-
-    /**
-     * Seat a player, snapshotting their chips as the count at the start of the hand.
-     */
-    private PokerPlayer seat(PokerTable table, int nSeat, int nId, int nChips)
-    {
-        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
-        p.setChipCount(nChips);
-        p.newSimulatedHand();
-        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
-        game_.addPlayer(p);
-        return p;
-    }
-
     /**
      * The rank the sort-based implementation produced, kept here so the single-pass
      * version can be held to it.

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGameSettledChipsTest.java
@@ -32,10 +32,6 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.config.ApplicationType;
-import com.donohoedigital.config.ConfigManager;
-import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,53 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * while a hand is in progress used to sink whoever had chips in the pot - which is
  * everyone at the current table for most of its hand.
  */
-public class PokerGameSettledChipsTest
+public class PokerGameSettledChipsTest extends AbstractPokerTest
 {
-    private PokerGame game_;
-
-    @BeforeEach
-    public void setUp()
-    {
-        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
-        game_ = new PokerGame(null);
-        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
-    }
-
-    private PokerTable table(int nNum)
-    {
-        PokerTable t = new PokerTable(game_, nNum);
-        t.setMinChip(1); // HoldemHand.addToPot() divides by this
-        return t;
-    }
-
-    /**
-     * Seat a player holding the given chips, with that count snapshotted as their
-     * chip count at the start of the hand.
-     */
-    private PokerPlayer seat(PokerTable table, int nSeat, int nId, String sName, int nChips)
-    {
-        PokerPlayer p = new PokerPlayer(nId, sName, true);
-        p.setChipCount(nChips);
-        p.newSimulatedHand(); // snapshots nChipsAtStart_
-        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
-        game_.addPlayer(p);
-        return p;
-    }
-
-    /**
-     * Put a hand in progress at the table, far enough along that chips can be committed.
-     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
-     * needs it before any bet is recorded.
-     */
-    private HoldemHand startHand(PokerTable table)
-    {
-        table.setButton(1); // seat 0 posts the big blind, so it commits a useful amount
-        HoldemHand hhand = new HoldemHand(table);
-        table.setHoldemHand(hhand);
-        hhand.deal();
-        return hhand;
-    }
-
     @Test
     public void reportsStartOfHandChipsWhileHandInProgress()
     {

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerMainTransportTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerMainTransportTest.java
@@ -1,0 +1,102 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.games.poker.network.PokerConnection;
+import com.donohoedigital.udp.UDPID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * PokerMain.getPokerConnectionServer(PokerConnection) names the server a message arrived
+ * on, so a reply can be built with the right transport.
+ * <p/>
+ * It is deliberately distinct from the boolean overload, which decides which transport the
+ * game itself uses and creates or shuts down real servers as a side effect.  Calling that
+ * one to answer "what did this arrive on?" would tear down the game's server.
+ */
+public class PokerMainTransportTest
+{
+    private TestPokerMain main_;
+    private SocketChannel channel_;
+
+    @BeforeEach
+    public void setUp() throws IOException
+    {
+        main_ = AbstractPokerTest.engine();
+        channel_ = SocketChannel.open(); // never connected; only its identity is used
+    }
+
+    @Test
+    public void udpConnectionRoutesToUdpServer()
+    {
+        PokerConnection conn = new PokerConnection(new UDPID("00000000-0000-0000-0000-000000000001"));
+        assertSame(main_.getFakeUDP(), main_.getPokerConnectionServer(conn));
+    }
+
+    @Test
+    public void tcpConnectionRoutesToTcpServer()
+    {
+        assertSame(main_.getFakeTCP(), main_.getPokerConnectionServer(new PokerConnection(channel_)));
+    }
+
+    /**
+     * Nothing to route by, so fall back to whatever the game is using.
+     */
+    @Test
+    public void noConnectionFallsBackToGameTransport()
+    {
+        main_.setGameTransport(main_.getFakeUDP());
+        assertSame(main_.getFakeUDP(), main_.getPokerConnectionServer(null));
+
+        main_.setGameTransport(main_.getFakeTCP());
+        assertSame(main_.getFakeTCP(), main_.getPokerConnectionServer(null));
+    }
+
+    /**
+     * A game with no server yet has nothing to fall back to.  PokerMain.messageReceived()
+     * relies on this to drop the message rather than build an unsendable reply.
+     */
+    @Test
+    public void noGameTransportGivesNull()
+    {
+        main_.setGameTransport(null);
+        assertNull(main_.getPokerConnectionServer(null));
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
@@ -32,11 +32,8 @@
  */
 package com.donohoedigital.games.poker;
 
-import com.donohoedigital.config.ApplicationType;
-import com.donohoedigital.config.ConfigManager;
 import com.donohoedigital.games.poker.engine.PokerConstants;
 import com.donohoedigital.games.poker.model.TournamentProfile;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,66 +49,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * returns 0 rather than throwing when the player is not seated here, since it is asked
  * about whoever is under the mouse.
  */
-public class PokerTableRankTest
+public class PokerTableRankTest extends AbstractPokerTest
 {
-    private PokerGame game_;
-
-    @BeforeEach
-    public void setUp()
-    {
-        new ConfigManager("poker", ApplicationType.HEADLESS_CLIENT);
-        game_ = new PokerGame(null);
-        game_.setProfile(new TournamentProfile("test")); // dealing a hand reads it
-    }
-
-    private PokerTable table(int nNum)
-    {
-        PokerTable t = new PokerTable(game_, nNum);
-        t.setMinChip(1); // HoldemHand.addToPot() divides by this
-        return t;
-    }
-
-    /**
-     * Seat a player, snapshotting their chips as the count at the start of the hand.
-     */
-    private PokerPlayer seat(PokerTable table, int nSeat, int nId, int nChips)
-    {
-        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
-        p.setChipCount(nChips);
-        p.newSimulatedHand();
-        table.setPlayer(p, nSeat); // seats at the table AND sets the player's table/seat
-        game_.addPlayer(p);
-        return p;
-    }
-
-    /**
-     * A player in the tournament but not seated anywhere - which is what a busted
-     * player is, once OtherTables.cleanTable() has removed them.
-     */
-    private PokerPlayer unseated(int nId, int nChips)
-    {
-        PokerPlayer p = new PokerPlayer(nId, "P" + nId, true);
-        p.setChipCount(nChips);
-        game_.addPlayer(p);
-        return p;
-    }
-
-    /**
-     * Put a hand in progress at the table, far enough along that chips can be committed.
-     * setPlayerOrder() is the first thing HoldemHand.deal() does, and the pot bookkeeping
-     * needs it before any bet is recorded.
-     */
-    private HoldemHand startHand(PokerTable table)
-    {
-        // the button, and with it the blinds, has to land somewhere - which seat ends
-        // up posting depends on how many are seated, so each caller says for itself
-        table.setButton(1);
-        HoldemHand hhand = new HoldemHand(table);
-        table.setHoldemHand(hhand);
-        hhand.deal();
-        return hhand;
-    }
-
     @Test
     public void countsPlayersAtThisTableWithStrictlyMoreChips()
     {
@@ -203,7 +142,7 @@ public class PokerTableRankTest
     {
         PokerTable table = table(1);
         seat(table, 0, 1, 1000);
-        PokerPlayer busted = unseated(2, 0);
+        PokerPlayer busted = add(2, 0);
 
         assertEquals(0, table.getRank(busted));
     }

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/TestPokerMain.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/TestPokerMain.java
@@ -1,0 +1,125 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import com.donohoedigital.games.poker.network.PokerConnectionServer;
+
+/**
+ * A PokerMain that never opens a socket.
+ * <p/>
+ * The constructor chain is cheap: BaseApp's headless constructor only assigns fields (the
+ * Mac Desktop setup is guarded by !bHeadless), GameEngine's sets the engine_ singleton, and
+ * all the heavy work - the main window, themes, prefs, license keys - lives in init(),
+ * which is never called here.
+ * <p/>
+ * Only the three server accessors are overridden, so the routing in
+ * getPokerConnectionServer(PokerConnection) remains the production code under test.
+ * <p/>
+ * Constructing this DOES set the GameEngine singleton for the life of the JVM, and it is
+ * never cleared, which is why AbstractPokerTest builds exactly one and hands it out.
+ */
+public class TestPokerMain extends PokerMain
+{
+    private FakePokerConnectionServer udp_ = FakePokerConnectionServer.udp();
+    private FakePokerConnectionServer tcp_ = FakePokerConnectionServer.tcp();
+    private PokerConnectionServer game_ = tcp_;
+
+    TestPokerMain()
+    {
+        super("poker", "poker", new String[0], true /* headless */, false /* loadNames */);
+    }
+
+    /**
+     * Fresh servers, so one test cannot see what another sent.  Game transport defaults to
+     * TCP, which is what a hosted game actually uses unless testing turns UDP on.
+     */
+    public void reset()
+    {
+        udp_ = FakePokerConnectionServer.udp();
+        tcp_ = FakePokerConnectionServer.tcp();
+        game_ = tcp_;
+    }
+
+    public FakePokerConnectionServer getFakeUDP()
+    {
+        return udp_;
+    }
+
+    public FakePokerConnectionServer getFakeTCP()
+    {
+        return tcp_;
+    }
+
+    /**
+     * Which transport the game itself is on - what p2p_ would hold in production.
+     */
+    public void setGameTransport(PokerConnectionServer p2p)
+    {
+        game_ = p2p;
+    }
+
+    ////
+    //// PokerMain overrides - hand out the fakes instead of binding anything
+    ////
+
+    @Override
+    PokerConnectionServer udpServer()
+    {
+        return udp_;
+    }
+
+    @Override
+    PokerConnectionServer tcpServer()
+    {
+        return tcp_;
+    }
+
+    @Override
+    PokerConnectionServer gameServer()
+    {
+        return game_;
+    }
+
+    @Override
+    public PokerConnectionServer getPokerConnectionServer(boolean bUDP)
+    {
+        // the production version creates and shuts down real servers
+        return bUDP ? udp_ : tcp_;
+    }
+
+    @Override
+    public void shutdownPokerConnectionServer(PokerConnectionServer p2p)
+    {
+        // nothing to shut down - keeps OnlineManager.finish() safe in a test
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/online/OnlineManagerTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/online/OnlineManagerTest.java
@@ -1,0 +1,246 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker.online;
+
+import com.donohoedigital.comms.DDMessageTransporter;
+import com.donohoedigital.games.poker.AbstractPokerTest;
+import com.donohoedigital.games.poker.FakePokerConnectionServer;
+import com.donohoedigital.games.poker.PokerPlayer;
+import com.donohoedigital.games.poker.TestPokerMain;
+import com.donohoedigital.games.poker.network.OnlineMessage;
+import com.donohoedigital.games.poker.network.PokerConnection;
+import com.donohoedigital.games.poker.network.PokerUDPTransporter;
+import com.donohoedigital.p2p.Peer2PeerMessage;
+import com.donohoedigital.udp.UDPID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A reply must be built with the transport the message arrived on, not the transport the
+ * game happens to be using.
+ * <p/>
+ * These are not the same thing.  A hosted game is TCP unless testing turns UDP on, while
+ * the chat lobby is always UDP, so a client can be handed a UDP message while its game
+ * runs over TCP.  Before this was fixed, every reply came from p2p_ - the game's transport
+ * - and PokerMain.monitorEvent() then cast it to PokerUDPTransporter:
+ * <pre>
+ * ClassCastException: com.donohoedigital.p2p.Peer2PeerMessage cannot be cast to
+ *                     com.donohoedigital.games.poker.network.PokerUDPTransporter
+ * </pre>
+ * It was not fatal - UDPLink.fireEvent() catches it - but the reply was dropped and the
+ * link never closed, so the sender got silence and waited out a timeout.
+ */
+public class OnlineManagerTest extends AbstractPokerTest
+{
+    private static final String TCP_GAME_ID = "n-1"; // "n-" is the TCP prefix
+    private static final String UDP_GAME_ID = "u-1"; // "u-" is the UDP prefix
+    private static final String PASSWORD = "secret";
+
+    private TestPokerMain main_;
+    private OnlineManager mgr_;
+    private SocketChannel channel_;
+
+    @BeforeEach
+    public void setUpOnline() throws IOException
+    {
+        main_ = engine();
+        game_.setOnlineGameID(TCP_GAME_ID);
+        game_.setOnlinePassword(PASSWORD);
+        channel_ = SocketChannel.open(); // never connected; only its identity is used
+    }
+
+    @AfterEach
+    public void tearDownOnline() throws IOException
+    {
+        if (mgr_ != null) mgr_.finish(); // shuts down the OnlineManagerQueue threads
+        mgr_ = null;
+        channel_.close();
+    }
+
+    /**
+     * Build a manager for a game on the given transport.  The local player is deliberately
+     * not the host: host construction reaches for PokerPrefsPlayerList, which reads
+     * java.util.prefs and caches statically across tests.
+     */
+    private OnlineManager manager(FakePokerConnectionServer gameTransport)
+    {
+        main_.setGameTransport(gameTransport);
+        PokerPlayer local = new PokerPlayer(1, "local", true);
+        game_.addPlayer(local);
+        mgr_ = new OnlineManager(game_, main_, gameTransport, local);
+        return mgr_;
+    }
+
+    private PokerConnection udpConnection()
+    {
+        return new PokerConnection(new UDPID("00000000-0000-0000-0000-000000000001"));
+    }
+
+    private PokerConnection tcpConnection()
+    {
+        return new PokerConnection(channel_);
+    }
+
+    /**
+     * A message that fails validation, which is what a stray lobby message looks like:
+     * it carries no game id and no password, so it can never match a running game.
+     */
+    private DDMessageTransporter strayMessage(FakePokerConnectionServer from)
+    {
+        OnlineMessage omsg = new OnlineMessage(OnlineMessage.CAT_CHAT_HELLO);
+        return from.newMessage(omsg.getData());
+    }
+
+    //
+    // the regression
+    //
+
+    /**
+     * The bug, exactly: a UDP message reaches a TCP-hosted game, validation rejects it,
+     * and the rejection has to go back out over UDP.  Against the old code this returned a
+     * Peer2PeerMessage and monitorEvent() threw ClassCastException.
+     */
+    @Test
+    public void udpMessageToTcpGameGetsUdpReply()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        DDMessageTransporter reply = mgr.handleMessage(strayMessage(main_.getFakeUDP()), udpConnection());
+
+        assertNotNull(reply, "a rejected message must still produce a reply");
+        assertInstanceOf(PokerUDPTransporter.class, reply,
+                         "reply to a UDP message must be UDP even though the game is TCP");
+    }
+
+    /**
+     * The ordinary case is unchanged - a TCP message to a TCP game replies over TCP.
+     */
+    @Test
+    public void tcpMessageToTcpGameGetsTcpReply()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        DDMessageTransporter reply = mgr.handleMessage(strayMessage(main_.getFakeTCP()), tcpConnection());
+
+        assertNotNull(reply);
+        assertInstanceOf(Peer2PeerMessage.class, reply);
+    }
+
+    /**
+     * And a UDP-hosted game still replies over UDP.
+     */
+    @Test
+    public void udpMessageToUdpGameGetsUdpReply()
+    {
+        game_.setOnlineGameID(UDP_GAME_ID);
+        OnlineManager mgr = manager(main_.getFakeUDP());
+
+        DDMessageTransporter reply = mgr.handleMessage(strayMessage(main_.getFakeUDP()), udpConnection());
+
+        assertNotNull(reply);
+        assertInstanceOf(PokerUDPTransporter.class, reply);
+    }
+
+    /**
+     * The same rule on the other reply path - an unrecognized category, which is answered
+     * from processMessage()'s default branch rather than from validate().
+     */
+    @Test
+    public void unhandledCategoryRepliesOnArrivingTransport()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        OnlineMessage omsg = new OnlineMessage(-999); // no such category
+        omsg.setGameID(TCP_GAME_ID); // valid, so it reaches the switch
+        omsg.setPassword(PASSWORD);
+        DDMessageTransporter msg = main_.getFakeUDP().newMessage(omsg.getData());
+
+        DDMessageTransporter reply = mgr.handleMessage(msg, udpConnection());
+
+        assertNotNull(reply);
+        assertInstanceOf(PokerUDPTransporter.class, reply);
+    }
+
+    /**
+     * A message we built ourselves carries no connection, so there is nothing to route by.
+     * That falls back to the game's own transport.
+     */
+    @Test
+    public void messageWithNoConnectionFallsBackToGameTransport()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        DDMessageTransporter reply = mgr.handleMessage(strayMessage(main_.getFakeTCP()), null);
+
+        assertNotNull(reply);
+        assertInstanceOf(Peer2PeerMessage.class, reply, "no connection means use the game transport");
+    }
+
+    /**
+     * The rejection carries the diagnostic string that says why it failed - it is the only
+     * record of a mismatch once the message is gone.
+     */
+    @Test
+    public void validationFailureCarriesDiagnosticData()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        DDMessageTransporter reply = mgr.handleMessage(strayMessage(main_.getFakeUDP()), udpConnection());
+
+        String data = reply.getMessage().getString("x-validation-data", null);
+        assertNotNull(data, "rejection should record what did not match");
+        assertTrue(data.contains("gid=" + TCP_GAME_ID), "should name the game id: " + data);
+    }
+
+    /**
+     * A valid message on a category with nothing to say produces no reply at all - so the
+     * transport rule above is about replies, not about every message.
+     */
+    @Test
+    public void aliveMessageProducesNoReply()
+    {
+        OnlineManager mgr = manager(main_.getFakeTCP());
+
+        OnlineMessage omsg = new OnlineMessage(OnlineMessage.CAT_ALIVE);
+        omsg.setGameID(TCP_GAME_ID);
+        omsg.setPassword(PASSWORD);
+
+        assertNull(mgr.handleMessage(main_.getFakeUDP().newMessage(omsg.getData()), udpConnection()));
+    }
+}

--- a/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/PokerConnectionServer.java
+++ b/code/pokernetwork/src/main/java/com/donohoedigital/games/poker/network/PokerConnectionServer.java
@@ -46,6 +46,10 @@ import java.io.IOException;
  */
 public interface PokerConnectionServer
 {
+    // is this a UDP transport?  Asked rather than tested with instanceof so a
+    // caller can tell the transports apart without depending on their classes.
+    boolean isUDP();
+
     // init the server
     void init();
 

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -142,6 +142,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.6.0</version>
+        <configuration>
+          <systemPropertyVariables>
+            <!-- Keep a test run out of the developer's real home directory.  Everything
+                 the client writes - logs, saved games, player profiles, the HSQLDB
+                 database - hangs off ConfigManager.getUserHome(), which resolves through
+                 user.home. -->
+            <user.home>${project.build.directory}/test-home</user.home>
+
+            <!-- user.home does not cover java.util.prefs: on a Mac, MacOSXPreferences
+                 writes to ~/Library/Preferences no matter what user.home says.  This
+                 keeps preferences in memory, per JVM, so tests neither read nor corrupt
+                 the real ones. -->
+            <java.util.prefs.PreferencesFactory>com.donohoedigital.config.MemoryPreferencesFactory</java.util.prefs.PreferencesFactory>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/installer/install4j/poker.install4j
+++ b/installer/install4j/poker.install4j
@@ -24,7 +24,7 @@
       <executable name="ddpoker" iconSet="true" iconFile="./custom/pokericon16to64.ico" executableDir="." redirectStderr="false" stderrFile="log/err.txt" stdoutFile="log/out.txt" failOnStderrOutput="false" executableMode="gui">
         <versionInfo include="true" fileVersion="3.0.0.0" fileDescription="http://www.ddpoker.com/" legalCopyright="Copyright © 2004-2026. Donohoe Digital LLC." internalName="DD Poker" />
       </executable>
-      <java mainClass="com.donohoedigital.games.poker.PokerMain" vmParameters="&quot;-Dcom.donohoedigital.classpath=${launcher:sys.launcherDirectory}&quot; -Dsun.java2d.noddraw=true  -Xms32m -Xmx512m" preferredVM="client">
+      <java mainClass="com.donohoedigital.games.poker.PokerMain" vmParameters="&quot;-Dcom.donohoedigital.classpath=${launcher:sys.launcherDirectory}&quot; -Xms32m -Xmx512m" preferredVM="client">
         <classPath>
           <directory location="." failOnError="false" />
           <scanDirectory location="." failOnError="false" />

--- a/tools/bin/poker
+++ b/tools/bin/poker
@@ -49,7 +49,7 @@ fi
 
 runjava poker \
   $JAVAOPTS \
-  -Dsun.java2d.noddraw=true -Dverbose:gc \
+  -Dverbose:gc \
   -Dlog4j.rootLogger="DEBUG, Console" \
   -Xms32m -Xmx512m com.donohoedigital.games.poker.PokerMain "$@"
 echo


### PR DESCRIPTION
Two related online/chat defects, plus the test foundation needed to pin the first one.

## UDP reply built with the TCP transport

A hosted game and the chat lobby use different transports at the same time, and the reply path assumed they were the same one. `OnlineManager` built every reply from `p2p_` — the transport chosen for *the game* — so a message arriving on the UDP link produced a `Peer2PeerMessage`, which `PokerMain.monitorEvent` then cast to `PokerUDPTransporter`:

```
ClassCastException: com.donohoedigital.p2p.Peer2PeerMessage cannot be cast to
                    com.donohoedigital.games.poker.network.PokerUDPTransporter
```

Not fatal — `UDPLink.fireEvent()` catches it — but the reply was dropped and `link.close()` never ran, so the sender got silence and waited out a timeout. A black hole, not a crash. Dates to the initial open-source commit.

**Fix:** choose the transport from the connection the message arrived on rather than from `p2p_`. `PokerConnection` already knows which it is, and every reply routes through one of two static helpers, so a single `replyServer()` change covers all 18 sites. `PokerMain.messageReceived()` had the same bug in its no-`OnlineManager` branch. The cast is now an `instanceof` pattern that logs and drops rather than throwing.

## A client accepts chat from anything

`PokerMain.monitorEvent` displayed any datagram tagged `USERTYPE_CHAT` without checking it arrived on `chatLink_`, so anything that could reach a client could inject text into its lobby. This is how one game client ended up acting as another client's chat server, and it took a day to diagnose because every symptom looked like a chat bug.

Now compared against `udp_.getChatLink()`, matching what the `TIMEOUT` / `RESEND_FAILURE` / `SESSION_CHANGED` branches in the same method already do. In-game chat is unaffected — it goes out as usertype 0, never `USERTYPE_CHAT`.

## A stray hello now answers back

The other half of the same misconfiguration: a client pointed at another client sends a `USERTYPE_HELLO` that has no business reaching game code. Rather than dropping it silently and leaving the sender to time out, the client now replies "that address is a game client, not a chat server" and names the address they got wrong.

No new message type — this reuses the chat server's own rejection protocol (`CAT_CHAT_ADMIN` with `CHAT_ADMIN_ERROR`, then close), which `OnlineLobby.chatReceived()` already displays. The reply is 236 bytes against a 447-byte hello, so it cannot serve as a UDP amplifier, and it names neither the game nor the player.

## Test foundation

Nothing pinned the transport fix, and `OnlineManager` could not be constructed in a test at all — its constructor reached through the `PokerMain` singleton, built a real socket server, resolved the local player via a license key, and spawned threads.

- **`AbstractPokerTest`** — `PokerGameRankTest`, `PokerGameSettledChipsTest` and `PokerTableRankTest` each carried a copy of the same setup and factories; they now share one. Their assertions are unchanged, which is the evidence the extraction is faithful.
- **A constructible headless `PokerMain`** — `BaseApp`'s headless constructor only assigns fields, so `getPokerMain()` now resolves in tests without a display.
- **Two small seams:** `PokerConnectionServer.isUDP()` replaces an `instanceof` against a concrete `Thread` subclass (which no fake could ever satisfy), and `OnlineManager` gains a package-private constructor taking what it used to look up — following the existing `PokerDatabase.init(profile, saveDir)` precedent.
- **`OnlineManagerTest`** — six tests over the reply-transport rule. The key one fails against the pre-fix code with exactly the `Peer2PeerMessage` / `PokerUDPTransporter` mismatch from the original report.

Poker module goes from 29 to 44 tests; 171 across all modules.

## Logging and test isolation

`PokerMain`'s static initializer ran `LoggingConfig.init()` and forced the version string at class-load, so merely *referencing* the class reconfigured log4j against the real `~/.dd-poker3/log/`. That moves to `BaseApp`'s constructor, where the POC in ddphotos put it; class-load is now inert. Only `BaseApp`'s own logger had to move with it — subclass instance initializers run after the superclass constructor, so `GameEngine` and `PokerMain` were already safe.

Tests now run against a throwaway home (`user.home` → `target/test-home`) with in-memory preferences, both asserted by `TestIsolationTest`. Preferences need their own treatment because `MacOSXPreferences` ignores `user.home`. This turned up pre-existing pollution: `common`'s tests had been writing `~/.gervill/soundbank-emg.sf2` and `~/.dd-test/copy.class` into the real home directory.

Also drops `sun.java2d.noddraw`, a legacy Windows DirectDraw workaround.

## Verification

Full suite green across all modules with MySQL up. The transport fix and the reply-on-arriving-transport rule are covered by tests; the hello reply and the chat-link check were verified manually with two clients, since `monitorEvent` needs a real `UDPLink`.
