### PR TITLE
Fix player list thread safety and sorting over live chip counts

### DIFF
--- a/code/gameengine/src/main/java/com/donohoedigital/games/engine/Game.java
+++ b/code/gameengine/src/main/java/com/donohoedigital/games/engine/Game.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.*;
 import javax.swing.event.*;
 import java.beans.*;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.prefs.*;
 
 /**
@@ -58,9 +59,19 @@ public class Game extends TypedHashMap implements GameInfo, GamePlayerList, Game
 {
     static Logger logger = LogManager.getLogger(Game.class);
 
-    // list of players
-    protected List<GamePlayer> players_ = new ArrayList<GamePlayer>();
-    private List<GamePlayer> observers_ = new ArrayList<GamePlayer>();
+    // List of players.  Copy-on-write because these are mutated from threads which do
+    // not own the game: a message thread as players join, and the EDT when the host
+    // switches someone between player and observer (OnlineManager.switchPlayer()), while
+    // the game thread is reading them.  A plain ArrayList made every for-each over either
+    // list a ConcurrentModificationException waiting to happen, and every ranking path
+    // walks one of them.  The iterator of a CopyOnWriteArrayList is a snapshot, taken
+    // without allocating or locking, which is exactly what those readers want.
+    //
+    // The cost is that each add or remove copies the backing array.  That is nothing on
+    // the join, quit and switch paths; where a whole field is added at once, add it at
+    // once - see PokerGame.addPlayers().
+    protected final List<GamePlayer> players_ = new CopyOnWriteArrayList<>();
+    private final List<GamePlayer> observers_ = new CopyOnWriteArrayList<>();
 
     // current player (set from loop phases/other)
     private GamePlayer currentPlayer_ = null;

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerGame.java
@@ -119,7 +119,7 @@ public class PokerGame extends Game implements PlayerActionListener
     public static final String PROP_PLAYER_FINISHED = "_busted_";
 
     // game info
-    private DMArrayList<PokerTable> tables_ = new DMArrayList<>();
+    private final DMArrayList<PokerTable> tables_ = new DMArrayList<>();
     private TournamentProfile profile_;
     private int nLevel_ = 0;
     private boolean bClockMode_ = false;
@@ -141,7 +141,7 @@ public class PokerGame extends Game implements PlayerActionListener
     private int nNumOut_ = 0;
 
     // clock object used to store seconds remaining, used in tournament/poker night manager
-    private GameClock clock_ = new GameClock();
+    private final GameClock clock_ = new GameClock();
 
     // input mode
     public static final int MODE_NONE = -1;
@@ -151,9 +151,9 @@ public class PokerGame extends Game implements PlayerActionListener
     public static final int MODE_CLIENT = 3;
     public static final int MODE_CANCELLED = 4;
 
-    ////
-    //// members below are transient (not saved)
-    ////
+    //
+    // members below are transient (not saved)
+    //
 
     // total chips
     private int totalChipsInPlay_;
@@ -167,7 +167,7 @@ public class PokerGame extends Game implements PlayerActionListener
     private boolean bStartFromLobby_;
 
     /**
-     *
+     * empty constructor for loading from file
      */
     public PokerGame()
     {
@@ -175,9 +175,7 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
-     * empty constructor for loading
-     *
-     * @param context
+     * standard constructor
      */
     public PokerGame(GameContext context)
     {
@@ -292,6 +290,25 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
+     * Add a whole field of players at once.  The player list is copy-on-write, so adding
+     * one at a time copies its backing array once per player - nothing when somebody
+     * joins, but O(n^2) building the 5,625 player tournament setupComputerPlayers()
+     * creates in one go.
+     * <p/>
+     * Everything after the add is per player exactly as addPlayer() does it, so the only
+     * difference a listener can see is that the events arrive together at the end.
+     */
+    public void addPlayers(List<PokerPlayer> players)
+    {
+        players_.addAll(players);
+        for (PokerPlayer player : players)
+        {
+            updatePlayerList(player);
+            firePropertyChange(PROP_PLAYERS, null, player);
+        }
+    }
+
+    /**
      * Update profile for online game too (override completely so
      * prop change event happens after profile updated)
      */
@@ -304,7 +321,10 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
-     * Return copy of player list (thus it can be changed)
+     * Return copy of player list (thus it can be changed).
+     * <p/>
+     * Safe to walk while another thread is adding or removing: the list is
+     * copy-on-write, so this iterator is a snapshot.  See Game.players_.
      */
     public List<PokerPlayer> getPokerPlayersCopy()
     {
@@ -387,8 +407,6 @@ public class PokerGame extends Game implements PlayerActionListener
     /**
      * Remove observer - override to make sure players
      * is removed from their table's observer list too
-     *
-     * @param player
      */
     @Override
     public void removeObserver(GamePlayer player)
@@ -502,34 +520,26 @@ public class PokerGame extends Game implements PlayerActionListener
         return getPokerPlayerFromID(GamePlayer.HOST_ID);
     }
 
-    // this game's players, as the players a rank is counted over.  Held as a field so
-    // that counting a rank allocates nothing.
-    private final RankUtils.Players rankPlayers_ = new RankUtils.Players()
-    {
-        public int size()
-        {
-            return getNumPlayers();
-        }
-
-        public PokerPlayer getPlayerAt(int n)
-        {
-            return getPokerPlayerAt(n);
-        }
-    };
+    // This game's players, as the players a rank is counted over.  The live list itself:
+    // it is copy-on-write, so RankUtils walking it takes a snapshot without allocating
+    // or locking, and a rank counted while somebody switches to observer still sees a
+    // consistent field.  Everything in it is a PokerPlayer - addPlayer() casts to one.
+    @SuppressWarnings("unchecked")
+    private final Iterable<PokerPlayer> rankPlayers_ = (Iterable<PokerPlayer>) (Iterable<?>) players_;
 
     /**
      * Return rank of player based on chips, across the whole tournament.  Players
      * holding equal chips share a rank, so this is one more than the number of players
      * holding strictly more - the same result the previous sort-based version produced.
-     *
+     * <p>
      * Counted in a single pass by RankUtils rather than by sorting a copy of the player
      * list.  This runs every time the rank is displayed, which is at the end of every
      * hand, and in a large tournament the old version allocated and sorted a 5,625
      * element list each time.  PokerTable.getRank() counts the same way over one table.
-     *
+     * <p>
      * Every player in the tournament is in this list, so not finding one is an error -
      * unlike the table-scoped version, where it just means "seated elsewhere".
-     *
+     * <p>
      * See RankUtils for why settled chip counts are compared rather than live ones,
      * and for what re-reading the list size on every pass does and does not buy.
      */
@@ -547,14 +557,14 @@ public class PokerGame extends Game implements PlayerActionListener
     /**
      * Get a player's chip count as of the last point at which chips were settled -
      * that is, with nothing committed to a pot yet to be awarded.
-     *
+     * <p>
      * getChipCount() is the live stack, which is decremented the instant a blind,
      * ante or bet is committed and is not credited back until the pot is awarded.
      * Comparing live counts across tables while a hand is in progress therefore
      * understates whoever is in the middle of a hand - which is everyone at the
      * current table for most of its hand.  Same idea as BUG 420 (see
      * PokerTable.isRebuyAllowed()).
-     *
+     * <p>
      * Not synchronized on purpose - see PokerTable.isHandInProgress().
      */
     public int getSettledChipCount(PokerPlayer player)
@@ -600,42 +610,80 @@ public class PokerGame extends Game implements PlayerActionListener
     }
 
     /**
-     * Get sorted list of players
+     * Get sorted list of players, biggest stack first.
+     * <p/>
+     * Each player's chips and place are read once, up front, and the sort compares that
+     * capture.  SortChips used to read them live on every comparison, which makes the
+     * comparator inconsistent with itself if the tournament director moves chips while
+     * the sort is running - Collections.sort notices and throws
+     * "Comparison method violates its general contract!".  TournamentSummaryPanel sorts
+     * on the EDT with the director still running, so this is reachable.  Same fix, and
+     * the same shape, as ChipLeaderPanel.createUI().
      */
     public List<PokerPlayer> getPlayersByRank()
     {
-        List<PokerPlayer> sort = getPokerPlayersCopy();
-        Collections.sort(sort, SORTCHIPS);
-        return sort;
+        List<PokerPlayer> players = getPokerPlayersCopy();
+
+        List<Ranked> ranked = new ArrayList<>(players.size());
+        for (PokerPlayer player : players)
+        {
+            ranked.add(new Ranked(player));
+        }
+        ranked.sort(SORTCHIPS);
+
+        List<PokerPlayer> sorted = new ArrayList<>(ranked.size());
+        for (Ranked each : ranked)
+        {
+            sorted.add(each.player);
+        }
+        return sorted;
+    }
+
+    /**
+     * A player's chips and place as of one instant, so that the sort compares values
+     * which cannot change underneath it.  Both are live mutable state on PokerPlayer.
+     */
+    private static class Ranked
+    {
+        private final PokerPlayer player;
+        private final int nChips;
+        private final int nPlace;
+
+        private Ranked(PokerPlayer player)
+        {
+            this.player = player;
+            nChips = player.getChipCount();
+            nPlace = player.getPlace();
+        }
     }
 
     // instances for sorting
-    private static SortChips SORTCHIPS = new SortChips();
+    private static final SortChips SORTCHIPS = new SortChips();
 
-    // sort players by chips they have at start of hand
-    private static class SortChips implements Comparator<PokerPlayer>
+    // sort players by the chips they hold, most first
+    private static class SortChips implements Comparator<Ranked>
     {
         /**
          * Compares its two arguments for order.  Returns a negative integer,
          * zero, or a positive integer as the first argument is less than, equal
          * to, or greater than the second.
          */
-        public int compare(PokerPlayer p1, PokerPlayer p2)
+        public int compare(Ranked r1, Ranked r2)
         {
             // reverse comparison so highest chips at top
-            int diff = p2.getChipCount() - p1.getChipCount();
+            int diff = r2.nChips - r1.nChips;
             if (diff != 0) return diff;
 
             // if no diff, and chip count is zero, sort by place
             // normal comparison so best finish at top
-            if (p1.getChipCount() == 0)
+            if (r1.nChips == 0)
             {
-                diff = p1.getPlace() - p2.getPlace();
+                diff = r1.nPlace - r2.nPlace;
                 if (diff != 0) return diff;
             }
 
             // if still no diff, rank by id, which puts human towards the top
-            return p1.getID() - p2.getID();
+            return r1.player.getID() - r2.player.getID();
         }
     }
 
@@ -1173,12 +1221,17 @@ public class PokerGame extends Game implements PlayerActionListener
             hsUsed.add(getPokerPlayerAt(i).getName());
         }
 
-        // fill remaining players with computer players
+        // Fill remaining players with computer players.  Built up here and added in one
+        // shot at the end rather than one at a time - see addPlayers() for why.  Nothing
+        // in the loop reads the player list: the bound is the for-init, evaluated once,
+        // getNextPlayerID() is a sequence rather than a scan, and the names already used
+        // are tracked in hsUsed.
         PlayerType playerType;
         String sName;
         String sKey = getPublicUseKey();
         Map<String, List<String>> hmRoster = new HashMap<>();
         List<String> roster;
+        List<PokerPlayer> computers = new ArrayList<>();
         for (int i = getNumPlayers(); i < nNumPlayers; i++)
         {
             playerType = getNextPlayerType(/*i - nNumHumans, nNumPlayers - nNumHumans*/);
@@ -1191,8 +1244,9 @@ public class PokerGame extends Game implements PlayerActionListener
             sName = getName(names, roster, hsUsed);
             player = new PokerPlayer(sKey, getNextPlayerID(), sName, false);
             player.setPlayerType(playerType);
-            addPlayer(player);
+            computers.add(player);
         }
+        addPlayers(computers);
     }
 
     private PlayerType getNextPlayerType()
@@ -1455,14 +1509,14 @@ public class PokerGame extends Game implements PlayerActionListener
 
         if (wait != null && wait.size() > 1)
         {
-            Collections.sort(wait, SORTBYWAIT);
+            wait.sort(SORTBYWAIT);
         }
 
         return wait;
     }
 
     // instances for sorting
-    private static SortByWait SORTBYWAIT = new SortByWait();
+    private static final SortByWait SORTBYWAIT = new SortByWait();
 
     // sort players by when they were added to wait list
     private static class SortByWait implements Comparator<PokerPlayer>

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/PokerTable.java
@@ -42,7 +42,6 @@ import com.donohoedigital.base.ApplicationError;
 import com.donohoedigital.base.ErrorCodes;
 import com.donohoedigital.base.Utils;
 import static com.donohoedigital.config.DebugConfig.TESTING;
-import static com.donohoedigital.config.DebugConfig.isTestingOn;
 import com.donohoedigital.comms.DMTypedHashMap;
 import com.donohoedigital.comms.MsgState;
 import com.donohoedigital.comms.ObjectID;
@@ -93,11 +92,11 @@ public class PokerTable implements ObjectID
     private boolean bCurrent_ = false;
     private boolean bZipMode_ = false;
     private HoldemHand hhand_;
-    private List<PokerPlayer> waitList_ = new ArrayList<>();
-    private List<PokerPlayer> addedList_ = new ArrayList<>();
-    private List<PokerPlayer> addonList_ = new ArrayList<>();
-    private List<PokerPlayer> rebuyList_ = new ArrayList<>();
-    private List<PokerPlayer> observers_ = new ArrayList<>();
+    private final List<PokerPlayer> waitList_ = new ArrayList<>();
+    private final List<PokerPlayer> addedList_ = new ArrayList<>();
+    private final List<PokerPlayer> addonList_ = new ArrayList<>();
+    private final List<PokerPlayer> rebuyList_ = new ArrayList<>();
+    private final List<PokerPlayer> observers_ = new ArrayList<>();
     private int nTableState_ = STATE_NONE;
     private int nPrevState_ = STATE_NONE;
     private int nPendingState_ = STATE_NONE;
@@ -429,21 +428,15 @@ public class PokerTable implements ObjectID
         return players_[nSeat];
     }
 
-    // this table's seats, as the players a rank is counted over.  The whole array is
-    // walked, not getSeats(): addPlayer() seats at a random index in 0..SEATS-1
-    // whatever the table's size, so a shorter bound would miss players in high seats.
-    private final RankUtils.Players rankPlayers_ = new RankUtils.Players()
-    {
-        public int size()
-        {
-            return PokerConstants.SEATS;
-        }
-
-        public PokerPlayer getPlayerAt(int n)
-        {
-            return players_[n];
-        }
-    };
+    // This table's seats, as the players a rank is counted over.  A fixed view of the
+    // seat array - Arrays.asList() does not copy, and the array is never replaced, so
+    // this stays current as players sit down and allocates nothing per rank.  Empty
+    // seats come through as nulls, which RankUtils skips.
+    //
+    // The whole array is walked, not getSeats(): addPlayer() seats at a random index in
+    // 0..SEATS-1 whatever the table's size, so a shorter bound would miss players in
+    // high seats.
+    private final List<PokerPlayer> rankPlayers_ = Arrays.asList(players_);
 
     /**
      * Return rank of a player among those seated at this table, based on chips.
@@ -487,7 +480,7 @@ public class PokerTable implements ObjectID
     }
 
     // instances for sorting
-    private static SortByMoved SORTBYMOVED = new SortByMoved();
+    private static final SortByMoved SORTBYMOVED = new SortByMoved();
 
     // sort players by when they last moved - smaller # hands played
     // at last moved means moved less recently
@@ -1360,7 +1353,7 @@ public class PokerTable implements ObjectID
     }
     
     // instances for sorting
-    private SortChipRace SORTCHIPRACE = new SortChipRace();
+    private final SortChipRace SORTCHIPRACE = new SortChipRace();
 
     // sort players by top card in hand - players who would
     // go broke from chip race end up at top
@@ -1886,7 +1879,7 @@ public class PokerTable implements ObjectID
     ////
     //// PokerTableListener
     ////
-    private List<ListenerInfo> listeners_ = new ArrayList<>();
+    private final List<ListenerInfo> listeners_ = new ArrayList<>();
     
     /**
      * notify table that display preferences changed so listeners can react
@@ -1975,7 +1968,7 @@ public class PokerTable implements ObjectID
     {
         public static final ListenerInfo NULL_LISTENER = new ListenerInfo(null, 0);
 
-        private PokerTableListener listener;
+        private final PokerTableListener listener;
         private int nTypes;
 
         private ListenerInfo(PokerTableListener listener, int nTypes)

--- a/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
+++ b/code/poker/src/main/java/com/donohoedigital/games/poker/RankUtils.java
@@ -41,27 +41,6 @@ package com.donohoedigital.games.poker;
 public class RankUtils
 {
     /**
-     * The players a rank is counted over.
-     *
-     * Deliberately an indexed list rather than a java.util.List: neither caller has
-     * one to hand, and copying into one on every call is exactly what counting in a
-     * single pass exists to avoid.
-     */
-    public interface Players
-    {
-        /**
-         * Number of slots to walk.
-         */
-        int size();
-
-        /**
-         * Player in slot n, or null if the slot is empty - a table's seats are a
-         * fixed-size array with gaps in it.
-         */
-        PokerPlayer getPlayerAt(int n);
-    }
-
-    /**
      * Return rank of a player among the given players, based on chips.  Players
      * holding equal chips share a rank, so this is one more than the number holding
      * strictly more - the same result the previous sort-based version produced.
@@ -75,21 +54,24 @@ public class RankUtils
      * A rank is read at arbitrary moments: the Rank dashboard item recomputes when
      * another table finishes a hand, which lands in the middle of ours, and PlayerInfo
      * recomputes on every mouse-over.  Live counts sink whoever has chips in a pot.
+     *
+     * Walks an Iterable rather than indexing, because a rank is counted while the list
+     * underneath may be changing - PokerGame's shrinks when a player switches to observer
+     * (see PokerGame.removePlayer(), called from OnlineManager on the EDT).  Both callers
+     * hand over something whose iterator is a snapshot and costs nothing to take: a
+     * copy-on-write list, or a fixed view of a seat array.  Indexing them instead would
+     * mean reading a size and then a slot, which is two reads of something which can
+     * change in between.
      */
-    public static int getRank(PokerGame game, Players players, PokerPlayer player)
+    public static int getRank(PokerGame game, Iterable<PokerPlayer> players, PokerPlayer player)
     {
         int nChips = game.getSettledChipCount(player);
         int nRank = 1;
         boolean bFound = false;
 
-        // size() is re-read on every pass on purpose.  PokerGame's list can shrink
-        // from another thread (see PokerGame.removePlayer(), called from OnlineManager
-        // when a player switches to observer), and a bound captured up front would
-        // index off the end.  It does not close the window between reading size() and
-        // reading the slot - that race is older than this method and unchanged by it.
-        for (int i = 0; i < players.size(); i++)
+        for (PokerPlayer p : players)
         {
-            PokerPlayer p = players.getPlayerAt(i);
+            // a table's seats are a fixed-size array with gaps in it
             if (p == null) continue;
             if (p == player)
             {

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGamePlayerListTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGamePlayerListTest.java
@@ -1,0 +1,193 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies the tournament's player list survives being read on one thread while it is
+ * changed on another, and that adding a whole field at once behaves like adding one at a
+ * time.
+ * <p/>
+ * The list is changed off the game thread for real: OnlineManager.switchPlayer() moves
+ * somebody between player and observer from the EDT, and a join arrives on a message
+ * thread.  Meanwhile every ranking path walks it.  While it was a plain ArrayList that was
+ * a ConcurrentModificationException waiting for the right moment.
+ */
+public class PokerGamePlayerListTest extends AbstractPokerTest
+{
+    /** Big enough that a reader is inside the list for a while, small enough to stay quick. */
+    private static final int FIELD = 60;
+
+    /** Wall clock each churn test spends trying to provoke a failure. */
+    private static final long RUN_MILLIS = 300;
+
+    private PokerPlayer stable_;
+    private PokerPlayer churn_;
+
+    /**
+     * Hammer the given reader on this thread while a second thread takes one player out of
+     * the tournament and puts them back - which is what switching to observer and back
+     * does to the list.  Fails with whatever either thread threw.
+     */
+    private void underChurn(Runnable reader) throws InterruptedException
+    {
+        for (int i = 1; i <= FIELD; i++)
+        {
+            add(i, i * 100);
+        }
+        stable_ = game_.getPokerPlayerAt(0); // never removed, so always rankable
+        churn_ = add(FIELD + 1, 5000);
+
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean stop = new AtomicBoolean();
+
+        Thread mutator = new Thread(() -> {
+            try
+            {
+                while (!stop.get())
+                {
+                    game_.removePlayer(churn_);
+                    game_.addPlayer(churn_);
+                }
+            }
+            catch (Throwable t)
+            {
+                failure.compareAndSet(null, t);
+            }
+        }, "player-list-churn");
+        mutator.setDaemon(true);
+        mutator.start();
+
+        try
+        {
+            long end = System.currentTimeMillis() + RUN_MILLIS;
+            while (System.currentTimeMillis() < end && failure.get() == null)
+            {
+                reader.run();
+            }
+        }
+        catch (Throwable t)
+        {
+            failure.compareAndSet(null, t);
+        }
+        finally
+        {
+            stop.set(true);
+            mutator.join(5000);
+        }
+
+        if (failure.get() != null)
+        {
+            fail("threw while the player list was being changed", failure.get());
+        }
+    }
+
+    @Test
+    public void copyingThePlayerListToleratesAConcurrentSwitch() throws InterruptedException
+    {
+        underChurn(() -> game_.getPokerPlayersCopy());
+    }
+
+    /**
+     * The one which matters most: every ranking path walks the list, and the rank of a
+     * player who is in it must come back rather than blowing up or reporting "not found".
+     */
+    @Test
+    public void rankingToleratesAConcurrentSwitch() throws InterruptedException
+    {
+        underChurn(() -> game_.getRank(stable_));
+    }
+
+    @Test
+    public void sortingByRankToleratesAConcurrentSwitch() throws InterruptedException
+    {
+        underChurn(() -> game_.getPlayersByRank());
+    }
+
+    /**
+     * Online, adding or removing a player also rewrites the profile's player list, which
+     * walks the whole tournament - so the thread doing the changing is reading it too.
+     */
+    @Test
+    public void onlineChurnRewritesTheProfilePlayerList() throws InterruptedException
+    {
+        game_.setOnlineGameID("test-online-game");
+        underChurn(() -> game_.getPokerPlayersCopy());
+    }
+
+    /**
+     * setupComputerPlayers() builds the computer field and hands it over in one call,
+     * because the list is copy-on-write and adding one at a time copies its backing array
+     * per player.  The result has to be indistinguishable from having added them one by
+     * one, events included.
+     */
+    @Test
+    public void addPlayersMatchesAddingOneAtATime()
+    {
+        AtomicInteger events = new AtomicInteger();
+        PropertyChangeListener counter = evt -> events.incrementAndGet();
+        game_.addPropertyChangeListener(PokerGame.PROP_PLAYERS, counter);
+
+        PokerPlayer first = add(1, 100); // one at a time, for something to follow
+        assertEquals(1, events.get());
+
+        List<PokerPlayer> field = new ArrayList<>();
+        for (int i = 2; i <= 5; i++)
+        {
+            PokerPlayer player = new PokerPlayer(i, "P" + i, true);
+            player.setChipCount(i * 100);
+            field.add(player);
+        }
+        game_.addPlayers(field);
+
+        assertEquals(5, events.get(), "one event per player added, as addPlayer() fires");
+        assertEquals(5, game_.getNumPlayers());
+
+        List<PokerPlayer> expected = new ArrayList<>();
+        expected.add(first);
+        expected.addAll(field);
+        assertEquals(expected, game_.getPokerPlayersCopy(), "added in order, after what was there");
+
+        game_.removePropertyChangeListener(PokerGame.PROP_PLAYERS, counter);
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGamePlayersByRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerGamePlayersByRankTest.java
@@ -1,0 +1,161 @@
+/*
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ * DD Poker - Source Code
+ * Copyright (c) 2003-2026 Doug Donohoe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For the full License text, please see the LICENSE.txt file
+ * in the root directory of this project.
+ *
+ * The "DD Poker" and "Donohoe Digital" names and logos, as well as any images,
+ * graphics, text, and documentation found in this repository (including but not
+ * limited to written documentation, website content, and marketing materials)
+ * are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+ * 4.0 International License (CC BY-NC-ND 4.0). You may not use these assets
+ * without explicit written permission for any uses not covered by this License.
+ * For the full License text, please see the LICENSE-CREATIVE-COMMONS.txt file
+ * in the root directory of this project.
+ *
+ * For inquiries regarding commercial licensing of this source code or
+ * the use of names, logos, images, text, or other assets, please contact
+ * doug [at] donohoe [dot] info.
+ * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+package com.donohoedigital.games.poker;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies PokerGame.getPlayersByRank() sorts a capture of each player's chips and place
+ * rather than reading them live inside the comparator.
+ * <p/>
+ * Chips and place are mutable state owned by the tournament director.  A comparator which
+ * reads them live can answer the same question about the same pair of players two
+ * different ways, which Collections.sort detects and rejects with "Comparison method
+ * violates its general contract!".  TournamentSummaryPanel sorts on the EDT while the
+ * director is still running, so this is reachable in a real game.
+ * <p/>
+ * These tests pin the property which makes that impossible - each player is read once, up
+ * front - rather than trying to provoke the exception.  Whether the sort notices a
+ * comparator contradicting itself depends on how the data happens to fall: over a randomized
+ * field of 64 with one mid-sort chip movement it throws in well under a tenth of runs, and a
+ * seed picked because it happens to throw would be pinning the JDK's merge strategy rather
+ * than anything about this code.  One read per player is the guarantee; no read can
+ * disagree with a read that never happens.
+ */
+public class PokerGamePlayersByRankTest extends AbstractPokerTest
+{
+    /**
+     * A player who answers honestly the first time and differently every time after, and
+     * who counts how often it was asked.
+     * <p/>
+     * Capturing reads each player once, so it only ever sees the honest answer.  Reading
+     * live inside the comparator reads each player many times, and sees the shifting one -
+     * which is what a director moving chips mid-sort looks like from inside a sort.
+     */
+    private static class ShiftingPlayer extends PokerPlayer
+    {
+        private final int nChips;
+        private final int nPlace;
+        private final Random scramble;
+        private int nChipReads;
+        private int nPlaceReads;
+
+        private ShiftingPlayer(int nId, int nChips, int nPlace)
+        {
+            super(nId, "P" + nId, true);
+            this.nChips = nChips;
+            this.nPlace = nPlace;
+            scramble = new Random(nId); // seeded, so a failure here reproduces
+        }
+
+        @Override
+        public int getChipCount()
+        {
+            return nChipReads++ == 0 ? nChips : scramble.nextInt(10000);
+        }
+
+        @Override
+        public int getPlace()
+        {
+            return nPlaceReads++ == 0 ? nPlace : scramble.nextInt(10000);
+        }
+    }
+
+    private ShiftingPlayer add(int nId, int nChips, int nPlace)
+    {
+        ShiftingPlayer player = new ShiftingPlayer(nId, nChips, nPlace);
+        game_.addPlayer(player);
+        return player;
+    }
+
+    /**
+     * Added in a jumbled order so the result cannot be the insertion order by accident.
+     */
+    @Test
+    public void orderIsTakenFromOneReadPerPlayer()
+    {
+        ShiftingPlayer p400 = add(1, 400, 0);
+        ShiftingPlayer p900 = add(2, 900, 0);
+        ShiftingPlayer p100 = add(3, 100, 0);
+        ShiftingPlayer p700 = add(4, 700, 0);
+
+        assertEquals(List.of(p900, p700, p400, p100), game_.getPlayersByRank());
+    }
+
+    /**
+     * The zero-chip tiebreak compares place, which is just as mutable - a player is given
+     * one the moment they bust - so it has to be captured too.
+     */
+    @Test
+    public void placeIsCapturedAlongWithChips()
+    {
+        ShiftingPlayer third = add(1, 0, 3);
+        ShiftingPlayer first = add(2, 0, 1);
+        ShiftingPlayer fourth = add(3, 0, 4);
+        ShiftingPlayer second = add(4, 0, 2);
+
+        assertEquals(List.of(first, second, third, fourth), game_.getPlayersByRank(),
+                     "best finish at the top");
+    }
+
+    /**
+     * The guarantee itself, over a field big enough for the sort to merge runs rather than
+     * just insert, and with the ties that make it compare the same pair more than once.
+     */
+    @Test
+    public void eachPlayerIsReadExactlyOnce()
+    {
+        List<ShiftingPlayer> added = new ArrayList<>();
+        for (int i = 1; i <= 64; i++)
+        {
+            added.add(add(i, (i % 7) * 100, i)); // ties on chips, so the tiebreaks are used too
+        }
+
+        List<PokerPlayer> rank = game_.getPlayersByRank();
+
+        for (ShiftingPlayer player : added)
+        {
+            assertEquals(1, player.nChipReads, "chips read more than once for " + player.getName());
+            assertEquals(1, player.nPlaceReads, "place read more than once for " + player.getName());
+        }
+
+        assertEquals(added.size(), rank.size());
+        assertEquals(new HashSet<>(added), new HashSet<>(rank), "every player comes back, exactly once");
+    }
+}

--- a/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
+++ b/code/poker/src/test/java/com/donohoedigital/games/poker/PokerTableRankTest.java
@@ -274,4 +274,42 @@ public class PokerTableRankTest extends AbstractPokerTest
             assertEquals(game_.getRank(p), table.getRank(p), "table and tournament rank differ for " + p.getName());
         }
     }
+
+    /**
+     * Seats do not hold still: a tournament breaks tables and moves players between them
+     * all the way down to the final table, and a busted player just vacates a seat.
+     * <p/>
+     * The rank has to follow that.  It is counted over a view of the seat array rather
+     * than a copy of it, which only stays correct while the array itself is the same
+     * object - every seating and un-seating writes a slot in place.  Anyone replacing it
+     * with a fresh array would break this silently, hence the test.
+     */
+    @Test
+    public void rankFollowsPlayersMovingBetweenTables()
+    {
+        PokerTable table = table(1);
+        PokerTable other = table(2);
+
+        PokerPlayer big = seat(table, 0, 1, 5000);
+        PokerPlayer middle = seat(table, 1, 2, 3000);
+        PokerPlayer small = seat(table, 2, 3, 1000);
+
+        assertEquals(3, table.getRank(small));
+
+        // the two above them bust out, and their seats are vacated
+        table.removePlayer(0);
+        table.removePlayer(1);
+        assertEquals(1, table.getRank(small), "last one seated is the chip leader of this table");
+        assertEquals(0, table.getRank(big), "and a player no longer seated here has no rank here");
+
+        // the table fills back up from a broken one, seated in the gaps just vacated
+        PokerPlayer arrival = seat(table, 1, 4, 9000);
+        assertEquals(2, table.getRank(small), "the new arrival counts against the ones already here");
+        assertEquals(1, table.getRank(arrival));
+
+        // and someone moved away is ranked at the table they moved to
+        other.setPlayer(middle, 0);
+        assertEquals(1, other.getRank(middle));
+        assertEquals(0, table.getRank(middle), "no longer ranked where they came from");
+    }
 }


### PR DESCRIPTION
Fixes the two crash risks at the top of the TODO list, plus the stale comment that was item 5.

## 1. `players_` was mutated from other threads without synchronization

`PokerGame.getPokerPlayersCopy()` walked `players_` with a fail-fast for-each while `OnlineManager.switchPlayer()` mutated it from the EDT and `GameState.loadPlayers` could clear it on a `SAVE_ALL` load. `ConcurrentModificationException` was structurally possible, and every ranking path goes through there.

- `Game.players_` / `observers_` are now `CopyOnWriteArrayList`, so iterating either takes a snapshot without allocating or locking.
- `RankUtils.getRank()` takes an `Iterable<PokerPlayer>` instead of the indexed `Players` interface, now deleted. That also closes the `size()`-then-`get(i)` window the old comment described as still open — those two reads could straddle a removal. `PokerGame` passes the live copy-on-write list; `PokerTable` passes a non-copying `Arrays.asList()` view of its seat array, so neither allocates per rank.

No save/load coupling to worry about: the lists are persisted entry-by-entry through the `GamePlayerList` interface, never by concrete type.

## 2. `Collections.sort` over live mutable state

`getPlayersByRank()` sorted with a comparator reading live `getChipCount()` / `getPlace()`. If the tournament director moved chips mid-sort, TimSort would throw `IllegalArgumentException: Comparison method violates its general contract!`. `TournamentSummaryPanel` sorts on the EDT with the director still running, so it was reachable.

Chips and place are now captured once per player into a `Ranked`, and the comparator reads the capture — the same shape as the fix already in `ChipLeaderPanel.createUI()`. Ordering is unchanged.

Item 5 was the stale `// sort players by chips they have at start of hand` comment on that same comparator, over code reading live chips. Corrected while rewriting it.

## Keeping tournament setup O(n)

Copy-on-write makes each add an array copy, which would have turned `setupComputerPlayers()` into O(n²) — it adds up to 5,625 computer players one at a time. It now builds the field locally and hands it over via a new `PokerGame.addPlayers()` doing a single `addAll`. Measured at 5,625: ~35ms one at a time, ~0ms bulk.

Behavior is identical — nothing in that loop reads the player list (the bound is the `for`-init, `getNextPlayerID()` is a sequence rather than a scan, and names already used are tracked in a local set). Only the `PROP_PLAYERS` events move, from interleaved to all at the end; `PokerGameState.setIds()` is idempotent and the lobby's model re-reads from the game.

`GameState.loadPlayers` still adds one at a time behind an O(n) `containsPlayer()` check — already O(n²) before this change, so left alone.

## Tests

All headless (`mvn -o -pl poker -am test`). Each was verified to fail with the fix stashed:

- **`PokerGamePlayerListTest`** — hammers `getPokerPlayersCopy()`, `getRank()` and `getPlayersByRank()` while a second thread switches a player in and out. Without the fix these throw `ConcurrentModificationException`, and the ranking one throws `IndexOutOfBoundsException: Index 60 out of bounds for length 60` — the exact size/index race. Also covers `addPlayers()` matching one-at-a-time adds, events included.
- **`PokerGamePlayersByRankTest`** — pins that each player is read exactly once, so the comparator cannot observe a change. It asserts the read counts rather than trying to provoke the exception: over a randomized field of 64 with one mid-sort chip movement it throws in well under a tenth of runs, so a seed picked because it happens to throw would be pinning the JDK's merge strategy rather than anything about this code. (The 64-player case does throw the real `IllegalArgumentException` without the fix.)
- **`PokerTableRankTest`** — adds `rankFollowsPlayersMovingBetweenTables`: busts, refills into vacated seats, and a move to another table. The table's rank walks a view of the seat array rather than a copy, which is only correct while the array object is never replaced; swapping the view for a copy fails this test and nine existing ones.

53 poker tests pass; all 21 modules build.

## Still to smoke test

Not reachable from the automated tests:

- **Save and reload a tournament in progress** — `GameState.loadPlayers` clears and refills the list, and `PokerTable` demarshal writes seats in place.
- **Online lobby player ↔ observer switch** — the original crash scenario, and the only exercise of the observers list.
- **Online host start with computer fill** — the one intentional behavior change (event timing).
- **Game over payouts** — `TournamentSummaryPanel` indexes `getPlayersByRank()` by payout spot.
